### PR TITLE
Atualiza cadastro de usuário

### DIFF
--- a/app.py
+++ b/app.py
@@ -475,9 +475,9 @@ def admin_usuarios():
         data_nascimento_str = request.form.get('data_nascimento', '').strip()
         data_admissao_str = request.form.get('data_admissao', '').strip()
         estabelecimento_id = request.form.get('estabelecimento_id', type=int)
-        setor_id = request.form.get('setor_id', type=int)
+        setor_ids = [int(s) for s in request.form.getlist('setor_ids') if s]
         cargo_id = request.form.get('cargo_id', type=int)
-        celula_id = request.form.get('celula_id', type=int)
+        celula_ids = [int(c) for c in request.form.getlist('celula_ids') if c]
 
         data_nascimento = None
         if data_nascimento_str:
@@ -493,8 +493,8 @@ def admin_usuarios():
             except ValueError:
                 flash('Data de admissão inválida.', 'danger')
 
-        if not username or not email:
-            flash('Usuário e Email são obrigatórios.', 'danger')
+        if not username or not email or not estabelecimento_id or not setor_ids or not celula_ids:
+            flash('Usuário, Email, Estabelecimento, Setor e Célula são obrigatórios.', 'danger')
         else:
             query_username = User.query.filter_by(username=username)
             query_email = User.query.filter_by(email=email)
@@ -522,9 +522,11 @@ def admin_usuarios():
                     usr.data_nascimento = data_nascimento
                     usr.data_admissao = data_admissao
                     usr.estabelecimento_id = estabelecimento_id
-                    usr.setor_id = setor_id
+                    usr.setor_id = setor_ids[0] if setor_ids else None
                     usr.cargo_id = cargo_id
-                    usr.celula_id = celula_id
+                    usr.celula_id = celula_ids[0] if celula_ids else None
+                    usr.extra_setores = [Setor.query.get(sid) for sid in setor_ids]
+                    usr.extra_celulas = [Celula.query.get(cid) for cid in celula_ids]
                     if password:
                         usr.set_password(password)
                     action_msg = 'atualizado'
@@ -545,11 +547,13 @@ def admin_usuarios():
                         data_nascimento=data_nascimento,
                         data_admissao=data_admissao,
                         estabelecimento_id=estabelecimento_id,
-                        setor_id=setor_id,
+                        setor_id=setor_ids[0] if setor_ids else None,
                         cargo_id=cargo_id,
-                        celula_id=celula_id,
+                        celula_id=celula_ids[0] if celula_ids else None,
                     )
                     usr.set_password(password)
+                    usr.extra_setores = [Setor.query.get(sid) for sid in setor_ids]
+                    usr.extra_celulas = [Celula.query.get(cid) for cid in celula_ids]
                     db.session.add(usr)
                     action_msg = 'criado'
 

--- a/models.py
+++ b/models.py
@@ -20,6 +20,19 @@ article_extra_users = db.Table(
     db.Column('user_id', db.Integer, db.ForeignKey('user.id'), primary_key=True)
 )
 
+# Association tables for users responsible for multiple setores/células
+user_extra_celulas = db.Table(
+    'user_extra_celulas',
+    db.Column('user_id', db.Integer, db.ForeignKey('user.id'), primary_key=True),
+    db.Column('celula_id', db.Integer, db.ForeignKey('celula.id'), primary_key=True),
+)
+
+user_extra_setores = db.Table(
+    'user_extra_setores',
+    db.Column('user_id', db.Integer, db.ForeignKey('user.id'), primary_key=True),
+    db.Column('setor_id', db.Integer, db.ForeignKey('setor.id'), primary_key=True),
+)
+
 # --- NOVOS MODELOS ORGANIZACIONAIS (FASE 1) ---
 
 class Instituicao(db.Model):
@@ -162,17 +175,23 @@ class User(db.Model):
     # Novas Chaves Estrangeiras e Relacionamentos (Fase 1)
     # Um usuário pertence a um estabelecimento, um setor e tem um cargo.
     # Nullable=True para flexibilidade inicial ou para usuários que não se encaixam perfeitamente.
-    estabelecimento_id = db.Column(db.Integer, db.ForeignKey('estabelecimento.id'), nullable=True)
+    estabelecimento_id = db.Column(db.Integer, db.ForeignKey('estabelecimento.id'), nullable=False)
     estabelecimento = db.relationship('Estabelecimento', back_populates='usuarios')
 
-    setor_id = db.Column(db.Integer, db.ForeignKey('setor.id'), nullable=True)
+    setor_id = db.Column(db.Integer, db.ForeignKey('setor.id'), nullable=False)
     setor = db.relationship('Setor', back_populates='usuarios')
 
-    celula_id = db.Column(db.Integer, db.ForeignKey('celula.id'), nullable=True)
+    celula_id = db.Column(db.Integer, db.ForeignKey('celula.id'), nullable=False)
     celula = db.relationship('Celula', back_populates='usuarios')
 
     cargo_id = db.Column(db.Integer, db.ForeignKey('cargo.id'), nullable=True)
     cargo = db.relationship('Cargo', back_populates='usuarios')
+
+    # Relações de múltiplas células e setores
+    extra_celulas = db.relationship(
+        'Celula', secondary=user_extra_celulas, lazy='dynamic')
+    extra_setores = db.relationship(
+        'Setor', secondary=user_extra_setores, lazy='dynamic')
     
     # Relacionamentos existentes (verifique se os back_populates/backrefs estão corretos com seus outros modelos)
     articles = db.relationship('Article', back_populates='author', lazy='dynamic', cascade='all, delete-orphan')

--- a/templates/admin/usuarios.html
+++ b/templates/admin/usuarios.html
@@ -140,20 +140,18 @@
                         </div>
                         <div class="row">
                             <div class="col-md-3 mb-1">
-                                <label for="estabelecimento_id" class="form-label">Estabelecimento</label>
-                                <select class="form-select form-select-sm" id="estabelecimento_id" name="estabelecimento_id">
-                                    <option value="">Selecione</option>
+                                <label for="estabelecimento_id" class="form-label">Estabelecimento <span class="text-danger">*</span></label>
+                                <select class="form-select form-select-sm" id="estabelecimento_id" name="estabelecimento_id" required>
                                     {% for est in estabelecimentos %}
                                         <option value="{{ est.id }}" {% if request.form.get('estabelecimento_id') == est.id|string %}selected{% endif %}>{{ est.nome_fantasia }}</option>
                                     {% endfor %}
                                 </select>
                             </div>
                             <div class="col-md-3 mb-1">
-                                <label for="setor_id" class="form-label">Setor</label>
-                                <select class="form-select form-select-sm" id="setor_id" name="setor_id">
-                                    <option value="">Selecione</option>
+                                <label for="setor_ids" class="form-label">Setor <span class="text-danger">*</span></label>
+                                <select multiple class="form-select form-select-sm" id="setor_ids" name="setor_ids" required>
                                     {% for st in setores %}
-                                        <option value="{{ st.id }}" {% if request.form.get('setor_id') == st.id|string %}selected{% endif %}>{{ st.nome }}</option>
+                                        <option value="{{ st.id }}" {% if st.id|string in request.form.getlist('setor_ids') %}selected{% endif %}>{{ st.nome }}</option>
                                     {% endfor %}
                                 </select>
                             </div>
@@ -167,11 +165,10 @@
                                 </select>
                             </div>
                             <div class="col-md-3 mb-1">
-                                <label for="celula_id" class="form-label">Célula</label>
-                                <select class="form-select form-select-sm" id="celula_id" name="celula_id">
-                                    <option value="">Selecione</option>
+                                <label for="celula_ids" class="form-label">Célula <span class="text-danger">*</span></label>
+                                <select multiple class="form-select form-select-sm" id="celula_ids" name="celula_ids" required>
                                     {% for cel in celulas %}
-                                        <option value="{{ cel.id }}" {% if request.form.get('celula_id') == cel.id|string %}selected{% endif %}>{{ cel.nome }}</option>
+                                        <option value="{{ cel.id }}" {% if cel.id|string in request.form.getlist('celula_ids') %}selected{% endif %}>{{ cel.nome }}</option>
                                     {% endfor %}
                                 </select>
                             </div>
@@ -260,20 +257,18 @@
                     </div>
                     <div class="row">
                         <div class="col-md-3 mb-1">
-                            <label for="edit_estabelecimento_id" class="form-label">Estabelecimento</label>
-                            <select class="form-select form-select-sm" id="edit_estabelecimento_id" name="estabelecimento_id">
-                                <option value="">Selecione</option>
+                            <label for="edit_estabelecimento_id" class="form-label">Estabelecimento <span class="text-danger">*</span></label>
+                            <select class="form-select form-select-sm" id="edit_estabelecimento_id" name="estabelecimento_id" required>
                                 {% for est in estabelecimentos %}
                                 <option value="{{ est.id }}" {% if (request.form.get('estabelecimento_id') == est.id|string) or (not request.form.get('estabelecimento_id') and user_editar.estabelecimento_id == est.id) %}selected{% endif %}>{{ est.nome_fantasia }}</option>
                                 {% endfor %}
                             </select>
                         </div>
                         <div class="col-md-3 mb-1">
-                            <label for="edit_setor_id" class="form-label">Setor</label>
-                            <select class="form-select form-select-sm" id="edit_setor_id" name="setor_id">
-                                <option value="">Selecione</option>
+                            <label for="edit_setor_ids" class="form-label">Setor <span class="text-danger">*</span></label>
+                            <select multiple class="form-select form-select-sm" id="edit_setor_ids" name="setor_ids" required>
                                 {% for st in setores %}
-                                <option value="{{ st.id }}" {% if (request.form.get('setor_id') == st.id|string) or (not request.form.get('setor_id') and user_editar.setor_id == st.id) %}selected{% endif %}>{{ st.nome }}</option>
+                                <option value="{{ st.id }}" {% if (request.form.getlist('setor_ids') and st.id|string in request.form.getlist('setor_ids')) or (not request.form.getlist('setor_ids') and (st in user_editar.extra_setores.all() or st.id == user_editar.setor_id)) %}selected{% endif %}>{{ st.nome }}</option>
                                 {% endfor %}
                             </select>
                         </div>
@@ -287,11 +282,10 @@
                             </select>
                         </div>
                         <div class="col-md-3 mb-1">
-                            <label for="edit_celula_id" class="form-label">Célula</label>
-                            <select class="form-select form-select-sm" id="edit_celula_id" name="celula_id">
-                                <option value="">Selecione</option>
+                            <label for="edit_celula_ids" class="form-label">Célula <span class="text-danger">*</span></label>
+                            <select multiple class="form-select form-select-sm" id="edit_celula_ids" name="celula_ids" required>
                                 {% for cel in celulas %}
-                                <option value="{{ cel.id }}" {% if (request.form.get('celula_id') == cel.id|string) or (not request.form.get('celula_id') and user_editar.celula_id == cel.id) %}selected{% endif %}>{{ cel.nome }}</option>
+                                <option value="{{ cel.id }}" {% if (request.form.getlist('celula_ids') and cel.id|string in request.form.getlist('celula_ids')) or (not request.form.getlist('celula_ids') and (cel in user_editar.extra_celulas.all() or cel.id == user_editar.celula_id)) %}selected{% endif %}>{{ cel.nome }}</option>
                                 {% endfor %}
                             </select>
                         </div>

--- a/tests/test_admin_usuarios.py
+++ b/tests/test_admin_usuarios.py
@@ -13,7 +13,21 @@ def client():
     app.config['TESTING'] = True
     with app.app_context():
         db.create_all()
+        inst = Instituicao(nome='Inst')
+        db.session.add(inst)
+        db.session.flush()
+        est = Estabelecimento(codigo='E1', nome_fantasia='Estab', instituicao_id=inst.id)
+        db.session.add(est)
+        db.session.flush()
+        setor = Setor(nome='Setor1', estabelecimento_id=est.id)
+        db.session.add(setor)
+        db.session.flush()
+        cel = Celula(nome='Cel1', estabelecimento_id=est.id, setor_id=setor.id)
+        db.session.add(cel)
+        db.session.commit()
+        base_ids = {'est': est.id, 'setor': setor.id, 'cel': cel.id}
         with app.test_client() as client:
+            client.base_ids = base_ids
             yield client
         db.session.remove()
         db.drop_all()
@@ -26,11 +40,15 @@ def login_admin(client):
 
 def test_create_user(client):
     login_admin(client)
+    ids = client.base_ids
     response = client.post('/admin/usuarios', data={
         'username': 'newuser',
         'email': 'new@example.com',
         'role': 'colaborador',
-        'ativo_check': 'on'
+        'ativo_check': 'on',
+        'estabelecimento_id': ids['est'],
+        'setor_ids': [str(ids['setor'])],
+        'celula_ids': [str(ids['cel'])]
     }, follow_redirects=True)
     assert response.status_code == 200
     with app.app_context():
@@ -39,12 +57,24 @@ def test_create_user(client):
         assert user.email == 'new@example.com'
         assert user.check_password(DEFAULT_NEW_USER_PASSWORD)
         assert user.ativo is True
+        assert user.celula_id == ids['cel']
+        assert user.setor_id == ids['setor']
+        assert user.extra_celulas.filter_by(id=ids['cel']).count() == 1
 
 
 def test_toggle_user_active(client):
+    ids = client.base_ids
     with app.app_context():
-        u = User(username='temp', email='temp@test.com')
+        u = User(
+            username='temp',
+            email='temp@test.com',
+            estabelecimento_id=ids['est'],
+            setor_id=ids['setor'],
+            celula_id=ids['cel']
+        )
         u.set_password('Pass123!')
+        u.extra_setores.append(Setor.query.get(ids['setor']))
+        u.extra_celulas.append(Celula.query.get(ids['cel']))
         db.session.add(u)
         db.session.commit()
         uid = u.id
@@ -77,10 +107,13 @@ def test_create_user_with_celula(client):
         'email': 'cel@example.com',
         'role': 'colaborador',
         'ativo_check': 'on',
-        'celula_id': cel_id
+        'estabelecimento_id': est.id,
+        'setor_ids': [str(setor.id)],
+        'celula_ids': [str(cel_id)]
     }, follow_redirects=True)
     assert response.status_code == 200
     with app.app_context():
         usr = User.query.filter_by(username='celuser').first()
         assert usr is not None
         assert usr.celula_id == cel_id
+        assert usr.extra_celulas.filter_by(id=cel_id).count() == 1


### PR DESCRIPTION
## Summary
- tornar campos de setor/estabelecimento/célula obrigatórios no modelo de usuário
- permitir múltiplas seleções de setores e células no formulário de usuários
- ajustar rota `/admin/usuarios` para lidar com as novas listas
- atualizar testes relacionados ao cadastro de usuário

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_685573090be4832e8e06e2a3015ef550