### PR TITLE
Implement CRUD for Setor

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ Orquetask é um sistema web integrado construído com Flask e Python, projetado 
     * Busca Full-Text em conteúdo e anexos.
 * **Módulo de Administração Global:**
     * Gerenciamento de Usuários (com campos detalhados e status ativo/inativo).
-    * Gerenciamento de Estrutura Organizacional: Estabelecimentos, Centros de Custo, Setores e Cargos.
+    * Gerenciamento de Estrutura Organizacional: CRUD de Estabelecimentos, Centros de Custo e Setores. (Cargos em desenvolvimento)
     * (Planejado) Gestão de Perfis de Acesso e Permissões (Funções).
 * **Página Inicial Personalizada:** Dashboard do usuário pós-login.
 * **Perfil de Usuário Detalhado:** Visualização e edição de dados, foto e senha.

--- a/templates/admin/centros_custo.html
+++ b/templates/admin/centros_custo.html
@@ -1,0 +1,184 @@
+{% extends "base.html" %}
+
+{% block title %}Admin - Gerenciar Centros de Custo{% endblock %}
+
+{% block content %}
+<div class="container-fluid px-5 mt-3">
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-1 border-bottom">
+        <h1 class="h2">Gerenciar Centros de Custo</h1>
+    </div>
+
+    <ul class="nav nav-tabs" id="tabCC" role="tablist">
+        <li class="nav-item">
+            <button class="nav-link active" id="consulta-tab" data-bs-toggle="tab" data-bs-target="#consulta" type="button" role="tab">Consulta</button>
+        </li>
+        <li class="nav-item">
+            <button class="nav-link" id="cadastro-tab" data-bs-toggle="tab" data-bs-target="#cadastro" type="button" role="tab">Cadastro</button>
+        </li>
+    </ul>
+
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <div class="tab-content" id="tabCCContent">
+                <div class="tab-pane fade show active p-3" id="consulta" role="tabpanel" aria-labelledby="consulta-tab">
+                    <div class="card shadow-sm mb-4">
+                        <div class="card-header">
+                            <h5 class="mb-0"><i class="bi bi-list-ul me-2"></i>Centros de Custo Cadastrados ({{ centros|length }})</h5>
+                        </div>
+                        <div class="card-body">
+                            {% if centros %}
+                                <div class="table-responsive">
+                                    <table class="table table-hover table-sm align-middle">
+                                        <thead>
+                                            <tr>
+                                                <th>Código</th>
+                                                <th>Nome</th>
+                                                <th>Estabelecimento</th>
+                                                <th>Status</th>
+                                                <th style="width: 200px;" class="text-end">Ações</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for cc in centros %}
+                                            <tr class="{{ 'table-light text-muted' if not cc.ativo else '' }} clickable-row" data-href="{{ url_for('admin_centros_custo', edit_id=cc.id) }}">
+                                                <td>{{ cc.codigo }}</td>
+                                                <td>{{ cc.nome }}</td>
+                                                <td>{{ cc.estabelecimento.nome_fantasia }}</td>
+                                                <td>
+                                                    {% if cc.ativo %}
+                                                        <span class="badge bg-success">Ativo</span>
+                                                    {% else %}
+                                                        <span class="badge bg-secondary">Inativo</span>
+                                                    {% endif %}
+                                                </td>
+                                                <td class="text-end">
+                                                    <a href="{{ url_for('admin_centros_custo', edit_id=cc.id) }}" class="btn btn-sm btn-outline-primary me-1" title="Editar">
+                                                        <i class="bi bi-pencil-fill"></i>
+                                                    </a>
+                                                    {% set confirm_text = 'DESATIVAR' if cc.ativo else 'ATIVAR' %}
+                                                    <form action="{{ url_for('admin_toggle_ativo_centro_custo', id=cc.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_text }} o centro de custo ' + {{ cc.nome | tojson }} + '?');">
+                                                        {% if cc.ativo %}
+                                                            <button type="submit" class="btn btn-sm btn-outline-warning" title="Desativar">
+                                                                <i class="bi bi-archive-fill"></i> Desativar
+                                                            </button>
+                                                        {% else %}
+                                                            <button type="submit" class="btn btn-sm btn-outline-success" title="Ativar">
+                                                                <i class="bi bi-archive-restore-fill"></i> Ativar
+                                                            </button>
+                                                        {% endif %}
+                                                    </form>
+                                                </td>
+                                            </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            {% else %}
+                                <p class="text-muted">Nenhum Centro de Custo cadastrado ainda. Adicione um acima!</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="tab-pane fade p-3" id="cadastro" role="tabpanel" aria-labelledby="cadastro-tab">
+                    <h5 class="mb-3">
+                        <i class="bi bi-plus-circle-fill me-2"></i>Adicionar Novo Centro de Custo
+                    </h5>
+
+                    <form method="POST" action="{{ url_for('admin_centros_custo') }}" novalidate class="compact-form">
+                        <div class="row">
+                            <div class="col-md-4 mb-1">
+                                <label for="codigo" class="form-label">Código <span class="text-danger">*</span></label>
+                                <input type="text" class="form-control form-control-sm" id="codigo" name="codigo" value="{{ request.form.get('codigo', '') }}" required maxlength="50">
+                            </div>
+                            <div class="col-md-4 mb-1">
+                                <label for="nome" class="form-label">Nome <span class="text-danger">*</span></label>
+                                <input type="text" class="form-control form-control-sm" id="nome" name="nome" value="{{ request.form.get('nome', '') }}" required maxlength="200">
+                            </div>
+                            <div class="col-md-4 mb-1">
+                                <label for="estabelecimento_id" class="form-label">Estabelecimento <span class="text-danger">*</span></label>
+                                <select class="form-select form-select-sm" id="estabelecimento_id" name="estabelecimento_id" required>
+                                    <option value="" disabled selected>Selecione...</option>
+                                    {% for est in estabelecimentos %}
+                                        <option value="{{ est.id }}" {% if request.form.get('estabelecimento_id') == est.id|string %}selected{% endif %}>{{ est.nome_fantasia }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                        </div>
+                        <div class="col-md-12 mb-1">
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" role="switch" id="ativo_check" name="ativo_check" checked>
+                                <label class="form-check-label" for="ativo_check">Ativo</label>
+                            </div>
+                        </div>
+                        <div class="d-flex pt-2 border-top">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="bi bi-check-lg me-1"></i> Adicionar Centro de Custo
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% if cc_editar %}
+<div class="modal fade" id="modalEditarCC" tabindex="-1" aria-labelledby="modalEditarCCLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalEditarCCLabel">Editar Centro de Custo</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+            </div>
+            <div class="modal-body">
+                <form method="POST" action="{{ url_for('admin_centros_custo') }}" novalidate class="compact-form">
+                    <input type="hidden" name="id_para_atualizar" value="{{ cc_editar.id }}">
+                    <div class="mb-1">
+                        <label for="edit_codigo" class="form-label">Código <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control form-control-sm" id="edit_codigo" name="codigo" value="{{ request.form.get('codigo', cc_editar.codigo) }}" required maxlength="50">
+                    </div>
+                    <div class="mb-1">
+                        <label for="edit_nome" class="form-label">Nome <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control form-control-sm" id="edit_nome" name="nome" value="{{ request.form.get('nome', cc_editar.nome) }}" required maxlength="200">
+                    </div>
+                    <div class="mb-1">
+                        <label for="edit_estabelecimento_id" class="form-label">Estabelecimento <span class="text-danger">*</span></label>
+                        <select class="form-select form-select-sm" id="edit_estabelecimento_id" name="estabelecimento_id" required>
+                            {% for est in estabelecimentos %}
+                                <option value="{{ est.id }}" {% if (request.form.get('estabelecimento_id', cc_editar.estabelecimento_id|string) == est.id|string) %}selected{% endif %}>{{ est.nome_fantasia }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-md-12 mb-1">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" role="switch" id="edit_ativo_check" name="ativo_check" {% if cc_editar.ativo %}checked{% endif %}>
+                            <label class="form-check-label" for="edit_ativo_check">Ativo</label>
+                        </div>
+                    </div>
+                    <div class="d-flex pt-2 border-top">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="bi bi-check-lg me-1"></i> Salvar Alterações
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary ms-2" data-bs-dismiss="modal">
+                            <i class="bi bi-x-lg me-1"></i> Cancelar
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+</div>
+{% endblock content %}
+
+{% block extra_js %}
+{% if cc_editar %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var modal = new bootstrap.Modal(document.getElementById('modalEditarCC'));
+    modal.show();
+});
+</script>
+{% endif %}
+{% endblock %}

--- a/templates/admin/setores.html
+++ b/templates/admin/setores.html
@@ -1,0 +1,183 @@
+{% extends "base.html" %}
+
+{% block title %}Admin - Gerenciar Setores{% endblock %}
+
+{% block content %}
+<div class="container-fluid px-5 mt-3">
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-1 border-bottom">
+        <h1 class="h2">Gerenciar Setores</h1>
+    </div>
+
+    <ul class="nav nav-tabs" id="tabSetor" role="tablist">
+        <li class="nav-item">
+            <button class="nav-link active" id="consulta-tab" data-bs-toggle="tab" data-bs-target="#consulta" type="button" role="tab">Consulta</button>
+        </li>
+        <li class="nav-item">
+            <button class="nav-link" id="cadastro-tab" data-bs-toggle="tab" data-bs-target="#cadastro" type="button" role="tab">Cadastro</button>
+        </li>
+    </ul>
+
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <div class="tab-content" id="tabSetorContent">
+                <div class="tab-pane fade show active p-3" id="consulta" role="tabpanel" aria-labelledby="consulta-tab">
+                    <div class="card shadow-sm mb-4">
+                        <div class="card-header">
+                            <h5 class="mb-0"><i class="bi bi-list-ul me-2"></i>Setores Cadastrados ({{ setores|length }})</h5>
+                        </div>
+                        <div class="card-body">
+                            {% if setores %}
+                                <div class="table-responsive">
+                                    <table class="table table-hover table-sm align-middle">
+                                        <thead>
+                                            <tr>
+                                                <th>Nome</th>
+                                                <th>Centro de Custo</th>
+                                                <th>Status</th>
+                                                <th style="width: 200px;" class="text-end">Ações</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for setor in setores %}
+                                            <tr class="{{ 'table-light text-muted' if not setor.ativo else '' }} clickable-row" data-href="{{ url_for('admin_setores', edit_id=setor.id) }}">
+                                                <td>{{ setor.nome }}</td>
+                                                <td>{{ setor.centro_custo.nome if setor.centro_custo else '--' }}</td>
+                                                <td>
+                                                    {% if setor.ativo %}
+                                                        <span class="badge bg-success">Ativo</span>
+                                                    {% else %}
+                                                        <span class="badge bg-secondary">Inativo</span>
+                                                    {% endif %}
+                                                </td>
+                                                <td class="text-end">
+                                                    <a href="{{ url_for('admin_setores', edit_id=setor.id) }}" class="btn btn-sm btn-outline-primary me-1" title="Editar">
+                                                        <i class="bi bi-pencil-fill"></i>
+                                                    </a>
+                                                    {% set confirm_text = 'DESATIVAR' if setor.ativo else 'ATIVAR' %}
+                                                    <form action="{{ url_for('admin_toggle_ativo_setor', id=setor.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_text }} o setor ' + {{ setor.nome | tojson }} + '?');">
+                                                        {% if setor.ativo %}
+                                                            <button type="submit" class="btn btn-sm btn-outline-warning" title="Desativar">
+                                                                <i class="bi bi-archive-fill"></i> Desativar
+                                                            </button>
+                                                        {% else %}
+                                                            <button type="submit" class="btn btn-sm btn-outline-success" title="Ativar">
+                                                                <i class="bi bi-archive-restore-fill"></i> Ativar
+                                                            </button>
+                                                        {% endif %}
+                                                    </form>
+                                                </td>
+                                            </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            {% else %}
+                                <p class="text-muted">Nenhum setor cadastrado ainda. Adicione um acima!</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="tab-pane fade p-3" id="cadastro" role="tabpanel" aria-labelledby="cadastro-tab">
+                    <h5 class="mb-3">
+                        <i class="bi bi-plus-circle-fill me-2"></i>Adicionar Novo Setor
+                    </h5>
+
+                    <form method="POST" action="{{ url_for('admin_setores') }}" novalidate class="compact-form">
+                        <div class="row">
+                            <div class="col-md-6 mb-1">
+                                <label for="nome" class="form-label">Nome <span class="text-danger">*</span></label>
+                                <input type="text" class="form-control form-control-sm" id="nome" name="nome" value="{{ request.form.get('nome', '') }}" required maxlength="200">
+                            </div>
+                            <div class="col-md-6 mb-1">
+                                <label for="centro_custo_id" class="form-label">Centro de Custo</label>
+                                <select class="form-select form-select-sm" id="centro_custo_id" name="centro_custo_id">
+                                    <option value="">-- Não associado --</option>
+                                    {% for cc in centros_custo %}
+                                        <option value="{{ cc.id }}" {% if request.form.get('centro_custo_id') == cc.id|string %}selected{% endif %}>{{ cc.nome }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                        </div>
+                        <div class="mb-1">
+                            <label for="descricao" class="form-label">Descrição</label>
+                            <textarea class="form-control form-control-sm" id="descricao" name="descricao" rows="3">{{ request.form.get('descricao', '') }}</textarea>
+                        </div>
+                        <div class="col-md-12 mb-1">
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" role="switch" id="ativo_check" name="ativo_check" checked>
+                                <label class="form-check-label" for="ativo_check">Ativo</label>
+                            </div>
+                        </div>
+                        <div class="d-flex pt-2 border-top">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="bi bi-check-lg me-1"></i> Adicionar Setor
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% if setor_editar %}
+<div class="modal fade" id="modalEditarSetor" tabindex="-1" aria-labelledby="modalEditarSetorLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalEditarSetorLabel">Editar Setor</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+            </div>
+            <div class="modal-body">
+                <form method="POST" action="{{ url_for('admin_setores') }}" novalidate class="compact-form">
+                    <input type="hidden" name="id_para_atualizar" value="{{ setor_editar.id }}">
+                    <div class="mb-1">
+                        <label for="edit_nome" class="form-label">Nome <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control form-control-sm" id="edit_nome" name="nome" value="{{ request.form.get('nome', setor_editar.nome) }}" required maxlength="200">
+                    </div>
+                    <div class="mb-1">
+                        <label for="edit_centro_custo_id" class="form-label">Centro de Custo</label>
+                        <select class="form-select form-select-sm" id="edit_centro_custo_id" name="centro_custo_id">
+                            <option value="">-- Não associado --</option>
+                            {% for cc in centros_custo %}
+                                <option value="{{ cc.id }}" {% if (request.form.get('centro_custo_id', setor_editar.centro_custo_id|string) == cc.id|string) %}selected{% endif %}>{{ cc.nome }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="mb-1">
+                        <label for="edit_descricao" class="form-label">Descrição</label>
+                        <textarea class="form-control form-control-sm" id="edit_descricao" name="descricao" rows="3">{{ request.form.get('descricao', setor_editar.descricao or '') }}</textarea>
+                    </div>
+                    <div class="col-md-12 mb-1">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" role="switch" id="edit_ativo_check" name="ativo_check" {% if setor_editar.ativo %}checked{% endif %}>
+                            <label class="form-check-label" for="edit_ativo_check">Ativo</label>
+                        </div>
+                    </div>
+                    <div class="d-flex pt-2 border-top">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="bi bi-check-lg me-1"></i> Salvar Alterações
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary ms-2" data-bs-dismiss="modal">
+                            <i class="bi bi-x-lg me-1"></i> Cancelar
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+</div>
+{% endblock content %}
+
+{% block extra_js %}
+{% if setor_editar %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var modal = new bootstrap.Modal(document.getElementById('modalEditarSetor'));
+    modal.show();
+});
+</script>
+{% endif %}
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -249,8 +249,8 @@
                                         <div class="collapse {{ 'show' if request.endpoint.startswith('admin_estabelecimentos') or request.endpoint.startswith('admin_centros_custo') or request.endpoint.startswith('admin_setores') or request.endpoint.startswith('admin_cargos') else '' }}" id="collapseCadastrosOrgSub">
                                             <ul class="nav flex-column ps-3">
                                                 <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_estabelecimentos' else '' }}" href="{{ url_for('admin_estabelecimentos') }}"><i class="bi bi-building me-2"></i> Estabelecimentos</a></li>
-                                                <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-diagram-3-fill me-2"></i> Centros de Custo</a></li>
-                                                <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-tags-fill me-2"></i> Setores</a></li>
+                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_centros_custo' else '' }}" href="{{ url_for('admin_centros_custo') }}"><i class="bi bi-diagram-3-fill me-2"></i> Centros de Custo</a></li>
+                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_setores' else '' }}" href="{{ url_for('admin_setores') }}"><i class="bi bi-tags-fill me-2"></i> Setores</a></li>
                                                 <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-person-badge-fill me-2"></i> Cargos</a></li>
                                             </ul>
                                         </div>

--- a/tests/test_centro_custo.py
+++ b/tests/test_centro_custo.py
@@ -1,0 +1,45 @@
+import os
+import pytest
+
+os.environ.setdefault('SECRET_KEY', 'test_secret')
+os.environ.setdefault('DATABASE_URI', 'sqlite:///:memory:')
+
+from app import app, db
+from models import Estabelecimento, CentroDeCusto
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        # Create establishment to satisfy FK
+        est = Estabelecimento(codigo='E1', nome_fantasia='Estab', razao_social='R', ativo=True)
+        db.session.add(est)
+        db.session.commit()
+        with app.test_client() as client:
+            yield client
+        db.session.remove()
+        db.drop_all()
+
+
+def login_admin(client):
+    with client.session_transaction() as sess:
+        sess['user_id'] = 1
+        sess['role'] = 'admin'
+
+
+def test_create_centro_custo(client):
+    login_admin(client)
+    est = Estabelecimento.query.first()
+    response = client.post('/admin/centros_custo', data={
+        'codigo': 'CC1',
+        'nome': 'Centro 1',
+        'estabelecimento_id': est.id,
+        'ativo_check': 'on'
+    }, follow_redirects=True)
+    assert response.status_code == 200
+    with app.app_context():
+        cc = CentroDeCusto.query.filter_by(codigo='CC1').first()
+        assert cc is not None
+        assert cc.nome == 'Centro 1'
+        assert cc.ativo is True

--- a/tests/test_centro_custo.py
+++ b/tests/test_centro_custo.py
@@ -12,8 +12,7 @@ def client():
     app.config['TESTING'] = True
     with app.app_context():
         db.create_all()
-        # Create establishment to satisfy FK
-        est = Estabelecimento(codigo='E1', nome_fantasia='Estab', razao_social='R', ativo=True)
+        est = Estabelecimento(codigo='EST1', nome_fantasia='Estab 1')
         db.session.add(est)
         db.session.commit()
         with app.test_client() as client:
@@ -30,16 +29,17 @@ def login_admin(client):
 
 def test_create_centro_custo(client):
     login_admin(client)
-    est = Estabelecimento.query.first()
+    with app.app_context():
+        est_id = Estabelecimento.query.first().id
     response = client.post('/admin/centros_custo', data={
-        'codigo': 'CC1',
+        'codigo': 'CC01',
         'nome': 'Centro 1',
-        'estabelecimento_id': est.id,
+        'estabelecimento_id': est_id,
         'ativo_check': 'on'
     }, follow_redirects=True)
     assert response.status_code == 200
     with app.app_context():
-        cc = CentroDeCusto.query.filter_by(codigo='CC1').first()
+        cc = CentroDeCusto.query.filter_by(codigo='CC01').first()
         assert cc is not None
+        assert cc.estabelecimento_id == est_id
         assert cc.nome == 'Centro 1'
-        assert cc.ativo is True

--- a/tests/test_setor.py
+++ b/tests/test_setor.py
@@ -1,0 +1,37 @@
+import os
+import pytest
+
+os.environ.setdefault('SECRET_KEY', 'test_secret')
+os.environ.setdefault('DATABASE_URI', 'sqlite:///:memory:')
+
+from app import app, db
+from models import Setor
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        with app.test_client() as client:
+            yield client
+        db.session.remove()
+        db.drop_all()
+
+def login_admin(client):
+    with client.session_transaction() as sess:
+        sess['user_id'] = 1
+        sess['role'] = 'admin'
+
+def test_create_setor(client):
+    login_admin(client)
+    response = client.post('/admin/setores', data={
+        'nome': 'Financeiro',
+        'descricao': 'Setor Financeiro',
+        'ativo_check': 'on'
+    }, follow_redirects=True)
+    assert response.status_code == 200
+    with app.app_context():
+        setor = Setor.query.filter_by(nome='Financeiro').first()
+        assert setor is not None
+        assert setor.descricao == 'Setor Financeiro'
+        assert setor.ativo is True


### PR DESCRIPTION
## Summary
- add Setor and CentroDeCusto imports in app
- implement `/admin/setores` and toggle routes
- link Setores menu item
- create Setores admin template
- add Setor tests
- link Centros de Custo menu item
- add missing newline at EOF for consistency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68433a05bc10832eaff500a7ec4e472f