### PR TITLE
Fix workflow failing due to missing pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ webencodings==0.5.1
 Werkzeug==3.1.3
 xlrd==2.0.1
 sendgrid==6.10.0
+pytest==8.1.1


### PR DESCRIPTION
## Summary
- add `pytest` to the requirements file so CI installs it

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pytest -q` *(fails: OperationalError - no such table: user)*

------
https://chatgpt.com/codex/tasks/task_e_684b38f46eb4832ea310fb500ec6b042