### PR TITLE
Implement tabbed layout for admin establishments

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -104,3 +104,10 @@ body > .container {
 .login-logo {
   max-width: 120px;
 }
+
+/* Formulários mais compactos */
+.compact-form .form-control-sm {
+  padding-top: .25rem;
+  padding-bottom: .25rem;
+  font-size: .875rem;
+}

--- a/templates/admin/estabelecimentos.html
+++ b/templates/admin/estabelecimentos.html
@@ -2,59 +2,131 @@
 
 {% block title %}Admin - Gerenciar Estabelecimentos{% endblock %}
 
-{% block content %} 
+{% block content %}
 <div class="container-fluid px-5 mt-3"> {# container-fluid para ocupar a largura do main-page-content #}
-    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-2 border-bottom">
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-1 border-bottom">
         <h1 class="h2">Gerenciar Estabelecimentos</h1>
     </div>
 
-    {# Formulário para Adicionar ou Editar Estabelecimento #}
-    <div class="card shadow-sm mb-4">
-        <div class="card-body">
-            <h5 class="card-title">
-                {% if est_editar %}
-                    <i class="bi bi-pencil-square me-2"></i>Editar Estabelecimento: <strong>{{ est_editar.nome_fantasia }}</strong>
-                {% else %}
-                    <i class="bi bi-plus-circle-fill me-2"></i>Adicionar Novo Estabelecimento
-                {% endif %}
-            </h5>
+    <ul class="nav nav-tabs" id="tabEstab" role="tablist">
+        <li class="nav-item">
+            <button class="nav-link active" id="consulta-tab" data-bs-toggle="tab" data-bs-target="#consulta" type="button" role="tab">Consulta</button>
+        </li>
+        <li class="nav-item">
+            <button class="nav-link" id="cadastro-tab" data-bs-toggle="tab" data-bs-target="#cadastro" type="button" role="tab">Cadastro</button>
+        </li>
+    </ul>
 
-            <form method="POST" action="{{ url_for('admin_estabelecimentos') }}" novalidate>
-                {% if est_editar %}
-                    <input type="hidden" name="id_para_atualizar" value="{{ est_editar.id }}">
-                {% endif %}
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <div class="tab-content" id="tabEstabContent">
+                <div class="tab-pane fade show active p-3" id="consulta" role="tabpanel" aria-labelledby="consulta-tab">
+                    <div class="card shadow-sm mb-4">
+                        <div class="card-header">
+                            <h5 class="mb-0"><i class="bi bi-list-ul me-2"></i>Estabelecimentos Cadastrados ({{ estabelecimentos|length }})</h5>
+                        </div>
+                        <div class="card-body">
+                            {% if estabelecimentos %}
+                                <div class="table-responsive">
+                                    <table class="table table-hover table-sm align-middle">
+                                        <thead>
+                                            <tr>
+                                                <th>Código</th>
+                                                <th>Nome Fantasia</th>
+                                                <th>CNPJ</th>
+                                                <th>Cidade/UF</th>
+                                                <th>Status</th>
+                                                <th style="width: 200px;" class="text-end">Ações</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for est in estabelecimentos %}
+                                            <tr class="{{ 'table-light text-muted' if not est.ativo else '' }}">
+                                                <td>{{ est.codigo }}</td>
+                                                <td>{{ est.nome_fantasia }}</td>
+                                                <td>{{ est.cnpj or '--' }}</td>
+                                                <td>{{ est.cidade or 'N/A' }}/{{ est.estado or 'N/A' }}</td>
+                                                <td>
+                                                    {% if est.ativo %}
+                                                        <span class="badge bg-success">Ativo</span>
+                                                    {% else %}
+                                                        <span class="badge bg-secondary">Inativo</span>
+                                                    {% endif %}
+                                                </td>
+                                                <td class="text-end">
+                                                    <a href="{{ url_for('admin_estabelecimentos', edit_id=est.id) }}" class="btn btn-sm btn-outline-primary me-1" title="Editar">
+                                                        <i class="bi bi-pencil-fill"></i>
+                                                    </a>
+                                                    {% set confirm_message_text = 'DESATIVAR' if est.ativo else 'ATIVAR' %}
+                                                    {% set estabelecimento_nome_js = est.nome_fantasia | tojson %}
+                                                    <form action="{{ url_for('admin_toggle_ativo_estabelecimento', id=est.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_message_text }} o estabelecimento ' + {{ estabelecimento_nome_js }} + '?');">
+                                                        {% if est.ativo %}
+                                                            <button type="submit" class="btn btn-sm btn-outline-warning" title="Desativar">
+                                                                <i class="bi bi-archive-fill"></i> Desativar
+                                                            </button>
+                                                        {% else %}
+                                                            <button type="submit" class="btn btn-sm btn-outline-success" title="Ativar">
+                                                                <i class="bi bi-archive-restore-fill"></i> Ativar
+                                                            </button>
+                                                        {% endif %}
+                                                    </form>
+                                                </td>
+                                            </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            {% else %}
+                                <p class="text-muted">Nenhum estabelecimento cadastrado ainda. Adicione um acima!</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+                <div class="tab-pane fade p-3" id="cadastro" role="tabpanel" aria-labelledby="cadastro-tab">
+                    <h5 class="mb-3">
+                        {% if est_editar %}
+                            <i class="bi bi-pencil-square me-2"></i>Editar Estabelecimento: <strong>{{ est_editar.nome_fantasia }}</strong>
+                        {% else %}
+                            <i class="bi bi-plus-circle-fill me-2"></i>Adicionar Novo Estabelecimento
+                        {% endif %}
+                    </h5>
+
+                    <form method="POST" action="{{ url_for('admin_estabelecimentos') }}" novalidate class="compact-form">
+                        {% if est_editar %}
+                            <input type="hidden" name="id_para_atualizar" value="{{ est_editar.id }}">
+                        {% endif %}
 
                 <div class="row">
-                    <div class="col-md-3 mb-2">
+                    <div class="col-md-3 mb-1">
                         <label for="codigo" class="form-label">Código <span class="text-danger">*</span></label>
-                        <input type="text" class="form-control" id="codigo" name="codigo" 
+                        <input type="text" class="form-control form-control-sm" id="codigo" name="codigo" 
                                value="{{ request.form.get('codigo', est_editar.codigo if est_editar else '') }}" 
                                required maxlength="50" placeholder="Ex: BH01">
                     </div>
-                    <div class="col-md-5 mb-2">
+                    <div class="col-md-5 mb-1">
                         <label for="nome_fantasia" class="form-label">Nome Fantasia <span class="text-danger">*</span></label>
-                        <input type="text" class="form-control" id="nome_fantasia" name="nome_fantasia"
+                        <input type="text" class="form-control form-control-sm" id="nome_fantasia" name="nome_fantasia"
                                value="{{ request.form.get('nome_fantasia', est_editar.nome_fantasia if est_editar else '') }}" 
                                required maxlength="200" placeholder="Nome popular">
                     </div>
-                    <div class="col-md-4 mb-2">
+                    <div class="col-md-4 mb-1">
                         <label for="cnpj" class="form-label">CNPJ</label>
-                        <input type="text" class="form-control" id="cnpj" name="cnpj"
+                        <input type="text" class="form-control form-control-sm" id="cnpj" name="cnpj"
                                value="{{ request.form.get('cnpj', est_editar.cnpj if est_editar else '') }}" 
                                maxlength="18" placeholder="XX.XXX.XXX/XXXX-XX">
                     </div>
                 </div>
 
                 <div class="row">
-                    <div class="col-md-8 mb-2">
+                    <div class="col-md-8 mb-1">
                         <label for="razao_social" class="form-label">Razão Social</label>
-                        <input type="text" class="form-control" id="razao_social" name="razao_social"
+                        <input type="text" class="form-control form-control-sm" id="razao_social" name="razao_social"
                                value="{{ request.form.get('razao_social', est_editar.razao_social if est_editar else '') }}" 
                                maxlength="255">
                     </div>
-                    <div class="col-md-4 mb-2">
+                    <div class="col-md-4 mb-1">
                         <label for="tipo_estabelecimento" class="form-label">Tipo</label>
-                        <input type="text" class="form-control" id="tipo_estabelecimento" name="tipo_estabelecimento"
+                        <input type="text" class="form-control form-control-sm" id="tipo_estabelecimento" name="tipo_estabelecimento"
                                value="{{ request.form.get('tipo_estabelecimento', est_editar.tipo_estabelecimento if est_editar else '') }}" 
                                maxlength="50" placeholder="Matriz, Filial, Loja...">
                     </div>
@@ -63,59 +135,59 @@
                 {# Endereço - pode ser um sub-bloco ou accordion no futuro se ficar muito grande #}
                 <h6 class="mt-3">Endereço</h6>
                 <div class="row">
-                    <div class="col-md-3 mb-2">
+                    <div class="col-md-3 mb-1">
                         <label for="cep" class="form-label">CEP</label>
-                        <input type="text" class="form-control" id="cep" name="cep" value="{{ request.form.get('cep', est_editar.cep if est_editar else '') }}" maxlength="9">
+                        <input type="text" class="form-control form-control-sm" id="cep" name="cep" value="{{ request.form.get('cep', est_editar.cep if est_editar else '') }}" maxlength="9">
                     </div>
-                    <div class="col-md-7 mb-2">
+                    <div class="col-md-7 mb-1">
                         <label for="logradouro" class="form-label">Logradouro</label>
-                        <input type="text" class="form-control" id="logradouro" name="logradouro" value="{{ request.form.get('logradouro', est_editar.logradouro if est_editar else '') }}" maxlength="255">
+                        <input type="text" class="form-control form-control-sm" id="logradouro" name="logradouro" value="{{ request.form.get('logradouro', est_editar.logradouro if est_editar else '') }}" maxlength="255">
                     </div>
-                    <div class="col-md-2 mb-2">
+                    <div class="col-md-2 mb-1">
                         <label for="numero" class="form-label">Número</label>
-                        <input type="text" class="form-control" id="numero" name="numero" value="{{ request.form.get('numero', est_editar.numero if est_editar else '') }}" maxlength="20">
+                        <input type="text" class="form-control form-control-sm" id="numero" name="numero" value="{{ request.form.get('numero', est_editar.numero if est_editar else '') }}" maxlength="20">
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-md-4 mb-2">
+                    <div class="col-md-4 mb-1">
                         <label for="complemento" class="form-label">Complemento</label>
-                        <input type="text" class="form-control" id="complemento" name="complemento" value="{{ request.form.get('complemento', est_editar.complemento if est_editar else '') }}" maxlength="100">
+                        <input type="text" class="form-control form-control-sm" id="complemento" name="complemento" value="{{ request.form.get('complemento', est_editar.complemento if est_editar else '') }}" maxlength="100">
                     </div>
-                    <div class="col-md-4 mb-2">
+                    <div class="col-md-4 mb-1">
                         <label for="bairro" class="form-label">Bairro</label>
-                        <input type="text" class="form-control" id="bairro" name="bairro" value="{{ request.form.get('bairro', est_editar.bairro if est_editar else '') }}" maxlength="100">
+                        <input type="text" class="form-control form-control-sm" id="bairro" name="bairro" value="{{ request.form.get('bairro', est_editar.bairro if est_editar else '') }}" maxlength="100">
                     </div>
-                     <div class="col-md-3 mb-2">
+                     <div class="col-md-3 mb-1">
                         <label for="cidade" class="form-label">Cidade</label>
-                        <input type="text" class="form-control" id="cidade" name="cidade" value="{{ request.form.get('cidade', est_editar.cidade if est_editar else '') }}" maxlength="100">
+                        <input type="text" class="form-control form-control-sm" id="cidade" name="cidade" value="{{ request.form.get('cidade', est_editar.cidade if est_editar else '') }}" maxlength="100">
                     </div>
-                    <div class="col-md-1 mb-2">
+                    <div class="col-md-1 mb-1">
                         <label for="estado" class="form-label">UF</label>
-                        <input type="text" class="form-control" id="estado" name="estado" value="{{ request.form.get('estado', est_editar.estado if est_editar else '') }}" maxlength="2">
+                        <input type="text" class="form-control form-control-sm" id="estado" name="estado" value="{{ request.form.get('estado', est_editar.estado if est_editar else '') }}" maxlength="2">
                     </div>
                 </div>
 
                 <h6 class="mt-3">Contato</h6>
                  <div class="row">
-                    <div class="col-md-4 mb-2">
+                    <div class="col-md-4 mb-1">
                         <label for="telefone_principal" class="form-label">Telefone Principal</label>
-                        <input type="text" class="form-control" id="telefone_principal" name="telefone_principal" value="{{ request.form.get('telefone_principal', est_editar.telefone_principal if est_editar else '') }}" maxlength="20">
+                        <input type="text" class="form-control form-control-sm" id="telefone_principal" name="telefone_principal" value="{{ request.form.get('telefone_principal', est_editar.telefone_principal if est_editar else '') }}" maxlength="20">
                     </div>
-                    <div class="col-md-4 mb-2">
+                    <div class="col-md-4 mb-1">
                         <label for="email_contato" class="form-label">E-mail de Contato</label>
-                        <input type="email" class="form-control" id="email_contato" name="email_contato" value="{{ request.form.get('email_contato', est_editar.email_contato if est_editar else '') }}" maxlength="120">
+                        <input type="email" class="form-control form-control-sm" id="email_contato" name="email_contato" value="{{ request.form.get('email_contato', est_editar.email_contato if est_editar else '') }}" maxlength="120">
                     </div>
-                     <div class="col-md-4 mb-2">
+                     <div class="col-md-4 mb-1">
                         <label for="data_abertura" class="form-label">Data de Abertura</label>
-                        <input type="date" class="form-control" id="data_abertura" name="data_abertura" value="{{ request.form.get('data_abertura', est_editar.data_abertura.strftime('%Y-%m-%d') if est_editar and est_editar.data_abertura else '') }}">
+                        <input type="date" class="form-control form-control-sm" id="data_abertura" name="data_abertura" value="{{ request.form.get('data_abertura', est_editar.data_abertura.strftime('%Y-%m-%d') if est_editar and est_editar.data_abertura else '') }}">
                     </div>
                 </div>
-                <div class="mb-2">
+                <div class="mb-1">
                     <label for="observacoes" class="form-label">Observações</label>
-                    <textarea class="form-control" id="observacoes" name="observacoes" rows="3">{{ request.form.get('observacoes', est_editar.observacoes if est_editar else '') }}</textarea>
+                    <textarea class="form-control form-control-sm" id="observacoes" name="observacoes" rows="3">{{ request.form.get('observacoes', est_editar.observacoes if est_editar else '') }}</textarea>
                 </div>
 
-                <div class="col-md-12 mb-2">
+                <div class="col-md-12 mb-1">
                     <div class="form-check form-switch">
                         <input class="form-check-input" type="checkbox" role="switch" id="ativo_check" name="ativo_check"
                                {% if est_editar %}{% if est_editar.ativo %}checked{% endif %}{% else %}checked{% endif %}>
@@ -144,70 +216,8 @@
         </div>
     </div>
 
-    {# Lista de Estabelecimentos Existentes #}
-    <div class="card shadow-sm">
-        <div class="card-header">
-            <h5 class="mb-0"><i class="bi bi-list-ul me-2"></i>Estabelecimentos Cadastrados ({{ estabelecimentos|length }})</h5>
-        </div>
-        <div class="card-body">
-            {% if estabelecimentos %}
-                <div class="table-responsive">
-                    <table class="table table-hover table-sm align-middle">
-                        <thead>
-                            <tr>
-                                <th>Código</th>
-                                <th>Nome Fantasia</th>
-                                <th>CNPJ</th>
-                                <th>Cidade/UF</th>
-                                <th>Status</th>
-                                <th style="width: 200px;" class="text-end">Ações</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for est in estabelecimentos %}
-                            <tr class="{{ 'table-light text-muted' if not est.ativo else '' }}">
-                                <td>{{ est.codigo }}</td>
-                                <td>{{ est.nome_fantasia }}</td>
-                                <td>{{ est.cnpj or '--' }}</td>
-                                <td>{{ est.cidade or 'N/A' }}/{{ est.estado or 'N/A' }}</td>
-                                <td>
-                                    {% if est.ativo %}
-                                        <span class="badge bg-success">Ativo</span>
-                                    {% else %}
-                                        <span class="badge bg-secondary">Inativo</span>
-                                    {% endif %}
-                                </td>
-                                <td class="text-end">
-                                    <a href="{{ url_for('admin_estabelecimentos', edit_id=est.id) }}" 
-                                       class="btn btn-sm btn-outline-primary me-1" title="Editar">
-                                        <i class="bi bi-pencil-fill"></i>
-                                    </a>
-                                    
-                                    {% set confirm_message_text = 'DESATIVAR' if est.ativo else 'ATIVAR' %}
-                                    {# Usamos tojson para escapar corretamente o nome para dentro de uma string JavaScript #}
-                                    {% set estabelecimento_nome_js = est.nome_fantasia | tojson %} 
-                                    <form action="{{ url_for('admin_toggle_ativo_estabelecimento', id=est.id) }}" method="POST" 
-                                        class="d-inline"
-                                        onsubmit="return confirm('Tem certeza que deseja {{ confirm_message_text }} o estabelecimento ' + {{ estabelecimento_nome_js }} + '?');">
-                                        {% if est.ativo %}
-                                            <button type="submit" class="btn btn-sm btn-outline-warning" title="Desativar">
-                                                <i class="bi bi-archive-fill"></i> Desativar
-                                            </button>
-                                        {% else %}
-                                            <button type="submit" class="btn btn-sm btn-outline-success" title="Ativar">
-                                                <i class="bi bi-archive-restore-fill"></i> Ativar
-                                            </button>
-                                        {% endif %}
-                                    </form>
-                                </td>
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
                 </div>
-            {% else %}
-                <p class="text-muted">Nenhum estabelecimento cadastrado ainda. Adicione um acima!</p>
-            {% endif %}
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- show establishments admin page in tabs
- default to consultation tab and add compact form styling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_68420698e1d0832e99207e0feddec5c3