### PR TITLE
Improve novo_artigo loading indicator

### DIFF
--- a/templates/novo_artigo.html
+++ b/templates/novo_artigo.html
@@ -70,8 +70,10 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // Sincroniza conteúdo Quill no campo hidden antes de submeter
-  document.querySelector('form').addEventListener('submit', () => {
+  const form = document.querySelector('form');
+  form.addEventListener('submit', () => {
     document.getElementById('hidden-texto').value = quill.root.innerHTML;
+    overlay.style.display = 'flex';
   });
 
   // Preview de anexos
@@ -109,7 +111,6 @@ document.addEventListener('DOMContentLoaded', () => {
       });
       overlay.style.display = 'none';
     });
-    overlay.style.display = 'none';
   });
 
   preview.addEventListener('click', e => {


### PR DESCRIPTION
## Summary
- show loading overlay while the form is submitted
- fix hiding logic of overlay when generating previews

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6849d7f9176c832e8147c004023405e0