### PR TITLE
Show loading indicator when adding attachments

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -119,3 +119,15 @@ body > .container {
   padding-bottom: .25rem;
   font-size: .875rem;
 }
+.file-loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.7);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1055;
+}

--- a/templates/novo_artigo.html
+++ b/templates/novo_artigo.html
@@ -6,6 +6,11 @@
 {% endblock %}
 
 {% block content %}
+<div id="fileLoadingOverlay" class="file-loading-overlay">
+  <div class="spinner-border text-primary" role="status">
+    <span class="visually-hidden">Carregando...</span>
+  </div>
+</div>
 <div class="row">
   <div class="col-md-10 mx-auto">
     <div class="card shadow-sm">
@@ -72,9 +77,11 @@ document.addEventListener('DOMContentLoaded', () => {
   // Preview de anexos
   const input = document.getElementById('files');
   const preview = document.getElementById('preview');
+  const overlay = document.getElementById('fileLoadingOverlay');
   const dt = new DataTransfer();
 
   input.addEventListener('change', () => {
+    overlay.style.display = 'flex';
     Array.from(input.files).forEach(file => {
       if (!Array.from(dt.files).some(
         f => f.name === file.name && f.size === file.size && f.lastModified === file.lastModified
@@ -99,6 +106,7 @@ document.addEventListener('DOMContentLoaded', () => {
         </div>`;
       preview.appendChild(col);
     });
+    overlay.style.display = 'none';
   });
 
   preview.addEventListener('click', e => {


### PR DESCRIPTION
## Summary
- overlay spinner to indicate large file uploads on **Novo Artigo** page
- add matching styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_684749d40200832ea8aac2b4039c022f