### PR TITLE
Update docs about nullable migrations

### DIFF
--- a/docs/GUIA_DE_INSTALACAO.md
+++ b/docs/GUIA_DE_INSTALACAO.md
@@ -196,6 +196,8 @@ flask db upgrade
 ```
 Este comando executará todos os scripts de migração na pasta migrations/versions/ e criará todas as tabelas e estruturas necessárias no seu banco de dados repositorio_equipe_db (ou o nome que você configurou na sua DATABASE_URI).
 
+> **Observação:** se você adicionar uma nova coluna marcada como `nullable=True` em modelos existentes (como o `User`), remova previamente os registros ou deixe o campo temporariamente como `nullable=False` para rodar o `flask db upgrade`. Após a migração, altere o campo no banco para aceitar valores nulos, se desejar.
+
 ## 11. (Opcional, mas Recomendado) Popular Dados Iniciais
 Se você possui um script para criar usuários de exemplo ou outros dados iniciais (como o `seed_users.py` que ajustamos):
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@ Para rodar este projeto em um ambiente de desenvolvimento, você precisará ter 
     ```bash
     flask db upgrade
     ```
+    > Se suas migrações incluírem novas colunas com `nullable=True` em tabelas já existentes (ex.: `User`), remova os registros atuais ou defina o campo como `nullable=False` temporariamente para que a migração execute sem erros. Depois do `flask db upgrade`, ajuste o campo para permitir nulos, se for o caso.
 
 6.  **(Opcional) Popule dados iniciais (usuários de exemplo):**
     ```bash


### PR DESCRIPTION
## Summary
- add note about managing nullable columns in migrations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_6843067be938832e9922aecf204bc5a9