### PR TITLE
Add Centro de Custo CRUD

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,9 +22,9 @@ from functools import wraps # Essencial para decoradores, você já tinha
 
 from database import db
 from enums import ArticleStatus
-from models import ( # Importando os modelos necessários
+from models import (  # Importando os modelos necessários
     User, Article, RevisionRequest, Notification, Comment, Attachment,
-    Estabelecimento # <<< NOSSO NOVO MODELO PARA A ROTA DE ADMIN
+    Estabelecimento, CentroDeCusto  # Modelos utilizados nas rotas de admin
 )
 from utils import sanitize_html, extract_text
 from mimetypes import guess_type # Se for usar, descomente
@@ -304,6 +304,94 @@ def admin_toggle_ativo_estabelecimento(id):
         flash(f'Erro ao alterar status do estabelecimento: {str(e)}', 'danger')
         app.logger.error(f"Erro ao alterar status do est. {est.id}: {e}")
     return redirect(url_for('admin_estabelecimentos'))
+
+@app.route('/admin/centros_custo', methods=['GET', 'POST'])
+@admin_required
+def admin_centros_custo():
+    """CRUD para Centros de Custo."""
+    centro_para_editar = None
+    if request.method == 'GET':
+        edit_id = request.args.get('edit_id', type=int)
+        if edit_id:
+            centro_para_editar = CentroDeCusto.query.get_or_404(edit_id)
+
+    if request.method == 'POST':
+        id_para_atualizar = request.form.get('id_para_atualizar')
+        codigo = request.form.get('codigo', '').strip().upper()
+        nome = request.form.get('nome', '').strip()
+        estabelecimento_id = request.form.get('estabelecimento_id', type=int)
+        ativo = request.form.get('ativo_check') == 'on'
+
+        if not codigo or not nome or not estabelecimento_id:
+            flash('Código, Nome e Estabelecimento são obrigatórios.', 'danger')
+        else:
+            query_codigo_existente = CentroDeCusto.query.filter_by(codigo=codigo)
+            if id_para_atualizar:
+                query_codigo_existente = query_codigo_existente.filter(CentroDeCusto.id != int(id_para_atualizar))
+            codigo_ja_existe = query_codigo_existente.first()
+
+            if codigo_ja_existe:
+                flash(f'O código de centro de custo "{codigo}" já está em uso.', 'danger')
+            else:
+                if id_para_atualizar:
+                    cc = CentroDeCusto.query.get_or_404(id_para_atualizar)
+                    cc.codigo = codigo
+                    cc.nome = nome
+                    cc.estabelecimento_id = estabelecimento_id
+                    cc.ativo = ativo
+                    action_msg = 'atualizado'
+                else:
+                    cc = CentroDeCusto(
+                        codigo=codigo,
+                        nome=nome,
+                        estabelecimento_id=estabelecimento_id,
+                        ativo=ativo
+                    )
+                    db.session.add(cc)
+                    action_msg = 'criado'
+
+                try:
+                    db.session.commit()
+                    flash(f'Centro de Custo {action_msg} com sucesso!', 'success')
+                    return redirect(url_for('admin_centros_custo'))
+                except Exception as e:
+                    db.session.rollback()
+                    flash(f'Erro ao salvar centro de custo: {str(e)}', 'danger')
+
+        if id_para_atualizar:
+            centro_para_editar = CentroDeCusto.query.get(id_para_atualizar)
+
+    todos_centros = CentroDeCusto.query.order_by(CentroDeCusto.nome).all()
+    todos_estabelecimentos = Estabelecimento.query.order_by(Estabelecimento.nome_fantasia).all()
+    return render_template(
+        'admin/centros_custo.html',
+        centros=todos_centros,
+        estabelecimentos=todos_estabelecimentos,
+        cc_editar=centro_para_editar
+    )
+
+
+@app.route('/admin/centros_custo/toggle_ativo/<int:id>', methods=['POST'])
+@admin_required
+def admin_toggle_ativo_centro_custo(id):
+    """Ativa ou inativa um Centro de Custo."""
+    cc = CentroDeCusto.query.get_or_404(id)
+
+    if cc.ativo and (cc.setores.count() > 0 or cc.usuarios.count() > 0):
+        flash(
+            f'Atenção: "{cc.nome}" possui Setores ou Usuários associados. Inativá-lo pode ter implicações.',
+            'warning'
+        )
+
+    cc.ativo = not cc.ativo
+    try:
+        db.session.commit()
+        status_texto = 'ativado' if cc.ativo else 'desativado'
+        flash(f'Centro de Custo "{cc.nome}" foi {status_texto} com sucesso!', 'success')
+    except Exception as e:
+        db.session.rollback()
+        flash(f'Erro ao alterar status do centro de custo: {str(e)}', 'danger')
+    return redirect(url_for('admin_centros_custo'))
 
 # -------------------------------------------------------------------------
 # ROTAS PRINCIPAIS

--- a/templates/admin/centros_custo.html
+++ b/templates/admin/centros_custo.html
@@ -1,0 +1,199 @@
+{% extends "base.html" %}
+
+{% block title %}Admin - Gerenciar Centros de Custo{% endblock %}
+
+{% block content %}
+<div class="container-fluid px-5 mt-3">
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-1 border-bottom">
+        <h1 class="h2">Gerenciar Centros de Custo</h1>
+    </div>
+
+    <ul class="nav nav-tabs" id="tabCC" role="tablist">
+        <li class="nav-item">
+            <button class="nav-link active" id="consulta-tab" data-bs-toggle="tab" data-bs-target="#consulta" type="button" role="tab">Consulta</button>
+        </li>
+        <li class="nav-item">
+            <button class="nav-link" id="cadastro-tab" data-bs-toggle="tab" data-bs-target="#cadastro" type="button" role="tab">Cadastro</button>
+        </li>
+    </ul>
+
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <div class="tab-content" id="tabCCContent">
+                <div class="tab-pane fade show active p-3" id="consulta" role="tabpanel" aria-labelledby="consulta-tab">
+                    <div class="card shadow-sm mb-4">
+                        <div class="card-header">
+                            <h5 class="mb-0"><i class="bi bi-list-ul me-2"></i>Centros de Custo Cadastrados ({{ centros|length }})</h5>
+                        </div>
+                        <div class="card-body">
+                            {% if centros %}
+                                <div class="table-responsive">
+                                    <table class="table table-hover table-sm align-middle">
+                                        <thead>
+                                            <tr>
+                                                <th>Código</th>
+                                                <th>Nome</th>
+                                                <th>Estabelecimento</th>
+                                                <th>Status</th>
+                                                <th style="width: 200px;" class="text-end">Ações</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for cc in centros %}
+                                            <tr class="{{ 'table-light text-muted' if not cc.ativo else '' }} clickable-row" data-href="{{ url_for('admin_centros_custo', edit_id=cc.id) }}">
+                                                <td>{{ cc.codigo }}</td>
+                                                <td>{{ cc.nome }}</td>
+                                                <td>{{ cc.estabelecimento.nome_fantasia }}</td>
+                                                <td>
+                                                    {% if cc.ativo %}
+                                                        <span class="badge bg-success">Ativo</span>
+                                                    {% else %}
+                                                        <span class="badge bg-secondary">Inativo</span>
+                                                    {% endif %}
+                                                </td>
+                                                <td class="text-end">
+                                                    <a href="{{ url_for('admin_centros_custo', edit_id=cc.id) }}" class="btn btn-sm btn-outline-primary me-1" title="Editar">
+                                                        <i class="bi bi-pencil-fill"></i>
+                                                    </a>
+                                                    {% set confirm_message_text = 'DESATIVAR' if cc.ativo else 'ATIVAR' %}
+                                                    {% set centro_nome_js = cc.nome | tojson %}
+                                                    <form action="{{ url_for('admin_toggle_ativo_centro_custo', id=cc.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_message_text }} o centro de custo ' + {{ centro_nome_js }} + '?');">
+                                                        {% if cc.ativo %}
+                                                            <button type="submit" class="btn btn-sm btn-outline-warning" title="Desativar">
+                                                                <i class="bi bi-archive-fill"></i> Desativar
+                                                            </button>
+                                                        {% else %}
+                                                            <button type="submit" class="btn btn-sm btn-outline-success" title="Ativar">
+                                                                <i class="bi bi-archive-restore-fill"></i> Ativar
+                                                            </button>
+                                                        {% endif %}
+                                                    </form>
+                                                </td>
+                                            </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            {% else %}
+                                <p class="text-muted">Nenhum centro de custo cadastrado ainda. Adicione um acima!</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+                <div class="tab-pane fade p-3" id="cadastro" role="tabpanel" aria-labelledby="cadastro-tab">
+                    <h5 class="mb-3">
+                        <i class="bi bi-plus-circle-fill me-2"></i>Adicionar Novo Centro de Custo
+                    </h5>
+
+                    <form method="POST" action="{{ url_for('admin_centros_custo') }}" novalidate class="compact-form">
+
+                    <div class="row">
+                        <div class="col-md-3 mb-1">
+                            <label for="codigo" class="form-label">Código <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control form-control-sm" id="codigo" name="codigo"
+                                   value="{{ request.form.get('codigo', '') }}"
+                                   required maxlength="50" placeholder="Ex: CC01">
+                        </div>
+                        <div class="col-md-5 mb-1">
+                            <label for="nome" class="form-label">Nome <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control form-control-sm" id="nome" name="nome"
+                                   value="{{ request.form.get('nome', '') }}"
+                                   required maxlength="200">
+                        </div>
+                        <div class="col-md-4 mb-1">
+                            <label for="estabelecimento_id" class="form-label">Estabelecimento <span class="text-danger">*</span></label>
+                            <select class="form-select form-select-sm" id="estabelecimento_id" name="estabelecimento_id" required>
+                                <option value="">Selecione</option>
+                                {% for est in estabelecimentos %}
+                                <option value="{{ est.id }}" {{ 'selected' if request.form.get('estabelecimento_id') == str(est.id) else '' }}>{{ est.nome_fantasia }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="col-md-12 mb-1">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" role="switch" id="ativo_check" name="ativo_check" checked>
+                            <label class="form-check-label" for="ativo_check">Ativo</label>
+                        </div>
+                    </div>
+
+                    <div class="d-flex pt-2 border-top">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="bi bi-check-lg me-1"></i>
+                            Adicionar Centro de Custo
+                        </button>
+                    </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+{% if cc_editar %}
+<div class="modal fade" id="modalEditarCentroCusto" tabindex="-1" aria-labelledby="modalEditarCentroCustoLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalEditarCentroCustoLabel">Editar Centro de Custo</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+            </div>
+            <div class="modal-body">
+                <form method="POST" action="{{ url_for('admin_centros_custo') }}" novalidate class="compact-form">
+                    <input type="hidden" name="id_para_atualizar" value="{{ cc_editar.id }}">
+
+                    <div class="row">
+                        <div class="col-md-4 mb-1">
+                            <label for="edit_codigo" class="form-label">Código <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control form-control-sm" id="edit_codigo" name="codigo"
+                                   value="{{ request.form.get('codigo', cc_editar.codigo) }}" required maxlength="50">
+                        </div>
+                        <div class="col-md-8 mb-1">
+                            <label for="edit_nome" class="form-label">Nome <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control form-control-sm" id="edit_nome" name="nome"
+                                   value="{{ request.form.get('nome', cc_editar.nome) }}" required maxlength="200">
+                        </div>
+                    </div>
+                    <div class="mb-1">
+                        <label for="edit_estabelecimento_id" class="form-label">Estabelecimento <span class="text-danger">*</span></label>
+                        <select class="form-select form-select-sm" id="edit_estabelecimento_id" name="estabelecimento_id" required>
+                            <option value="">Selecione</option>
+                            {% for est in estabelecimentos %}
+                            <option value="{{ est.id }}" {% if (request.form.get('estabelecimento_id') == str(est.id)) or (not request.form.get('estabelecimento_id') and cc_editar.estabelecimento_id == est.id) %}selected{% endif %}>{{ est.nome_fantasia }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-md-12 mb-1">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" role="switch" id="edit_ativo_check" name="ativo_check" {% if cc_editar.ativo %}checked{% endif %}>
+                            <label class="form-check-label" for="edit_ativo_check">Ativo</label>
+                        </div>
+                    </div>
+
+                    <div class="d-flex pt-2 border-top">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="bi bi-check-lg me-1"></i> Salvar Alterações
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary ms-2" data-bs-dismiss="modal">
+                            <i class="bi bi-x-lg me-1"></i> Cancelar
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+</div>
+{% endblock content %}
+
+{% block extra_js %}
+{% if cc_editar %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var modal = new bootstrap.Modal(document.getElementById('modalEditarCentroCusto'));
+    modal.show();
+});
+</script>
+{% endif %}
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -249,7 +249,7 @@
                                         <div class="collapse {{ 'show' if request.endpoint.startswith('admin_estabelecimentos') or request.endpoint.startswith('admin_centros_custo') or request.endpoint.startswith('admin_setores') or request.endpoint.startswith('admin_cargos') else '' }}" id="collapseCadastrosOrgSub">
                                             <ul class="nav flex-column ps-3">
                                                 <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_estabelecimentos' else '' }}" href="{{ url_for('admin_estabelecimentos') }}"><i class="bi bi-building me-2"></i> Estabelecimentos</a></li>
-                                                <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-diagram-3-fill me-2"></i> Centros de Custo</a></li>
+                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_centros_custo' else '' }}" href="{{ url_for('admin_centros_custo') }}"><i class="bi bi-diagram-3-fill me-2"></i> Centros de Custo</a></li>
                                                 <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-tags-fill me-2"></i> Setores</a></li>
                                                 <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-person-badge-fill me-2"></i> Cargos</a></li>
                                             </ul>

--- a/tests/test_centro_custo.py
+++ b/tests/test_centro_custo.py
@@ -1,0 +1,45 @@
+import os
+import pytest
+
+os.environ.setdefault('SECRET_KEY', 'test_secret')
+os.environ.setdefault('DATABASE_URI', 'sqlite:///:memory:')
+
+from app import app, db
+from models import Estabelecimento, CentroDeCusto
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        est = Estabelecimento(codigo='EST1', nome_fantasia='Estab 1')
+        db.session.add(est)
+        db.session.commit()
+        with app.test_client() as client:
+            yield client
+        db.session.remove()
+        db.drop_all()
+
+
+def login_admin(client):
+    with client.session_transaction() as sess:
+        sess['user_id'] = 1
+        sess['role'] = 'admin'
+
+
+def test_create_centro_custo(client):
+    login_admin(client)
+    with app.app_context():
+        est_id = Estabelecimento.query.first().id
+    response = client.post('/admin/centros_custo', data={
+        'codigo': 'CC01',
+        'nome': 'Centro 1',
+        'estabelecimento_id': est_id,
+        'ativo_check': 'on'
+    }, follow_redirects=True)
+    assert response.status_code == 200
+    with app.app_context():
+        cc = CentroDeCusto.query.filter_by(codigo='CC01').first()
+        assert cc is not None
+        assert cc.estabelecimento_id == est_id
+        assert cc.nome == 'Centro 1'


### PR DESCRIPTION
## Summary
- implement admin CRUD routes for `CentroDeCusto`
- add sidebar link for Centros de Custo
- create template for managing Centros de Custo
- test creation of Centro de Custo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684339f83934832e89f94450a597aa29