### PR TITLE
Expand admin user form

### DIFF
--- a/templates/admin/usuarios.html
+++ b/templates/admin/usuarios.html
@@ -102,9 +102,81 @@
                         </div>
                         <div class="row">
                             <div class="col-md-6 mb-1">
-                                <label for="password" class="form-label">Senha <span class="text-danger">*</span></label>
-                                <input type="password" class="form-control form-control-sm" id="password" name="password" required>
+                                <label for="nome_completo" class="form-label">Nome Completo</label>
+                                <input type="text" class="form-control form-control-sm" id="nome_completo" name="nome_completo" value="{{ request.form.get('nome_completo', '') }}">
                             </div>
+                            <div class="col-md-6 mb-1">
+                                <label for="matricula" class="form-label">Matrícula</label>
+                                <input type="text" class="form-control form-control-sm" id="matricula" name="matricula" value="{{ request.form.get('matricula', '') }}">
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-4 mb-1">
+                                <label for="cpf" class="form-label">CPF</label>
+                                <input type="text" class="form-control form-control-sm" id="cpf" name="cpf" value="{{ request.form.get('cpf', '') }}">
+                            </div>
+                            <div class="col-md-4 mb-1">
+                                <label for="rg" class="form-label">RG</label>
+                                <input type="text" class="form-control form-control-sm" id="rg" name="rg" value="{{ request.form.get('rg', '') }}">
+                            </div>
+                            <div class="col-md-4 mb-1">
+                                <label for="ramal" class="form-label">Ramal</label>
+                                <input type="text" class="form-control form-control-sm" id="ramal" name="ramal" value="{{ request.form.get('ramal', '') }}">
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-6 mb-1">
+                                <label for="telefone_contato" class="form-label">Telefone de Contato</label>
+                                <input type="text" class="form-control form-control-sm" id="telefone_contato" name="telefone_contato" value="{{ request.form.get('telefone_contato', '') }}">
+                            </div>
+                            <div class="col-md-3 mb-1">
+                                <label for="data_nascimento" class="form-label">Data Nascimento</label>
+                                <input type="date" class="form-control form-control-sm" id="data_nascimento" name="data_nascimento" value="{{ request.form.get('data_nascimento', '') }}">
+                            </div>
+                            <div class="col-md-3 mb-1">
+                                <label for="data_admissao" class="form-label">Data Admissão</label>
+                                <input type="date" class="form-control form-control-sm" id="data_admissao" name="data_admissao" value="{{ request.form.get('data_admissao', '') }}">
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-3 mb-1">
+                                <label for="estabelecimento_id" class="form-label">Estabelecimento</label>
+                                <select class="form-select form-select-sm" id="estabelecimento_id" name="estabelecimento_id">
+                                    <option value="">Selecione</option>
+                                    {% for est in estabelecimentos %}
+                                        <option value="{{ est.id }}" {% if request.form.get('estabelecimento_id') == est.id|string %}selected{% endif %}>{{ est.nome_fantasia }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                            <div class="col-md-3 mb-1">
+                                <label for="centro_custo_id" class="form-label">Centro de Custo</label>
+                                <select class="form-select form-select-sm" id="centro_custo_id" name="centro_custo_id">
+                                    <option value="">Selecione</option>
+                                    {% for cc in centros_custo %}
+                                        <option value="{{ cc.id }}" {% if request.form.get('centro_custo_id') == cc.id|string %}selected{% endif %}>{{ cc.nome }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                            <div class="col-md-3 mb-1">
+                                <label for="setor_id" class="form-label">Setor</label>
+                                <select class="form-select form-select-sm" id="setor_id" name="setor_id">
+                                    <option value="">Selecione</option>
+                                    {% for st in setores %}
+                                        <option value="{{ st.id }}" {% if request.form.get('setor_id') == st.id|string %}selected{% endif %}>{{ st.nome }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                            <div class="col-md-3 mb-1">
+                                <label for="cargo_id" class="form-label">Cargo</label>
+                                <select class="form-select form-select-sm" id="cargo_id" name="cargo_id">
+                                    <option value="">Selecione</option>
+                                    {% for cg in cargos %}
+                                        <option value="{{ cg.id }}" {% if request.form.get('cargo_id') == cg.id|string %}selected{% endif %}>{{ cg.nome }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row">
                             <div class="col-md-6 mb-1">
                                 <div class="form-check form-switch mt-4 pt-1">
                                     <input class="form-check-input" type="checkbox" role="switch" id="ativo_check" name="ativo_check" checked>
@@ -150,9 +222,81 @@
                     </div>
                     <div class="row">
                         <div class="col-md-6 mb-1">
-                            <label for="edit_password" class="form-label">Nova Senha</label>
-                            <input type="password" class="form-control form-control-sm" id="edit_password" name="password">
+                            <label for="edit_nome_completo" class="form-label">Nome Completo</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_nome_completo" name="nome_completo" value="{{ request.form.get('nome_completo', user_editar.nome_completo) }}">
                         </div>
+                        <div class="col-md-6 mb-1">
+                            <label for="edit_matricula" class="form-label">Matrícula</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_matricula" name="matricula" value="{{ request.form.get('matricula', user_editar.matricula) }}">
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-4 mb-1">
+                            <label for="edit_cpf" class="form-label">CPF</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_cpf" name="cpf" value="{{ request.form.get('cpf', user_editar.cpf) }}">
+                        </div>
+                        <div class="col-md-4 mb-1">
+                            <label for="edit_rg" class="form-label">RG</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_rg" name="rg" value="{{ request.form.get('rg', user_editar.rg) }}">
+                        </div>
+                        <div class="col-md-4 mb-1">
+                            <label for="edit_ramal" class="form-label">Ramal</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_ramal" name="ramal" value="{{ request.form.get('ramal', user_editar.ramal) }}">
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-1">
+                            <label for="edit_telefone_contato" class="form-label">Telefone de Contato</label>
+                            <input type="text" class="form-control form-control-sm" id="edit_telefone_contato" name="telefone_contato" value="{{ request.form.get('telefone_contato', user_editar.telefone_contato) }}">
+                        </div>
+                        <div class="col-md-3 mb-1">
+                            <label for="edit_data_nascimento" class="form-label">Data Nascimento</label>
+                            <input type="date" class="form-control form-control-sm" id="edit_data_nascimento" name="data_nascimento" value="{{ request.form.get('data_nascimento', user_editar.data_nascimento.strftime('%Y-%m-%d') if user_editar.data_nascimento else '') }}">
+                        </div>
+                        <div class="col-md-3 mb-1">
+                            <label for="edit_data_admissao" class="form-label">Data Admissão</label>
+                            <input type="date" class="form-control form-control-sm" id="edit_data_admissao" name="data_admissao" value="{{ request.form.get('data_admissao', user_editar.data_admissao.strftime('%Y-%m-%d') if user_editar.data_admissao else '') }}">
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3 mb-1">
+                            <label for="edit_estabelecimento_id" class="form-label">Estabelecimento</label>
+                            <select class="form-select form-select-sm" id="edit_estabelecimento_id" name="estabelecimento_id">
+                                <option value="">Selecione</option>
+                                {% for est in estabelecimentos %}
+                                <option value="{{ est.id }}" {% if (request.form.get('estabelecimento_id') == est.id|string) or (not request.form.get('estabelecimento_id') and user_editar.estabelecimento_id == est.id) %}selected{% endif %}>{{ est.nome_fantasia }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-3 mb-1">
+                            <label for="edit_centro_custo_id" class="form-label">Centro de Custo</label>
+                            <select class="form-select form-select-sm" id="edit_centro_custo_id" name="centro_custo_id">
+                                <option value="">Selecione</option>
+                                {% for cc in centros_custo %}
+                                <option value="{{ cc.id }}" {% if (request.form.get('centro_custo_id') == cc.id|string) or (not request.form.get('centro_custo_id') and user_editar.centro_custo_id == cc.id) %}selected{% endif %}>{{ cc.nome }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-3 mb-1">
+                            <label for="edit_setor_id" class="form-label">Setor</label>
+                            <select class="form-select form-select-sm" id="edit_setor_id" name="setor_id">
+                                <option value="">Selecione</option>
+                                {% for st in setores %}
+                                <option value="{{ st.id }}" {% if (request.form.get('setor_id') == st.id|string) or (not request.form.get('setor_id') and user_editar.setor_id == st.id) %}selected{% endif %}>{{ st.nome }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-3 mb-1">
+                            <label for="edit_cargo_id" class="form-label">Cargo</label>
+                            <select class="form-select form-select-sm" id="edit_cargo_id" name="cargo_id">
+                                <option value="">Selecione</option>
+                                {% for cg in cargos %}
+                                <option value="{{ cg.id }}" {% if (request.form.get('cargo_id') == cg.id|string) or (not request.form.get('cargo_id') and user_editar.cargo_id == cg.id) %}selected{% endif %}>{{ cg.nome }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+                    <div class="row">
                         <div class="col-md-6 mb-1">
                             <div class="form-check form-switch mt-4 pt-1">
                                 <input class="form-check-input" type="checkbox" role="switch" id="edit_ativo_check" name="ativo_check" {% if user_editar.ativo %}checked{% endif %}>

--- a/tests/test_admin_usuarios.py
+++ b/tests/test_admin_usuarios.py
@@ -6,6 +6,7 @@ os.environ.setdefault('DATABASE_URI', 'sqlite:///:memory:')
 
 from app import app, db
 from models import User
+from utils import DEFAULT_NEW_USER_PASSWORD
 
 @pytest.fixture
 def client():
@@ -28,7 +29,6 @@ def test_create_user(client):
     response = client.post('/admin/usuarios', data={
         'username': 'newuser',
         'email': 'new@example.com',
-        'password': 'Senha123!',
         'role': 'colaborador',
         'ativo_check': 'on'
     }, follow_redirects=True)
@@ -37,7 +37,7 @@ def test_create_user(client):
         user = User.query.filter_by(username='newuser').first()
         assert user is not None
         assert user.email == 'new@example.com'
-        assert user.check_password('Senha123!')
+        assert user.check_password(DEFAULT_NEW_USER_PASSWORD)
         assert user.ativo is True
 
 

--- a/utils.py
+++ b/utils.py
@@ -115,3 +115,13 @@ def extract_text(path: str) -> str:
 
     # outros formatos não suportados
     return ''
+
+import secrets
+import string
+
+DEFAULT_NEW_USER_PASSWORD = 'Mudanca123!'
+
+def generate_random_password(length=12):
+    """Gera uma senha aleatória com letras, números e caracteres especiais."""
+    alphabet = string.ascii_letters + string.digits + '!@#$%^&*()-_'
+    return ''.join(secrets.choice(alphabet) for _ in range(length))


### PR DESCRIPTION
## Summary
- add helper to generate default passwords
- include full editable user fields in admin create/edit logic
- hide password fields in admin template
- update tests for default password

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684357307894832e95332f3f25716a41