### PR TITLE
Atualizações no admin: tabelas e cadastro de cargos

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,6 +50,25 @@ from mimetypes import guess_type # Se for usar, descomente
 from werkzeug.utils import secure_filename # Útil para uploads, como na sua foto de perfil
 
 # -------------------------------------------------------------------------
+# Constantes de apoio
+# -------------------------------------------------------------------------
+# Mapeamento dos níveis hierárquicos de cargos. A chave numérica é armazenada no
+# banco de dados, enquanto o valor textual é apresentado nas interfaces.
+NIVEIS_HIERARQUICOS = [
+    (1, 'Diretor'),
+    (2, 'Gerente'),
+    (3, 'Coordenador'),
+    (4, 'Supervisor'),
+    (5, 'Líder'),
+    (6, 'Analista Sênior'),
+    (7, 'Analista Pleno'),
+    (8, 'Analista Júnior'),
+    (9, 'Assistente I'),
+    (10, 'Assistente II'),
+]
+NOME_NIVEL_CARGO = {valor: nome for valor, nome in NIVEIS_HIERARQUICOS}
+
+# -------------------------------------------------------------------------
 # Configuração da Aplicação (Seu código existente)
 # -------------------------------------------------------------------------
 app = Flask(__name__)
@@ -164,6 +183,11 @@ def inject_current_user():
 @app.context_processor
 def inject_zoneinfo():
     return dict(ZoneInfo=ZoneInfo)
+
+@app.context_processor
+def inject_niveis_cargo():
+    """Disponibiliza o mapeamento de níveis hierárquicos para todos os templates."""
+    return dict(NOME_NIVEL_CARGO=NOME_NIVEL_CARGO, NIVEIS_HIERARQUICOS=NIVEIS_HIERARQUICOS)
 
 # -------------------------------------------------------------------------
 # ROTAS DE ADMINISTRAÇÃO (NOVA SEÇÃO - ADICIONE AS ROTAS DO ADMIN AQUI)

--- a/templates/admin/cargos.html
+++ b/templates/admin/cargos.html
@@ -41,7 +41,7 @@
                                             {% for cargo in cargos %}
                                             <tr class="{{ 'table-light text-muted' if not cargo.ativo else '' }} clickable-row" data-href="{{ url_for('admin_cargos', edit_id=cargo.id) }}">
                                                 <td>{{ cargo.nome }}</td>
-                                                <td>{{ cargo.nivel_hierarquico if cargo.nivel_hierarquico is not none else '--' }}</td>
+                                                <td>{{ NOME_NIVEL_CARGO.get(cargo.nivel_hierarquico, '--') }}</td>
                                                 <td>
                                                     {% if cargo.ativo %}
                                                         <span class="badge bg-success">Ativo</span>
@@ -91,7 +91,12 @@
                             </div>
                             <div class="col-md-4 mb-1">
                                 <label for="nivel_hierarquico" class="form-label">Nível Hierárquico</label>
-                                <input type="number" class="form-control form-control-sm" id="nivel_hierarquico" name="nivel_hierarquico" value="{{ request.form.get('nivel_hierarquico', '') }}">
+                                <select class="form-select form-select-sm" id="nivel_hierarquico" name="nivel_hierarquico">
+                                    <option value="">Selecione</option>
+                                    {% for val, nome in NIVEIS_HIERARQUICOS %}
+                                        <option value="{{ val }}" {% if request.form.get('nivel_hierarquico') == val|string %}selected{% endif %}>{{ nome }}</option>
+                                    {% endfor %}
+                                </select>
                             </div>
                         </div>
                         <div class="mb-1">
@@ -137,7 +142,12 @@
                         </div>
                         <div class="col-md-4 mb-1">
                             <label for="edit_nivel_hierarquico" class="form-label">Nível Hierárquico</label>
-                            <input type="number" class="form-control form-control-sm" id="edit_nivel_hierarquico" name="nivel_hierarquico" value="{{ request.form.get('nivel_hierarquico', cargo_editar.nivel_hierarquico or '') }}">
+                            <select class="form-select form-select-sm" id="edit_nivel_hierarquico" name="nivel_hierarquico">
+                                <option value="">Selecione</option>
+                                {% for val, nome in NIVEIS_HIERARQUICOS %}
+                                    <option value="{{ val }}" {% if (request.form.get('nivel_hierarquico', cargo_editar.nivel_hierarquico|string) == val|string) %}selected{% endif %}>{{ nome }}</option>
+                                {% endfor %}
+                            </select>
                         </div>
                     </div>
                     <div class="mb-1">

--- a/templates/admin/estabelecimentos.html
+++ b/templates/admin/estabelecimentos.html
@@ -33,6 +33,7 @@
                                             <tr>
                                                 <th>Código</th>
                                                 <th>Nome Fantasia</th>
+                                                <th>Instituição</th>
                                                 <th>CNPJ</th>
                                                 <th>Cidade/UF</th>
                                                 <th>Status</th>
@@ -44,6 +45,7 @@
                                             <tr class="{{ 'table-light text-muted' if not est.ativo else '' }} clickable-row" data-href="{{ url_for('admin_estabelecimentos', edit_id=est.id) }}">
                                                 <td>{{ est.codigo }}</td>
                                                 <td>{{ est.nome_fantasia }}</td>
+                                                <td>{{ est.instituicao.nome if est.instituicao else '--' }}</td>
                                                 <td>{{ est.cnpj or '--' }}</td>
                                                 <td>{{ est.cidade or 'N/A' }}/{{ est.estado or 'N/A' }}</td>
                                                 <td>

--- a/templates/admin/setores.html
+++ b/templates/admin/setores.html
@@ -32,6 +32,7 @@
                                         <thead>
                                             <tr>
                                                 <th>Nome</th>
+                                                <th>Estabelecimento</th>
                                                 <th>Status</th>
                                                 <th style="width: 200px;" class="text-end">Ações</th>
                                             </tr>
@@ -40,6 +41,7 @@
                                             {% for setor in setores %}
                                             <tr class="{{ 'table-light text-muted' if not setor.ativo else '' }} clickable-row" data-href="{{ url_for('admin_setores', edit_id=setor.id) }}">
                                                 <td>{{ setor.nome }}</td>
+                                                <td>{{ setor.estabelecimento.nome_fantasia }}</td>
                                                 <td>
                                                     {% if setor.ativo %}
                                                         <span class="badge bg-success">Ativo</span>


### PR DESCRIPTION
## Summary
- adicionar lista de níveis hierárquicos em `app.py` e disponibilizar via context processor
- exibir a instituição na listagem de estabelecimentos
- exibir o estabelecimento na listagem de setores
- mostrar nome do nível hierárquico nas tabelas de cargos
- alterar o cadastro/edição de cargos para usar um `<select>` com nomes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6848a5dbe0a8832eb9f327a520e6c262