### PR TITLE
Add modal editing for establishments

### DIFF
--- a/templates/admin/estabelecimentos.html
+++ b/templates/admin/estabelecimentos.html
@@ -84,35 +84,28 @@
                 </div>
                 <div class="tab-pane fade p-3" id="cadastro" role="tabpanel" aria-labelledby="cadastro-tab">
                     <h5 class="mb-3">
-                        {% if est_editar %}
-                            <i class="bi bi-pencil-square me-2"></i>Editar Estabelecimento: <strong>{{ est_editar.nome_fantasia }}</strong>
-                        {% else %}
-                            <i class="bi bi-plus-circle-fill me-2"></i>Adicionar Novo Estabelecimento
-                        {% endif %}
+                        <i class="bi bi-plus-circle-fill me-2"></i>Adicionar Novo Estabelecimento
                     </h5>
 
                     <form method="POST" action="{{ url_for('admin_estabelecimentos') }}" novalidate class="compact-form">
-                        {% if est_editar %}
-                            <input type="hidden" name="id_para_atualizar" value="{{ est_editar.id }}">
-                        {% endif %}
 
                 <div class="row">
                     <div class="col-md-3 mb-1">
                         <label for="codigo" class="form-label">Código <span class="text-danger">*</span></label>
                         <input type="text" class="form-control form-control-sm" id="codigo" name="codigo" 
-                               value="{{ request.form.get('codigo', est_editar.codigo if est_editar else '') }}" 
+                               value="{{ request.form.get('codigo', '') }}"
                                required maxlength="50" placeholder="Ex: BH01">
                     </div>
                     <div class="col-md-5 mb-1">
                         <label for="nome_fantasia" class="form-label">Nome Fantasia <span class="text-danger">*</span></label>
                         <input type="text" class="form-control form-control-sm" id="nome_fantasia" name="nome_fantasia"
-                               value="{{ request.form.get('nome_fantasia', est_editar.nome_fantasia if est_editar else '') }}" 
+                               value="{{ request.form.get('nome_fantasia', '') }}"
                                required maxlength="200" placeholder="Nome popular">
                     </div>
                     <div class="col-md-4 mb-1">
                         <label for="cnpj" class="form-label">CNPJ</label>
                         <input type="text" class="form-control form-control-sm" id="cnpj" name="cnpj"
-                               value="{{ request.form.get('cnpj', est_editar.cnpj if est_editar else '') }}" 
+                               value="{{ request.form.get('cnpj', '') }}"
                                maxlength="18" placeholder="XX.XXX.XXX/XXXX-XX">
                     </div>
                 </div>
@@ -121,13 +114,13 @@
                     <div class="col-md-8 mb-1">
                         <label for="razao_social" class="form-label">Razão Social</label>
                         <input type="text" class="form-control form-control-sm" id="razao_social" name="razao_social"
-                               value="{{ request.form.get('razao_social', est_editar.razao_social if est_editar else '') }}" 
+                               value="{{ request.form.get('razao_social', '') }}"
                                maxlength="255">
                     </div>
                     <div class="col-md-4 mb-1">
                         <label for="tipo_estabelecimento" class="form-label">Tipo</label>
                         <input type="text" class="form-control form-control-sm" id="tipo_estabelecimento" name="tipo_estabelecimento"
-                               value="{{ request.form.get('tipo_estabelecimento', est_editar.tipo_estabelecimento if est_editar else '') }}" 
+                               value="{{ request.form.get('tipo_estabelecimento', '') }}"
                                maxlength="50" placeholder="Matriz, Filial, Loja...">
                     </div>
                 </div>
@@ -137,33 +130,33 @@
                 <div class="row">
                     <div class="col-md-3 mb-1">
                         <label for="cep" class="form-label">CEP</label>
-                        <input type="text" class="form-control form-control-sm" id="cep" name="cep" value="{{ request.form.get('cep', est_editar.cep if est_editar else '') }}" maxlength="9">
+                        <input type="text" class="form-control form-control-sm" id="cep" name="cep" value="{{ request.form.get('cep', '') }}" maxlength="9">
                     </div>
                     <div class="col-md-7 mb-1">
                         <label for="logradouro" class="form-label">Logradouro</label>
-                        <input type="text" class="form-control form-control-sm" id="logradouro" name="logradouro" value="{{ request.form.get('logradouro', est_editar.logradouro if est_editar else '') }}" maxlength="255">
+                        <input type="text" class="form-control form-control-sm" id="logradouro" name="logradouro" value="{{ request.form.get('logradouro', '') }}" maxlength="255">
                     </div>
                     <div class="col-md-2 mb-1">
                         <label for="numero" class="form-label">Número</label>
-                        <input type="text" class="form-control form-control-sm" id="numero" name="numero" value="{{ request.form.get('numero', est_editar.numero if est_editar else '') }}" maxlength="20">
+                        <input type="text" class="form-control form-control-sm" id="numero" name="numero" value="{{ request.form.get('numero', '') }}" maxlength="20">
                     </div>
                 </div>
                 <div class="row">
                     <div class="col-md-4 mb-1">
                         <label for="complemento" class="form-label">Complemento</label>
-                        <input type="text" class="form-control form-control-sm" id="complemento" name="complemento" value="{{ request.form.get('complemento', est_editar.complemento if est_editar else '') }}" maxlength="100">
+                        <input type="text" class="form-control form-control-sm" id="complemento" name="complemento" value="{{ request.form.get('complemento', '') }}" maxlength="100">
                     </div>
                     <div class="col-md-4 mb-1">
                         <label for="bairro" class="form-label">Bairro</label>
-                        <input type="text" class="form-control form-control-sm" id="bairro" name="bairro" value="{{ request.form.get('bairro', est_editar.bairro if est_editar else '') }}" maxlength="100">
+                        <input type="text" class="form-control form-control-sm" id="bairro" name="bairro" value="{{ request.form.get('bairro', '') }}" maxlength="100">
                     </div>
                      <div class="col-md-3 mb-1">
                         <label for="cidade" class="form-label">Cidade</label>
-                        <input type="text" class="form-control form-control-sm" id="cidade" name="cidade" value="{{ request.form.get('cidade', est_editar.cidade if est_editar else '') }}" maxlength="100">
+                        <input type="text" class="form-control form-control-sm" id="cidade" name="cidade" value="{{ request.form.get('cidade', '') }}" maxlength="100">
                     </div>
                     <div class="col-md-1 mb-1">
                         <label for="estado" class="form-label">UF</label>
-                        <input type="text" class="form-control form-control-sm" id="estado" name="estado" value="{{ request.form.get('estado', est_editar.estado if est_editar else '') }}" maxlength="2">
+                        <input type="text" class="form-control form-control-sm" id="estado" name="estado" value="{{ request.form.get('estado', '') }}" maxlength="2">
                     </div>
                 </div>
 
@@ -171,26 +164,25 @@
                  <div class="row">
                     <div class="col-md-4 mb-1">
                         <label for="telefone_principal" class="form-label">Telefone Principal</label>
-                        <input type="text" class="form-control form-control-sm" id="telefone_principal" name="telefone_principal" value="{{ request.form.get('telefone_principal', est_editar.telefone_principal if est_editar else '') }}" maxlength="20">
+                        <input type="text" class="form-control form-control-sm" id="telefone_principal" name="telefone_principal" value="{{ request.form.get('telefone_principal', '') }}" maxlength="20">
                     </div>
                     <div class="col-md-4 mb-1">
                         <label for="email_contato" class="form-label">E-mail de Contato</label>
-                        <input type="email" class="form-control form-control-sm" id="email_contato" name="email_contato" value="{{ request.form.get('email_contato', est_editar.email_contato if est_editar else '') }}" maxlength="120">
+                        <input type="email" class="form-control form-control-sm" id="email_contato" name="email_contato" value="{{ request.form.get('email_contato', '') }}" maxlength="120">
                     </div>
                      <div class="col-md-4 mb-1">
                         <label for="data_abertura" class="form-label">Data de Abertura</label>
-                        <input type="date" class="form-control form-control-sm" id="data_abertura" name="data_abertura" value="{{ request.form.get('data_abertura', est_editar.data_abertura.strftime('%Y-%m-%d') if est_editar and est_editar.data_abertura else '') }}">
+                        <input type="date" class="form-control form-control-sm" id="data_abertura" name="data_abertura" value="{{ request.form.get('data_abertura', '') }}">
                     </div>
                 </div>
                 <div class="mb-1">
                     <label for="observacoes" class="form-label">Observações</label>
-                    <textarea class="form-control form-control-sm" id="observacoes" name="observacoes" rows="3">{{ request.form.get('observacoes', est_editar.observacoes if est_editar else '') }}</textarea>
+                    <textarea class="form-control form-control-sm" id="observacoes" name="observacoes" rows="3">{{ request.form.get('observacoes', '') }}</textarea>
                 </div>
 
                 <div class="col-md-12 mb-1">
                     <div class="form-check form-switch">
-                        <input class="form-check-input" type="checkbox" role="switch" id="ativo_check" name="ativo_check"
-                               {% if est_editar %}{% if est_editar.ativo %}checked{% endif %}{% else %}checked{% endif %}>
+                        <input class="form-check-input" type="checkbox" role="switch" id="ativo_check" name="ativo_check" checked>
                         <label class="form-check-label" for="ativo_check">
                             Ativo
                         </label>
@@ -200,17 +192,8 @@
                 <div class="d-flex pt-2 border-top">
                     <button type="submit" class="btn btn-primary">
                         <i class="bi bi-check-lg me-1"></i> 
-                        {% if est_editar %}
-                            Salvar Alterações
-                        {% else %}
-                            Adicionar Estabelecimento
-                        {% endif %}
+                        Adicionar Estabelecimento
                     </button>
-                    {% if est_editar %}
-                        <a href="{{ url_for('admin_estabelecimentos') }}" class="btn btn-outline-secondary ms-2">
-                            <i class="bi bi-x-lg me-1"></i> Cancelar Edição
-                        </a>
-                    {% endif %}
                 </div>
             </form>
         </div>
@@ -220,5 +203,136 @@
             </div>
         </div>
     </div>
+
+{% if est_editar %}
+<div class="modal fade" id="modalEditarEstabelecimento" tabindex="-1" aria-labelledby="modalEditarEstabelecimentoLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalEditarEstabelecimentoLabel">Editar Estabelecimento</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+            </div>
+            <div class="modal-body">
+                <form method="POST" action="{{ url_for('admin_estabelecimentos') }}" novalidate class="compact-form">
+                    <input type="hidden" name="id_para_atualizar" value="{{ est_editar.id }}">
+
+                    <div class="row">
+                        <div class="col-md-3 mb-1">
+                            <label for="edit_codigo" class="form-label">Código <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control form-control-sm" id="edit_codigo" name="codigo"
+                                   value="{{ request.form.get('codigo', est_editar.codigo) }}" required maxlength="50" placeholder="Ex: BH01">
+                        </div>
+                        <div class="col-md-5 mb-1">
+                            <label for="edit_nome_fantasia" class="form-label">Nome Fantasia <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control form-control-sm" id="edit_nome_fantasia" name="nome_fantasia"
+                                   value="{{ request.form.get('nome_fantasia', est_editar.nome_fantasia) }}" required maxlength="200" placeholder="Nome popular">
+                        </div>
+                        <div class="col-md-4 mb-1">
+                            <label for="edit_cnpj" class="form-label">CNPJ</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_cnpj" name="cnpj"
+                                   value="{{ request.form.get('cnpj', est_editar.cnpj or '') }}" maxlength="18" placeholder="XX.XXX.XXX/XXXX-XX">
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-8 mb-1">
+                            <label for="edit_razao_social" class="form-label">Razão Social</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_razao_social" name="razao_social"
+                                   value="{{ request.form.get('razao_social', est_editar.razao_social or '') }}" maxlength="255">
+                        </div>
+                        <div class="col-md-4 mb-1">
+                            <label for="edit_tipo_estabelecimento" class="form-label">Tipo</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_tipo_estabelecimento" name="tipo_estabelecimento"
+                                   value="{{ request.form.get('tipo_estabelecimento', est_editar.tipo_estabelecimento or '') }}" maxlength="50" placeholder="Matriz, Filial, Loja...">
+                        </div>
+                    </div>
+
+                    <h6 class="mt-3">Endereço</h6>
+                    <div class="row">
+                        <div class="col-md-3 mb-1">
+                            <label for="edit_cep" class="form-label">CEP</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_cep" name="cep" value="{{ request.form.get('cep', est_editar.cep or '') }}" maxlength="9">
+                        </div>
+                        <div class="col-md-7 mb-1">
+                            <label for="edit_logradouro" class="form-label">Logradouro</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_logradouro" name="logradouro" value="{{ request.form.get('logradouro', est_editar.logradouro or '') }}" maxlength="255">
+                        </div>
+                        <div class="col-md-2 mb-1">
+                            <label for="edit_numero" class="form-label">Número</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_numero" name="numero" value="{{ request.form.get('numero', est_editar.numero or '') }}" maxlength="20">
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-4 mb-1">
+                            <label for="edit_complemento" class="form-label">Complemento</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_complemento" name="complemento" value="{{ request.form.get('complemento', est_editar.complemento or '') }}" maxlength="100">
+                        </div>
+                        <div class="col-md-4 mb-1">
+                            <label for="edit_bairro" class="form-label">Bairro</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_bairro" name="bairro" value="{{ request.form.get('bairro', est_editar.bairro or '') }}" maxlength="100">
+                        </div>
+                        <div class="col-md-3 mb-1">
+                            <label for="edit_cidade" class="form-label">Cidade</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_cidade" name="cidade" value="{{ request.form.get('cidade', est_editar.cidade or '') }}" maxlength="100">
+                        </div>
+                        <div class="col-md-1 mb-1">
+                            <label for="edit_estado" class="form-label">UF</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_estado" name="estado" value="{{ request.form.get('estado', est_editar.estado or '') }}" maxlength="2">
+                        </div>
+                    </div>
+
+                    <h6 class="mt-3">Contato</h6>
+                    <div class="row">
+                        <div class="col-md-4 mb-1">
+                            <label for="edit_telefone_principal" class="form-label">Telefone Principal</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_telefone_principal" name="telefone_principal" value="{{ request.form.get('telefone_principal', est_editar.telefone_principal or '') }}" maxlength="20">
+                        </div>
+                        <div class="col-md-4 mb-1">
+                            <label for="edit_email_contato" class="form-label">E-mail de Contato</label>
+                            <input type="email" class="form-control form-control-sm" id="edit_email_contato" name="email_contato" value="{{ request.form.get('email_contato', est_editar.email_contato or '') }}" maxlength="120">
+                        </div>
+                        <div class="col-md-4 mb-1">
+                            <label for="edit_data_abertura" class="form-label">Data de Abertura</label>
+                            <input type="date" class="form-control form-control-sm" id="edit_data_abertura" name="data_abertura" value="{{ request.form.get('data_abertura', est_editar.data_abertura.strftime('%Y-%m-%d') if est_editar.data_abertura else '') }}">
+                        </div>
+                    </div>
+
+                    <div class="mb-1">
+                        <label for="edit_observacoes" class="form-label">Observações</label>
+                        <textarea class="form-control form-control-sm" id="edit_observacoes" name="observacoes" rows="3">{{ request.form.get('observacoes', est_editar.observacoes or '') }}</textarea>
+                    </div>
+
+                    <div class="col-md-12 mb-1">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" role="switch" id="edit_ativo_check" name="ativo_check" {% if est_editar.ativo %}checked{% endif %}>
+                            <label class="form-check-label" for="edit_ativo_check">Ativo</label>
+                        </div>
+                    </div>
+
+                    <div class="d-flex pt-2 border-top">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="bi bi-check-lg me-1"></i> Salvar Alterações
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary ms-2" data-bs-dismiss="modal">
+                            <i class="bi bi-x-lg me-1"></i> Cancelar
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
 </div>
 {% endblock content %}
+
+{% block extra_js %}
+{% if est_editar %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var modal = new bootstrap.Modal(document.getElementById('modalEditarEstabelecimento'));
+    modal.show();
+});
+</script>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- keep Cadastro tab empty for new establishments only
- show modal with compact form when editing establishments
- automatically open modal if editing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `bleach`)*

------
https://chatgpt.com/codex/tasks/task_e_68432ef4b820832eb9ac5dd5a0bd745c