### PR TITLE
Fix missing ativo column on instituicao table

### DIFF
--- a/migrations/versions/9e9642d233f1_add_ativo_to_instituicao.py
+++ b/migrations/versions/9e9642d233f1_add_ativo_to_instituicao.py
@@ -1,0 +1,25 @@
+"""Add ativo column to Instituicao
+
+Revision ID: 9e9642d233f1
+Revises: 8f36375399a9
+Create Date: 2025-06-01 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '9e9642d233f1'
+down_revision = '8f36375399a9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('instituicao', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('ativo', sa.Boolean(), nullable=False, server_default='true'))
+
+
+def downgrade():
+    with op.batch_alter_table('instituicao', schema=None) as batch_op:
+        batch_op.drop_column('ativo')


### PR DESCRIPTION
## Summary
- add alembic migration to create `ativo` column in `instituicao`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement alembic==1.15.2)*

------
https://chatgpt.com/codex/tasks/task_e_68488cfd0964832ea933447b1a8bfd0c