### PR TITLE
Add admin user CRUD

### DIFF
--- a/templates/admin/usuarios.html
+++ b/templates/admin/usuarios.html
@@ -1,0 +1,189 @@
+{% extends "base.html" %}
+
+{% block title %}Admin - Gerenciar Usuários{% endblock %}
+
+{% block content %}
+<div class="container-fluid px-5 mt-3">
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-1 border-bottom">
+        <h1 class="h2">Gerenciar Usuários</h1>
+    </div>
+
+    <ul class="nav nav-tabs" id="tabUser" role="tablist">
+        <li class="nav-item">
+            <button class="nav-link active" id="consulta-tab" data-bs-toggle="tab" data-bs-target="#consulta" type="button" role="tab">Consulta</button>
+        </li>
+        <li class="nav-item">
+            <button class="nav-link" id="cadastro-tab" data-bs-toggle="tab" data-bs-target="#cadastro" type="button" role="tab">Cadastro</button>
+        </li>
+    </ul>
+
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <div class="tab-content" id="tabUserContent">
+                <div class="tab-pane fade show active p-3" id="consulta" role="tabpanel" aria-labelledby="consulta-tab">
+                    <div class="card shadow-sm mb-4">
+                        <div class="card-header">
+                            <h5 class="mb-0"><i class="bi bi-list-ul me-2"></i>Usuários Cadastrados ({{ usuarios|length }})</h5>
+                        </div>
+                        <div class="card-body">
+                            {% if usuarios %}
+                                <div class="table-responsive">
+                                    <table class="table table-hover table-sm align-middle">
+                                        <thead>
+                                            <tr>
+                                                <th>Usuário</th>
+                                                <th>Email</th>
+                                                <th>Perfil</th>
+                                                <th>Status</th>
+                                                <th style="width: 200px;" class="text-end">Ações</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for u in usuarios %}
+                                            <tr class="{{ 'table-light text-muted' if not u.ativo else '' }} clickable-row" data-href="{{ url_for('admin_usuarios', edit_id=u.id) }}">
+                                                <td>{{ u.username }}</td>
+                                                <td>{{ u.email }}</td>
+                                                <td>{{ u.role }}</td>
+                                                <td>
+                                                    {% if u.ativo %}
+                                                        <span class="badge bg-success">Ativo</span>
+                                                    {% else %}
+                                                        <span class="badge bg-secondary">Inativo</span>
+                                                    {% endif %}
+                                                </td>
+                                                <td class="text-end">
+                                                    <a href="{{ url_for('admin_usuarios', edit_id=u.id) }}" class="btn btn-sm btn-outline-primary me-1" title="Editar">
+                                                        <i class="bi bi-pencil-fill"></i>
+                                                    </a>
+                                                    {% set confirm_message_text = 'DESATIVAR' if u.ativo else 'ATIVAR' %}
+                                                    {% set usuario_nome_js = u.username | tojson %}
+                                                    <form action="{{ url_for('admin_toggle_ativo_usuario', id=u.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_message_text }} o usuário ' + {{ usuario_nome_js }} + '?');">
+                                                        {% if u.ativo %}
+                                                            <button type="submit" class="btn btn-sm btn-outline-warning" title="Desativar">
+                                                                <i class="bi bi-archive-fill"></i> Desativar
+                                                            </button>
+                                                        {% else %}
+                                                            <button type="submit" class="btn btn-sm btn-outline-success" title="Ativar">
+                                                                <i class="bi bi-archive-restore-fill"></i> Ativar
+                                                            </button>
+                                                        {% endif %}
+                                                    </form>
+                                                </td>
+                                            </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            {% else %}
+                                <p class="text-muted">Nenhum usuário cadastrado ainda. Adicione um acima!</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+                <div class="tab-pane fade p-3" id="cadastro" role="tabpanel" aria-labelledby="cadastro-tab">
+                    <h5 class="mb-3">
+                        <i class="bi bi-plus-circle-fill me-2"></i>Adicionar Novo Usuário
+                    </h5>
+
+                    <form method="POST" action="{{ url_for('admin_usuarios') }}" novalidate class="compact-form">
+                        <div class="row">
+                            <div class="col-md-4 mb-1">
+                                <label for="username" class="form-label">Usuário <span class="text-danger">*</span></label>
+                                <input type="text" class="form-control form-control-sm" id="username" name="username" value="{{ request.form.get('username', '') }}" required maxlength="80">
+                            </div>
+                            <div class="col-md-4 mb-1">
+                                <label for="email" class="form-label">Email <span class="text-danger">*</span></label>
+                                <input type="email" class="form-control form-control-sm" id="email" name="email" value="{{ request.form.get('email', '') }}" required maxlength="120">
+                            </div>
+                            <div class="col-md-4 mb-1">
+                                <label for="role" class="form-label">Perfil</label>
+                                <input type="text" class="form-control form-control-sm" id="role" name="role" value="{{ request.form.get('role', 'colaborador') }}" maxlength="50">
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-6 mb-1">
+                                <label for="password" class="form-label">Senha <span class="text-danger">*</span></label>
+                                <input type="password" class="form-control form-control-sm" id="password" name="password" required>
+                            </div>
+                            <div class="col-md-6 mb-1">
+                                <div class="form-check form-switch mt-4 pt-1">
+                                    <input class="form-check-input" type="checkbox" role="switch" id="ativo_check" name="ativo_check" checked>
+                                    <label class="form-check-label" for="ativo_check">Ativo</label>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="d-flex pt-2 border-top">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="bi bi-check-lg me-1"></i> Adicionar Usuário
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+{% if user_editar %}
+<div class="modal fade" id="modalEditarUsuario" tabindex="-1" aria-labelledby="modalEditarUsuarioLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalEditarUsuarioLabel">Editar Usuário</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+            </div>
+            <div class="modal-body">
+                <form method="POST" action="{{ url_for('admin_usuarios') }}" novalidate class="compact-form">
+                    <input type="hidden" name="id_para_atualizar" value="{{ user_editar.id }}">
+                    <div class="row">
+                        <div class="col-md-4 mb-1">
+                            <label for="edit_username" class="form-label">Usuário <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control form-control-sm" id="edit_username" name="username" value="{{ request.form.get('username', user_editar.username) }}" required maxlength="80">
+                        </div>
+                        <div class="col-md-4 mb-1">
+                            <label for="edit_email" class="form-label">Email <span class="text-danger">*</span></label>
+                            <input type="email" class="form-control form-control-sm" id="edit_email" name="email" value="{{ request.form.get('email', user_editar.email) }}" required maxlength="120">
+                        </div>
+                        <div class="col-md-4 mb-1">
+                            <label for="edit_role" class="form-label">Perfil</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_role" name="role" value="{{ request.form.get('role', user_editar.role) }}" maxlength="50">
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-1">
+                            <label for="edit_password" class="form-label">Nova Senha</label>
+                            <input type="password" class="form-control form-control-sm" id="edit_password" name="password">
+                        </div>
+                        <div class="col-md-6 mb-1">
+                            <div class="form-check form-switch mt-4 pt-1">
+                                <input class="form-check-input" type="checkbox" role="switch" id="edit_ativo_check" name="ativo_check" {% if user_editar.ativo %}checked{% endif %}>
+                                <label class="form-check-label" for="edit_ativo_check">Ativo</label>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="d-flex pt-2 border-top">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="bi bi-check-lg me-1"></i> Salvar Alterações
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary ms-2" data-bs-dismiss="modal">
+                            <i class="bi bi-x-lg me-1"></i> Cancelar
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+</div>
+{% endblock %}
+
+{% block extra_js %}
+{% if user_editar %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var modal = new bootstrap.Modal(document.getElementById('modalEditarUsuario'));
+    modal.show();
+});
+</script>
+{% endif %}
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -265,7 +265,7 @@
                                         </a>
                                         <div class="collapse {{ 'show' if request.endpoint.startswith('admin_usuarios') or request.endpoint.startswith('admin_perfis') else '' }}" id="collapseSegurancaSub">
                                             <ul class="nav flex-column ps-3">
-                                                <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-people-fill me-2"></i> Gerenciar Usuários</a></li>
+                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_usuarios' else '' }}" href="{{ url_for('admin_usuarios') }}"><i class="bi bi-people-fill me-2"></i> Gerenciar Usuários</a></li>
                                                 <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-key-fill me-2"></i> Gerenciar Perfis</a></li>
                                             </ul>
                                         </div>

--- a/tests/test_admin_usuarios.py
+++ b/tests/test_admin_usuarios.py
@@ -1,0 +1,56 @@
+import os
+import pytest
+
+os.environ.setdefault('SECRET_KEY', 'test_secret')
+os.environ.setdefault('DATABASE_URI', 'sqlite:///:memory:')
+
+from app import app, db
+from models import User
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        with app.test_client() as client:
+            yield client
+        db.session.remove()
+        db.drop_all()
+
+def login_admin(client):
+    with client.session_transaction() as sess:
+        sess['user_id'] = 1
+        sess['role'] = 'admin'
+
+
+def test_create_user(client):
+    login_admin(client)
+    response = client.post('/admin/usuarios', data={
+        'username': 'newuser',
+        'email': 'new@example.com',
+        'password': 'Senha123!',
+        'role': 'colaborador',
+        'ativo_check': 'on'
+    }, follow_redirects=True)
+    assert response.status_code == 200
+    with app.app_context():
+        user = User.query.filter_by(username='newuser').first()
+        assert user is not None
+        assert user.email == 'new@example.com'
+        assert user.check_password('Senha123!')
+        assert user.ativo is True
+
+
+def test_toggle_user_active(client):
+    with app.app_context():
+        u = User(username='temp', email='temp@test.com')
+        u.set_password('Pass123!')
+        db.session.add(u)
+        db.session.commit()
+        uid = u.id
+    login_admin(client)
+    response = client.post(f'/admin/usuarios/toggle_ativo/{uid}', follow_redirects=True)
+    assert response.status_code == 200
+    with app.app_context():
+        u = User.query.get(uid)
+        assert u.ativo is False


### PR DESCRIPTION
## Summary
- add Admin routes to manage users
- create template for admin user CRUD similar to establishment admin
- link Gerenciar Usuários in sidebar
- test user creation and status toggle

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68433a7c8760832ebbf9ced838742d95