### PR TITLE
Fix command in Windows install guide

### DIFF
--- a/docs/GUIA_DE_INSTALACAO.md
+++ b/docs/GUIA_DE_INSTALACAO.md
@@ -206,7 +206,7 @@ Lembre-se que o `seed_users.py` deve estar atualizado para incluir o campo `emai
 ## 12. Rodar a Aplicação Flask
 Finalmente! Para rodar o servidor de desenvolvimento do Flask:
 ```bash
-python flask run
+flask run (ou `python -m flask run`)
 ```
 O terminal deverá exibir mensagens indicando que o servidor está rodando, geralmente em `http://127.0.0.1:5000/`.
 


### PR DESCRIPTION
## Summary
- fix Flask run command in installation guide

## Testing
- `grep -n "python flask run" -n docs/GUIA_DE_INSTALACAO.md`

------
https://chatgpt.com/codex/tasks/task_e_684191aacb1c832e95e382c7e7256d07