### PR TITLE
Replace prints with logging and add send_email test

### DIFF
--- a/tests/test_send_email.py
+++ b/tests/test_send_email.py
@@ -1,0 +1,36 @@
+import os
+from flask import Flask
+from unittest.mock import MagicMock
+
+# Set environment variables required by send_email
+os.environ.setdefault('SECRET_KEY', 'test_secret')
+os.environ.setdefault('DATABASE_URI', 'sqlite:///:memory:')
+os.environ['SENDGRID_API_KEY'] = 'test_key'
+os.environ['EMAIL_FROM'] = 'from@example.com'
+
+from utils import send_email
+
+
+def test_send_email_constructs_and_sends_message(monkeypatch):
+    app = Flask(__name__)
+    with app.app_context():
+        captured = {}
+
+        class DummyMail:
+            def __init__(self, from_email, to_emails, subject, html_content):
+                captured['from_email'] = from_email
+                captured['to_emails'] = to_emails
+                captured['subject'] = subject
+                captured['html_content'] = html_content
+
+        mock_client = MagicMock()
+        monkeypatch.setattr('utils.Mail', DummyMail)
+        monkeypatch.setattr('utils.SendGridAPIClient', lambda key: mock_client)
+
+        send_email('to@example.com', 'Subject', '<p>Body</p>')
+
+        assert captured['from_email'] == 'from@example.com'
+        assert captured['to_emails'] == 'to@example.com'
+        assert captured['subject'] == 'Subject'
+        assert captured['html_content'] == '<p>Body</p>'
+        mock_client.send.assert_called_once()

--- a/utils.py
+++ b/utils.py
@@ -150,7 +150,7 @@ def send_email(to_email: str, subject: str, html_content: str) -> None:
     api_key = os.environ.get('SENDGRID_API_KEY')
     from_email = os.environ.get('EMAIL_FROM', 'no-reply@example.com')
     if not api_key:
-        print('SendGrid API key não configurada.')
+        current_app.logger.warning('SendGrid API key não configurada.')
         return
     try:
         sg = SendGridAPIClient(api_key)
@@ -158,4 +158,4 @@ def send_email(to_email: str, subject: str, html_content: str) -> None:
                         subject=subject, html_content=html_content)
         sg.send(message)
     except Exception as e:
-        print(f'Erro ao enviar e-mail: {e}')
+        current_app.logger.error(f'Erro ao enviar e-mail: {e}')


### PR DESCRIPTION
## Summary
- use `current_app.logger` for logging in `utils.send_email`
- add unit test for `send_email` when API key is configured

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6845bc2dc48c832e9ea265dce703c57b