### PR TITLE
Add CRUD tests for Instituicao and Celula

### DIFF
--- a/tests/test_celula.py
+++ b/tests/test_celula.py
@@ -47,3 +47,42 @@ def test_create_celula(client):
         assert cel.estabelecimento_id == est_id
         assert cel.centro_custo_id == cc_id
         assert cel.ativo is True
+
+
+def test_update_celula(client):
+    with app.app_context():
+        est_id = Estabelecimento.query.first().id
+        cc_id = CentroDeCusto.query.first().id
+        cel = Celula(nome='Orig', estabelecimento_id=est_id, centro_custo_id=cc_id)
+        db.session.add(cel)
+        db.session.commit()
+        cel_id = cel.id
+    login_admin(client)
+    response = client.post('/admin/celulas', data={
+        'id_para_atualizar': cel_id,
+        'nome': 'Atual',
+        'estabelecimento_id': est_id,
+        'centro_custo_id': cc_id,
+        'ativo_check': 'on'
+    }, follow_redirects=True)
+    assert response.status_code == 200
+    with app.app_context():
+        cel = Celula.query.get(cel_id)
+        assert cel.nome == 'Atual'
+        assert cel.ativo is True
+
+
+def test_toggle_celula_active(client):
+    with app.app_context():
+        est_id = Estabelecimento.query.first().id
+        cc_id = CentroDeCusto.query.first().id
+        cel = Celula(nome='Temp', estabelecimento_id=est_id, centro_custo_id=cc_id)
+        db.session.add(cel)
+        db.session.commit()
+        cel_id = cel.id
+    login_admin(client)
+    response = client.post(f'/admin/celulas/toggle_ativo/{cel_id}', follow_redirects=True)
+    assert response.status_code == 200
+    with app.app_context():
+        cel = Celula.query.get(cel_id)
+        assert cel.ativo is False

--- a/tests/test_instituicao.py
+++ b/tests/test_instituicao.py
@@ -36,3 +36,38 @@ def test_create_instituicao(client):
         assert inst is not None
         assert inst.descricao == 'Descricao'
         assert inst.ativo is True
+
+
+def test_update_instituicao(client):
+    with app.app_context():
+        inst = Instituicao(nome='Inst A', descricao='Old')
+        db.session.add(inst)
+        db.session.commit()
+        inst_id = inst.id
+    login_admin(client)
+    response = client.post('/admin/instituicoes', data={
+        'id_para_atualizar': inst_id,
+        'nome': 'Inst B',
+        'descricao': 'Nova',
+        'ativo_check': 'on'
+    }, follow_redirects=True)
+    assert response.status_code == 200
+    with app.app_context():
+        inst = Instituicao.query.get(inst_id)
+        assert inst.nome == 'Inst B'
+        assert inst.descricao == 'Nova'
+        assert inst.ativo is True
+
+
+def test_toggle_instituicao_active(client):
+    with app.app_context():
+        inst = Instituicao(nome='Ativa')
+        db.session.add(inst)
+        db.session.commit()
+        inst_id = inst.id
+    login_admin(client)
+    response = client.post(f'/admin/instituicoes/toggle_ativo/{inst_id}', follow_redirects=True)
+    assert response.status_code == 200
+    with app.app_context():
+        inst = Instituicao.query.get(inst_id)
+        assert inst.ativo is False


### PR DESCRIPTION
## Summary
- extend tests to include update/toggle flows for Instituicao and Celula
- include parent IDs when creating Estabelecimento and Setor

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68488e2f0820832ea060db1182dc9952