### PR TITLE
Implement article visibility checks

### DIFF
--- a/tests/test_article_visibility.py
+++ b/tests/test_article_visibility.py
@@ -44,3 +44,104 @@ def test_article_visibility_fields(client):
         assert fetched.visibility is ArticleVisibility.CELULA
         assert fetched.celula_id == cel.id
 
+
+def test_user_can_view_by_celula(client):
+    from utils import user_can_view_article
+    with app.app_context():
+        user1 = User.query.first()
+        est = user1.celula.estabelecimento
+        setor = user1.celula.setor
+        cel2 = Celula(nome='Celula 2', estabelecimento=est, setor=setor)
+        db.session.add(cel2)
+        user2 = User(username='u2', email='u2@test', password_hash='x', celula=cel2)
+        db.session.add(user2)
+        art = Article(
+            titulo='T2',
+            texto='C2',
+            user_id=user1.id,
+            celula_id=user1.celula_id,
+            visibility=ArticleVisibility.CELULA,
+            vis_celula_id=user1.celula_id,
+        )
+        db.session.add(art)
+        db.session.commit()
+
+        assert user_can_view_article(user1, art) is True
+        assert user_can_view_article(user2, art) is False
+
+
+def test_user_can_view_by_estabelecimento(client):
+    from utils import user_can_view_article
+    with app.app_context():
+        user1 = User.query.first()
+        est = user1.celula.estabelecimento
+        setor = user1.celula.setor
+        cel2 = Celula(nome='Celula 3', estabelecimento=est, setor=setor)
+        db.session.add(cel2)
+        user2 = User(username='u3', email='u3@test', password_hash='x', celula=cel2)
+        db.session.add(user2)
+        art = Article(
+            titulo='T3',
+            texto='C3',
+            user_id=user1.id,
+            celula_id=user1.celula_id,
+            visibility=ArticleVisibility.ESTABELECIMENTO,
+            estabelecimento_id=est.id,
+        )
+        db.session.add(art)
+        db.session.commit()
+
+        assert user_can_view_article(user2, art) is True
+
+
+
+def test_user_can_view_by_setor(client):
+    from utils import user_can_view_article
+    with app.app_context():
+        user1 = User.query.first()
+        est = user1.celula.estabelecimento
+        setor = user1.celula.setor
+        cel2 = Celula(nome='Celula 4', estabelecimento=est, setor=setor)
+        db.session.add(cel2)
+        user2 = User(username='u4', email='u4@test', password_hash='x', celula=cel2)
+        db.session.add(user2)
+        art = Article(
+            titulo='T4',
+            texto='C4',
+            user_id=user1.id,
+            celula_id=user1.celula_id,
+            visibility=ArticleVisibility.SETOR,
+            setor_id=setor.id,
+        )
+        db.session.add(art)
+        db.session.commit()
+
+        assert user_can_view_article(user2, art) is True
+
+
+def test_user_can_view_by_instituicao(client):
+    from utils import user_can_view_article
+    with app.app_context():
+        user1 = User.query.first()
+        inst = user1.celula.estabelecimento.instituicao
+        est2 = Estabelecimento(codigo='E2', nome_fantasia='Est 2', instituicao=inst)
+        db.session.add(est2)
+        setor2 = Setor(nome='Setor X', estabelecimento=est2)
+        db.session.add(setor2)
+        cel2 = Celula(nome='Celula 5', estabelecimento=est2, setor=setor2)
+        db.session.add(cel2)
+        user2 = User(username='u5', email='u5@test', password_hash='x', celula=cel2)
+        db.session.add(user2)
+        art = Article(
+            titulo='T5',
+            texto='C5',
+            user_id=user1.id,
+            celula_id=user1.celula_id,
+            visibility=ArticleVisibility.INSTITUICAO,
+            instituicao_id=inst.id,
+        )
+        db.session.add(art)
+        db.session.commit()
+
+        assert user_can_view_article(user2, art) is True
+

--- a/utils.py
+++ b/utils.py
@@ -180,14 +180,17 @@ def user_can_view_article(user, article):
 
     vis = article.visibility
 
+    user_est = user.estabelecimento or (user.celula.estabelecimento if user.celula else None)
+    user_setor = user.setor or (user.celula.setor if user.celula else None)
+
     if vis is ArticleVisibility.INSTITUICAO:
-        if user.estabelecimento and article.instituicao_id == user.estabelecimento.instituicao_id:
+        if user_est and article.instituicao_id == user_est.instituicao_id:
             return True
     elif vis is ArticleVisibility.ESTABELECIMENTO:
-        if user.estabelecimento_id == article.estabelecimento_id:
+        if user_est and article.estabelecimento_id == user_est.id:
             return True
     elif vis is ArticleVisibility.SETOR:
-        if user.setor_id == article.setor_id:
+        if user_setor and article.setor_id == user_setor.id:
             return True
     elif vis is ArticleVisibility.CELULA:
         if user.celula_id == article.vis_celula_id:

--- a/utils.py
+++ b/utils.py
@@ -159,3 +159,38 @@ def send_email(to_email: str, subject: str, html_content: str) -> None:
         sg.send(message)
     except Exception as e:
         current_app.logger.error(f'Erro ao enviar e-mail: {e}')
+
+
+def user_can_view_article(user, article):
+    """Verifica se o usuário tem permissão para visualizar o artigo."""
+    from models import Article  # import interno para evitar dependência circular
+    from enums import ArticleVisibility
+
+    if not isinstance(article, Article):
+        return False
+
+    if user.role in ("admin", "editor") or user.id == article.user_id:
+        return True
+
+    # Extras concedidos especificamente
+    if article.extra_users.filter_by(id=user.id).count():
+        return True
+    if user.celula_id and article.extra_celulas.filter_by(id=user.celula_id).count():
+        return True
+
+    vis = article.visibility
+
+    if vis is ArticleVisibility.INSTITUICAO:
+        if user.estabelecimento and article.instituicao_id == user.estabelecimento.instituicao_id:
+            return True
+    elif vis is ArticleVisibility.ESTABELECIMENTO:
+        if user.estabelecimento_id == article.estabelecimento_id:
+            return True
+    elif vis is ArticleVisibility.SETOR:
+        if user.setor_id == article.setor_id:
+            return True
+    elif vis is ArticleVisibility.CELULA:
+        if user.celula_id == article.vis_celula_id:
+            return True
+
+    return False


### PR DESCRIPTION
## Summary
- enforce visibility on article creation
- add `user_can_view_article` utility
- hide articles from unauthorized users
- filter search results based on permissions
- expand test coverage for visibility rules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685323805a78832eaf28398d28dc0a8a