### PR TITLE
Fix admin user creation feedback

### DIFF
--- a/app.py
+++ b/app.py
@@ -447,25 +447,13 @@ def admin_usuarios():
                     db.session.add(usr)
                     action_msg = 'criado'
 
-                commit_success = False
                 try:
                     db.session.commit()
-                    commit_success = True
-
                 except Exception as e:
                     db.session.rollback()
                     flash(f'Erro ao salvar usuário: {str(e)}', 'danger')
                     app.logger.error(f"Erro DB User: {e}")
                 else:
-                    if not id_para_atualizar:
-                        try:
-                            send_password_email(usr, 'create')
-                        except Exception as e:
-                            app.logger.error(f"Erro ao enviar e-mail de cadastro: {e}")
-                    flash(f'Usuário {action_msg} com sucesso!', 'success')
-                    return redirect(url_for('admin_usuarios'))
-
-                if commit_success:
                     if not id_para_atualizar:
                         try:
                             send_password_email(usr, 'create')

--- a/templates/partials/_flash_messages.html
+++ b/templates/partials/_flash_messages.html
@@ -1,0 +1,10 @@
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+    {% for category, message in messages %}
+      <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
+        {{ message }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+      </div>
+    {% endfor %}
+  {% endif %}
+{% endwith %}


### PR DESCRIPTION
## Summary
- simplify commit logic when creating/updating users
- add missing flash messages partial

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6845abb9662c832ea2317d4362de8a06