### PR TITLE
Atualiza página de login com logo

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -99,3 +99,8 @@ body > .container {
 .tooltip .tooltip-inner {
   text-align: center;
 }
+
+/* Logo da página de login */
+.login-logo {
+  max-width: 120px;
+}

--- a/templates/login.html
+++ b/templates/login.html
@@ -9,6 +9,10 @@
 {% block content %}
   <div class="row justify-content-center">
     <div class="col-md-4">
+      <div class="text-center mb-4">
+        <img src="{{ url_for('static', filename='icons/Logo.png') }}" class="login-logo mb-2" alt="Logo Orquetask">
+        <h1 class="h4 fw-bold mb-0">Orquetask</h1>
+      </div>
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
           {% for category, message in messages %}


### PR DESCRIPTION
## Summary
- exibir logo e nome do sistema no topo do formulário de login
- incluir estilo para redimensionar a imagem do logo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bleach')*

------
https://chatgpt.com/codex/tasks/task_e_6841fb1932bc832ea40f32cdeaa9888f