### PR TITLE
Add celula field to user admin form

### DIFF
--- a/app.py
+++ b/app.py
@@ -476,6 +476,7 @@ def admin_usuarios():
         estabelecimento_id = request.form.get('estabelecimento_id', type=int)
         setor_id = request.form.get('setor_id', type=int)
         cargo_id = request.form.get('cargo_id', type=int)
+        celula_id = request.form.get('celula_id', type=int)
 
         data_nascimento = None
         if data_nascimento_str:
@@ -522,6 +523,7 @@ def admin_usuarios():
                     usr.estabelecimento_id = estabelecimento_id
                     usr.setor_id = setor_id
                     usr.cargo_id = cargo_id
+                    usr.celula_id = celula_id
                     if password:
                         usr.set_password(password)
                     action_msg = 'atualizado'
@@ -544,6 +546,7 @@ def admin_usuarios():
                         estabelecimento_id=estabelecimento_id,
                         setor_id=setor_id,
                         cargo_id=cargo_id,
+                        celula_id=celula_id,
                     )
                     usr.set_password(password)
                     db.session.add(usr)
@@ -571,6 +574,7 @@ def admin_usuarios():
     estabelecimentos = Estabelecimento.query.order_by(Estabelecimento.nome_fantasia).all()
     setores = Setor.query.order_by(Setor.nome).all()
     cargos = Cargo.query.order_by(Cargo.nome).all()
+    celulas = Celula.query.order_by(Celula.nome).all()
     return render_template(
         'admin/usuarios.html',
         usuarios=usuarios,
@@ -578,6 +582,7 @@ def admin_usuarios():
         estabelecimentos=estabelecimentos,
         setores=setores,
         cargos=cargos,
+        celulas=celulas,
     )
 
 @app.route('/admin/usuarios/toggle_ativo/<int:id>', methods=['POST'])

--- a/templates/admin/usuarios.html
+++ b/templates/admin/usuarios.html
@@ -166,6 +166,15 @@
                                     {% endfor %}
                                 </select>
                             </div>
+                            <div class="col-md-3 mb-1">
+                                <label for="celula_id" class="form-label">Célula</label>
+                                <select class="form-select form-select-sm" id="celula_id" name="celula_id">
+                                    <option value="">Selecione</option>
+                                    {% for cel in celulas %}
+                                        <option value="{{ cel.id }}" {% if request.form.get('celula_id') == cel.id|string %}selected{% endif %}>{{ cel.nome }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
                         </div>
                         <div class="row">
                             <div class="col-md-6 mb-1">
@@ -274,6 +283,15 @@
                                 <option value="">Selecione</option>
                                 {% for cg in cargos %}
                                 <option value="{{ cg.id }}" {% if (request.form.get('cargo_id') == cg.id|string) or (not request.form.get('cargo_id') and user_editar.cargo_id == cg.id) %}selected{% endif %}>{{ cg.nome }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-3 mb-1">
+                            <label for="edit_celula_id" class="form-label">Célula</label>
+                            <select class="form-select form-select-sm" id="edit_celula_id" name="celula_id">
+                                <option value="">Selecione</option>
+                                {% for cel in celulas %}
+                                <option value="{{ cel.id }}" {% if (request.form.get('celula_id') == cel.id|string) or (not request.form.get('celula_id') and user_editar.celula_id == cel.id) %}selected{% endif %}>{{ cel.nome }}</option>
                                 {% endfor %}
                             </select>
                         </div>

--- a/tests/test_admin_usuarios.py
+++ b/tests/test_admin_usuarios.py
@@ -5,7 +5,7 @@ os.environ.setdefault('SECRET_KEY', 'test_secret')
 os.environ.setdefault('DATABASE_URI', 'sqlite:///:memory:')
 
 from app import app, db
-from models import User
+from models import User, Instituicao, Estabelecimento, Setor, Celula
 from utils import DEFAULT_NEW_USER_PASSWORD
 
 @pytest.fixture
@@ -54,3 +54,33 @@ def test_toggle_user_active(client):
     with app.app_context():
         u = User.query.get(uid)
         assert u.ativo is False
+
+
+def test_create_user_with_celula(client):
+    login_admin(client)
+    with app.app_context():
+        inst = Instituicao(nome='Inst')
+        db.session.add(inst)
+        db.session.flush()
+        est = Estabelecimento(codigo='E1', nome_fantasia='Estab', instituicao_id=inst.id)
+        db.session.add(est)
+        db.session.flush()
+        setor = Setor(nome='Setor1', estabelecimento_id=est.id)
+        db.session.add(setor)
+        db.session.flush()
+        cel = Celula(nome='Cel1', estabelecimento_id=est.id, setor_id=setor.id)
+        db.session.add(cel)
+        db.session.commit()
+        cel_id = cel.id
+    response = client.post('/admin/usuarios', data={
+        'username': 'celuser',
+        'email': 'cel@example.com',
+        'role': 'colaborador',
+        'ativo_check': 'on',
+        'celula_id': cel_id
+    }, follow_redirects=True)
+    assert response.status_code == 200
+    with app.app_context():
+        usr = User.query.filter_by(username='celuser').first()
+        assert usr is not None
+        assert usr.celula_id == cel_id


### PR DESCRIPTION
## Summary
- include celula_id on user admin route
- load celulas for user admin template
- add celula selection to user creation and edit forms
- test creating user with celula

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68531e70ace8832eab01abbdac71699f