### PR TITLE
Implement copy link feature

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -140,4 +140,15 @@ document.addEventListener("DOMContentLoaded", function () {
       }
     });
   });
+
+  document.querySelectorAll('.copy-link-icon').forEach((icon) => {
+    icon.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const url = icon.dataset.url;
+      if (url && navigator.clipboard) {
+        navigator.clipboard.writeText(url);
+      }
+    });
+  });
 });

--- a/templates/artigo.html
+++ b/templates/artigo.html
@@ -6,7 +6,7 @@
 <div class="row">
   <div class="col-md-10 mx-auto">
     <div class="card shadow-sm">
-      <div class="card-body">
+      <div class="card-body position-relative">
 
         {# Cabeçalho com título e status #}
         <div class="d-flex justify-content-between align-items-start">
@@ -131,12 +131,19 @@
           </a>
           {% endif %}
 
-          {% if session.get('username') and artigo.status == ArticleStatus.APROVADO %}
-          <a href="{{ url_for('solicitar_revisao', artigo_id=artigo.id) }}" class="btn btn-warning text-dark">
-            Solicitar Revisão
-          </a>
-          {% endif %}
-        </div>
+        {% if session.get('username') and artigo.status == ArticleStatus.APROVADO %}
+        <a href="{{ url_for('solicitar_revisao', artigo_id=artigo.id) }}" class="btn btn-warning text-dark">
+          Solicitar Revisão
+        </a>
+        {% endif %}
+        {% if artigo.status == ArticleStatus.APROVADO %}
+        <i
+          class="bi bi-copy text-secondary copy-link-icon"
+          data-url="{{ url_for('artigo', artigo_id=artigo.id, _external=True) }}"
+          style="position:absolute; bottom:10px; right:10px; cursor:pointer; font-size:1.3rem;"
+        ></i>
+        {% endif %}
+      </div>
 
       </div> {# .card-body #}
     </div> {# .card #}

--- a/templates/meus_artigos.html
+++ b/templates/meus_artigos.html
@@ -14,7 +14,7 @@
             {% for artigo in artigos %}
               {% set st = artigo.status %}
               <a href="{{ url_for('artigo', artigo_id=artigo.id) }}"
-                 class="list-group-item list-group-item-action d-flex justify-content-between align-items-start">
+                 class="list-group-item list-group-item-action d-flex justify-content-between align-items-start position-relative">
                 
                 <div>
                   <div class="fw-bold">{{ artigo.titulo }}</div>
@@ -25,6 +25,14 @@
                 <span class="badge rounded-pill bg-{{ st.color }} text-{{ st.text_color }}">
                   {{ st.label }}
                 </span>
+
+                {% if artigo.status == ArticleStatus.APROVADO %}
+                <i
+                  class="bi bi-copy text-secondary copy-link-icon"
+                  data-url="{{ url_for('artigo', artigo_id=artigo.id, _external=True) }}"
+                  style="position:absolute; bottom:5px; right:10px; cursor:pointer; font-size:1.2rem;"
+                ></i>
+                {% endif %}
               </a>
             {% endfor %}
           </div>

--- a/templates/pesquisar.html
+++ b/templates/pesquisar.html
@@ -24,7 +24,7 @@
         {% for artigo in artigos %}
           <a
             href="{{ url_for('artigo', artigo_id=artigo.id) }}"
-            class="list-group-item list-group-item-action d-flex justify-content-between align-items-start"
+            class="list-group-item list-group-item-action d-flex justify-content-between align-items-start position-relative"
           >
             <div>
               <div class="fw-bold">{{ artigo.titulo }}</div>
@@ -38,6 +38,12 @@
             <span class="badge rounded-pill bg-{{ st.color }} text-{{ st.text_color }}">
               {{ st.label }}
             </span>
+
+            <i
+              class="bi bi-copy text-secondary copy-link-icon"
+              data-url="{{ url_for('artigo', artigo_id=artigo.id, _external=True) }}"
+              style="position:absolute; bottom:5px; right:10px; cursor:pointer; font-size:1.2rem;"
+            ></i>
           </a>
         {% endfor %}
       </div>


### PR DESCRIPTION
## Summary
- add copy link icon on search results
- show copy link icon on approved article pages
- implement clipboard logic and temporary alerts
- update icon to `bi-copy` and copy full article URLs
- include copy icon on approved articles in "Meus Artigos" page
- remove temporary alert when copying links

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'bleach')*

------
https://chatgpt.com/codex/tasks/task_e_684330463c44832eaf7dd12db9d50169