### PR TITLE
Add visibility info to article pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1445,6 +1445,10 @@ def pesquisar():
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
         art.local_created = dt.astimezone(ZoneInfo("America/Sao_Paulo"))
+        dt2 = art.updated_at or dt
+        if dt2.tzinfo is None:
+            dt2 = dt2.replace(tzinfo=timezone.utc)
+        art.local_aprovado = dt2.astimezone(ZoneInfo("America/Sao_Paulo"))
 
     return render_template(
         'pesquisar.html',

--- a/enums.py
+++ b/enums.py
@@ -17,7 +17,15 @@ class ArticleStatus(Enum):
 
 
 class ArticleVisibility(Enum):
-    INSTITUICAO     = "instituicao"
-    ESTABELECIMENTO = "estabelecimento"
-    SETOR           = "setor"
-    CELULA          = "celula"
+    """Controla quem pode visualizar o artigo."""
+
+    def __new__(cls, value: str, label: str):
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.label = label
+        return obj
+
+    INSTITUICAO     = ("instituicao",     "Instituição")
+    ESTABELECIMENTO = ("estabelecimento", "Estabelecimento")
+    SETOR           = ("setor",           "Setor")
+    CELULA          = ("celula",          "Célula")

--- a/templates/aprovacao_detail.html
+++ b/templates/aprovacao_detail.html
@@ -11,7 +11,8 @@
         <h3>{{ artigo.titulo }}</h3>
         <p class="text-muted">
           Autor: {{ artigo.author.nome_completo or artigo.author.username }} |
-          Criado em: {{ artigo.created_at.strftime('%d/%m/%Y %H:%M') }}
+          Criado em: {{ artigo.created_at.strftime('%d/%m/%Y %H:%M') }} |
+          Visibilidade: {{ artigo.visibility.label }}
         </p>
         <hr>
         {# escapa tudo que não for texto e só depois converte quebras em <br> #}

--- a/templates/artigo.html
+++ b/templates/artigo.html
@@ -18,6 +18,8 @@
               {{ artigo.author.nome_completo or artigo.author.username }}
               <strong class="ms-2">Criado em:</strong>
               {{ artigo.created_at.strftime('%d/%m/%Y %H:%M') }}
+              <strong class="ms-2">Visibilidade:</strong>
+              {{ artigo.visibility.label }}
             </p>
           </div>
           {% set st = artigo.status %}

--- a/templates/editar_artigo.html
+++ b/templates/editar_artigo.html
@@ -12,6 +12,10 @@
     <div class="card shadow-sm">
       <div class="card-body">
         <h3>Editar Artigo</h3>
+        <p class="text-muted">
+          Criado em: {{ artigo.created_at.strftime('%d/%m/%Y %H:%M') }} |
+          Visibilidade: {{ artigo.visibility.label }}
+        </p>
         <form method="POST" enctype="multipart/form-data">
           <div class="mb-3">
             <label class="form-label">Título</label>

--- a/templates/meus_artigos.html
+++ b/templates/meus_artigos.html
@@ -19,7 +19,10 @@
                 
                 <div>
                   <div class="fw-bold">{{ artigo.titulo }}</div>
-                  <small class="text-muted">{{ artigo.local_created.strftime('%d/%m/%Y %H:%M') }}</small>
+                  <small class="text-muted">
+                    {{ artigo.local_created.strftime('%d/%m/%Y %H:%M') }} |
+                    Visibilidade: {{ artigo.visibility.label }}
+                  </small>
                 </div>
 
                 {# Badge usando propriedades do enum #}

--- a/templates/pesquisar.html
+++ b/templates/pesquisar.html
@@ -23,7 +23,8 @@
           <div>
             <div class="fw-bold">{{ artigo.titulo }}</div>
             <small class="text-muted">
-              {{ artigo.local_created.strftime('%d/%m/%Y %H:%M') }}
+              Criado em: {{ artigo.local_created.strftime('%d/%m/%Y %H:%M') }} |
+              Aprovado em: {{ artigo.local_aprovado.strftime('%d/%m/%Y %H:%M') }}
             </small>
           </div>
 


### PR DESCRIPTION
## Summary
- show article visibility alongside creation info on viewing and editing pages
- display visibility on the user's article list
- add approval date to search results
- expose friendly labels for `ArticleVisibility`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6855724093e8832ea3c5bba8c9ed5837