### PR TITLE
Fix horizontal scrollbars on article pages

### DIFF
--- a/templates/aprovacao.html
+++ b/templates/aprovacao.html
@@ -2,8 +2,9 @@
 {% block title %}Fila de Aprovação{% endblock %}
 
 {% block content %}
-<div class="row justify-content-center"> {# Usar justify-content-center na row é uma boa alternativa ao mx-auto na col #}
-  <div class="col-md-10 mt-4"> {# A coluna agora só define a largura. mt-4 para a margem superior #}
+<div class="container-fluid px-5">
+  <div class="row justify-content-center"> {# Usar justify-content-center na row é uma boa alternativa ao mx-auto na col #}
+    <div class="col-md-10 mt-4"> {# A coluna agora só define a largura. mt-4 para a margem superior #}
     
     {# Conteúdo que estava dentro do .container agora está direto no .col-md-10 #}
     <h3 class="mb-3">Aprovação de Artigos</h3>
@@ -48,5 +49,6 @@
     {# Fim do conteúdo que estava no .container #}
 
   </div> {# Fim do col-md-10 #}
-</div> {# Fim do row #}
+  </div> {# Fim do row #}
+</div>
 {% endblock %}

--- a/templates/aprovacao_detail.html
+++ b/templates/aprovacao_detail.html
@@ -3,8 +3,9 @@
 {% block title %}Aprovar: {{ artigo.titulo }}{% endblock %}
 
 {% block content %}
-<div class="row">
-  <div class="col-md-10 mx-auto">
+<div class="container-fluid px-5">
+  <div class="row">
+    <div class="col-md-10 mx-auto">
     <div class="card shadow-sm mb-4">
       <div class="card-body">
         <h3>{{ artigo.titulo }}</h3>
@@ -94,6 +95,7 @@
       </div>
     </div>
   </div>
+</div>
 </div>
 {% endblock %}
 

--- a/templates/artigo.html
+++ b/templates/artigo.html
@@ -3,8 +3,9 @@
 {% block title %}{{ artigo.titulo }}{% endblock %}
 
 {% block content %}
-<div class="row">
-  <div class="col-md-10 mx-auto">
+<div class="container-fluid px-5">
+  <div class="row">
+    <div class="col-md-10 mx-auto">
     <div class="card shadow-sm">
       <div class="card-body position-relative">
 
@@ -146,9 +147,10 @@
       </div>
 
       </div> {# .card-body #}
-    </div> {# .card #}
+  </div> {# .card #}
   </div> {# .col #}
 </div> {# .row #}
+</div>
 {% endblock %}
 {% block extra_js %}
 <script>

--- a/templates/editar_artigo.html
+++ b/templates/editar_artigo.html
@@ -6,8 +6,9 @@
 {% endblock %}
 
 {% block content %}
-<div class="row">
-  <div class="col-md-10 mx-auto">
+<div class="container-fluid px-5">
+  <div class="row">
+    <div class="col-md-10 mx-auto">
     <div class="card shadow-sm">
       <div class="card-body">
         <h3>Editar Artigo</h3>
@@ -75,6 +76,7 @@
       </div>
     </div>
   </div>
+</div>
 </div>
 {% endblock %}
 {% block extra_js %}

--- a/templates/meus_artigos.html
+++ b/templates/meus_artigos.html
@@ -3,8 +3,9 @@
 {% block title %}Meus Artigos{% endblock %}
 
 {% block content %}
-<div class="row">
-  <div class="col-md-10 mx-auto">
+<div class="container-fluid px-5">
+  <div class="row">
+    <div class="col-md-10 mx-auto">
     <div class="card shadow-sm">
       <div class="card-body">
         <h3>Meus Artigos</h3>
@@ -43,5 +44,6 @@
       </div>
     </div>
   </div>
+</div>
 </div>
 {% endblock %}

--- a/templates/novo_artigo.html
+++ b/templates/novo_artigo.html
@@ -6,6 +6,7 @@
 {% endblock %}
 
 {% block content %}
+<div class="container-fluid px-5">
 <div id="fileLoadingOverlay" class="file-loading-overlay">
   <div class="spinner-border text-primary" role="status">
     <span class="visually-hidden">Carregando...</span>
@@ -45,6 +46,7 @@
       </div>
     </div>
   </div>
+</div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- wrap article-related templates in `container-fluid` to avoid horizontal scrollbars

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6849e093e0a4832e9e6a95376cc7b9ec