### PR TITLE
Document permissões via funções

### DIFF
--- a/docs/fluxo_permissoes.md
+++ b/docs/fluxo_permissoes.md
@@ -9,3 +9,23 @@ Durante o login, as permissões efetivas são calculadas pela combinação das
 funções do cargo com as personalizadas do usuário. Decisões de acesso,
 como o decorador `admin_required`, utilizam `user.get_permissoes()` para
 validar se o usuário possui a permissão de código `admin`.
+
+## Funções como Permissões
+
+Cada `Funcao` registrada no banco equivale a uma permissão específica, como `artigo_ler`, `artigo_criar` ou `artigo_aprovar_celula`. Um mesmo **Cargo** pode ter várias dessas funções associadas, assim como um usuário pode receber permissões extras além das herdadas do cargo. As checagens de acesso (em rotas ou templates) devem chamar `user.has_permissao(<codigo>)`.
+
+```python
+# Criação de funções
+ler = Funcao(codigo="artigo_ler", nome="Ler artigos")
+criar = Funcao(codigo="artigo_criar", nome="Criar artigos")
+aprovar = Funcao(codigo="artigo_aprovar_celula", nome="Aprovar artigos na célula")
+
+db.session.add_all([ler, criar, aprovar])
+db.session.commit()
+
+# Associação das permissões a um cargo
+cargo_editor = Cargo(nome="Editor")
+cargo_editor.permissoes.extend([ler, criar, aprovar])
+db.session.add(cargo_editor)
+db.session.commit()
+```


### PR DESCRIPTION
## Summary
- document how cada `Funcao` representa uma permissão
- explain that cargos e usuários podem possuir várias funções
- show uso do `has_permissao` e snippet de criação de funções

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6855bf50ec94832eb5774bed56b33af8