### PR TITLE
Fix missing permission tables

### DIFF
--- a/migrations/versions/d9c4b82b9ae3_add_funcao_tables.py
+++ b/migrations/versions/d9c4b82b9ae3_add_funcao_tables.py
@@ -1,0 +1,42 @@
+"""add funcao and permission tables"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'd9c4b82b9ae3'
+down_revision = 'c1a2b3c4d5e6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'funcao',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('codigo', sa.String(length=100), nullable=False),
+        sa.Column('nome', sa.String(length=255), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('codigo')
+    )
+    op.create_table(
+        'cargo_funcoes',
+        sa.Column('cargo_id', sa.Integer(), nullable=False),
+        sa.Column('funcao_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['cargo_id'], ['cargo.id']),
+        sa.ForeignKeyConstraint(['funcao_id'], ['funcao.id']),
+        sa.PrimaryKeyConstraint('cargo_id', 'funcao_id')
+    )
+    op.create_table(
+        'user_funcoes',
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('funcao_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id']),
+        sa.ForeignKeyConstraint(['funcao_id'], ['funcao.id']),
+        sa.PrimaryKeyConstraint('user_id', 'funcao_id')
+    )
+
+
+def downgrade():
+    op.drop_table('user_funcoes')
+    op.drop_table('cargo_funcoes')
+    op.drop_table('funcao')


### PR DESCRIPTION
## Summary
- add migration for Funcao and association tables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_6855acd70f58832ebcc3a6f7e4968a39