### PR TITLE
Add env example and update docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Example environment configuration
+# Copy this file to .env and replace the placeholders with your values.
+
+SENDGRID_API_KEY=your_sendgrid_api_key_here
+EMAIL_FROM=your_email@example.com
+SECRET_KEY=replace_with_your_secret_key
+DATABASE_URI=postgresql://user:password@localhost:5432/your_db_name

--- a/docs/GUIA_DE_INSTALACAO.md
+++ b/docs/GUIA_DE_INSTALACAO.md
@@ -137,6 +137,8 @@ pip install -r requirements.txt
 ## 9. Configurar Variáveis de Ambiente Essenciais (no Windows)
 Para que o Orquetask funcione corretamente e de forma segura, é crucial configurar algumas **variáveis de ambiente** no seu sistema Windows. Essas variáveis permitem que a aplicação acesse configurações importantes sem que elas precisem estar escritas diretamente no código.
 
+Antes de prosseguir, copie o arquivo `.env.example` que acompanha o projeto para `.env` e preencha os valores de `SENDGRID_API_KEY`, `EMAIL_FROM`, `SECRET_KEY` e `DATABASE_URI` com suas próprias configurações. O Flask carregará essas variáveis automaticamente ao executar `flask run` se o arquivo `.env` estiver na raiz do projeto.
+
 * **Por que usar Variáveis de Ambiente?**
     * **Segurança:** É a forma mais segura de gerenciar informações sensíveis como chaves secretas (`SECRET_KEY`) e credenciais de banco de dados (`DATABASE_URI`), mantendo-as fora do código-fonte que pode ser versionado no Git.
     * **Flexibilidade:** Permite que a mesma aplicação rode em diferentes ambientes (desenvolvimento local, servidor de teste, produção) com configurações diferentes, apenas ajustando as variáveis de ambiente de cada local.

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,8 @@ Para rodar este projeto em um ambiente de desenvolvimento, você precisará ter 
     ```
 
 4.  **Configure o Banco de Dados PostgreSQL e Variáveis de Ambiente:**
-    * Siga as instruções detalhadas no nosso **[Guia de Instalação e Configuração](./GUIA_DE_INSTALACAO.md)** para criar o banco de dados, o usuário do banco com as permissões corretas, e para configurar as variáveis de ambiente essenciais (`FLASK_APP`, `FLASK_DEBUG`, `SECRET_KEY`, `DATABASE_URI`).
+    * Copie o arquivo `.env.example` (na raiz do projeto) para `.env` e preencha `SENDGRID_API_KEY`, `EMAIL_FROM`, `SECRET_KEY` e `DATABASE_URI` conforme sua configuração local.
+    * Siga as instruções detalhadas no nosso **[Guia de Instalação e Configuração](./GUIA_DE_INSTALACAO.md)** para criar o banco de dados, o usuário do banco com as permissões corretas e definir outras variáveis de ambiente essenciais (`FLASK_APP`, `FLASK_DEBUG`, `SECRET_KEY`, `DATABASE_URI`).
 
 5.  **Aplique as migrações do banco de dados:**
     ```bash


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders for common variables
- document copying this file to `.env` in README and GUIA

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6845bc2c36b4832ea2c94a44af1b8584