### PR TITLE
Atualiza opções de visibilidade e label

### DIFF
--- a/app.py
+++ b/app.py
@@ -1328,6 +1328,29 @@ def editar_artigo(artigo_id):
         artigo.texto  = request.form["texto"]
         artigo.updated_at = datetime.now(timezone.utc)
 
+        # visibilidade
+        user = User.query.filter_by(username=session["username"]).first()
+        vis_str = (request.form.get("visibility") or artigo.visibility.value).split(',')[0]
+        vis = ArticleVisibility.CELULA
+        if vis_str in ArticleVisibility._value2member_map_:
+            vis = ArticleVisibility(vis_str)
+
+        inst_id = est_id = setor_vis_id = vis_cel_id = None
+        if vis is ArticleVisibility.INSTITUICAO and user.estabelecimento:
+            inst_id = user.estabelecimento.instituicao_id
+        elif vis is ArticleVisibility.ESTABELECIMENTO:
+            est_id = user.estabelecimento_id
+        elif vis is ArticleVisibility.SETOR:
+            setor_vis_id = user.setor_id
+        elif vis is ArticleVisibility.CELULA:
+            vis_cel_id = user.celula_id
+
+        artigo.visibility = vis
+        artigo.instituicao_id = inst_id
+        artigo.estabelecimento_id = est_id
+        artigo.setor_id = setor_vis_id
+        artigo.vis_celula_id = vis_cel_id
+
         # anexos ─ exclusões + novos
         existing = json.loads(artigo.arquivos or "[]")
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -267,7 +267,7 @@
                                         <div class="collapse {{ 'show' if request.endpoint.startswith('admin_usuarios') or request.endpoint.startswith('admin_funcoes') else '' }}" id="collapseSegurancaSub">
                                             <ul class="nav flex-column ps-3">
                                                 <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_usuarios' else '' }}" href="{{ url_for('admin_usuarios') }}"><i class="bi bi-people-fill me-2"></i> Gerenciar Usuários</a></li>
-                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_funcoes' else '' }}" href="{{ url_for('admin_funcoes') }}"><i class="bi bi-key-fill me-2"></i> Gerenciar Perfis</a></li>
+                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_funcoes' else '' }}" href="{{ url_for('admin_funcoes') }}"><i class="bi bi-key-fill me-2"></i> Gerenciar Funções</a></li>
                                             </ul>
                                         </div>
                                     </li>

--- a/templates/editar_artigo.html
+++ b/templates/editar_artigo.html
@@ -26,8 +26,31 @@
             <label class="form-label">Texto</label>
             <!-- Quill Editor -->
             <div id="quill-editor" class="bg-white border rounded" style="height:300px; overflow:auto;"></div>
-            <input type="hidden" name="texto" id="hidden-texto">
+          <input type="hidden" name="texto" id="hidden-texto">
+        </div>
+
+        <div class="mb-3">
+          <label class="form-label">Visibilidade</label>
+          {% set vis = artigo.visibility.value %}
+          <div class="form-check">
+            <input class="form-check-input vis-check" type="checkbox" value="instituicao" id="editVisInst" data-label="Instituição" {{ 'checked' if vis == 'instituicao' }}>
+            <label class="form-check-label" for="editVisInst">Instituição</label>
           </div>
+          <div class="form-check">
+            <input class="form-check-input vis-check" type="checkbox" value="estabelecimento" id="editVisEst" data-label="Estabelecimento" {{ 'checked' if vis == 'estabelecimento' }}>
+            <label class="form-check-label" for="editVisEst">Estabelecimento</label>
+          </div>
+          <div class="form-check">
+            <input class="form-check-input vis-check" type="checkbox" value="setor" id="editVisSet" data-label="Setor" {{ 'checked' if vis == 'setor' }}>
+            <label class="form-check-label" for="editVisSet">Setor</label>
+          </div>
+          <div class="form-check">
+            <input class="form-check-input vis-check" type="checkbox" value="celula" id="editVisCel" data-label="Célula" {{ 'checked' if vis == 'celula' }}>
+            <label class="form-check-label" for="editVisCel">Célula</label>
+          </div>
+          <input type="hidden" name="visibility" id="visibilityInput" value="{{ artigo.visibility.value }}">
+          <div id="visibilityDisplay" class="mt-2"></div>
+        </div>
 
           {# Anexos existentes com remoção imediata #}
           {% if arquivos %}
@@ -111,12 +134,24 @@
   // mas a linha anterior sem ponto e vírgula confundia o parser.
   // O fechamento do addEventListener é só no final do script.
 
+  // Visibilidade por checkboxes
+  const visChecks = document.querySelectorAll('.vis-check');
+  const visInput = document.getElementById('visibilityInput');
+  const visDisplay = document.getElementById('visibilityDisplay');
+  function updateVisibility() {
+    const opts = Array.from(visChecks).filter(c => c.checked);
+    visInput.value = opts.map(o => o.value).join(',');
+    visDisplay.innerHTML = opts.map(o => `<span class="badge bg-secondary me-1">${o.dataset.label}</span>`).join('');
+  }
+  visChecks.forEach(cb => cb.addEventListener('change', updateVisibility));
+  updateVisibility();
+
   // Sincroniza conteúdo no hidden antes de submeter
   const form = document.querySelector('form');
   if (form) {
     form.addEventListener('submit', () => {
       const hiddenTexto = document.getElementById('hidden-texto');
-      if (hiddenTexto) { // Verifica se o campo hidden existe
+      if (hiddenTexto) {
         hiddenTexto.value = quill.root.innerHTML;
       }
     });

--- a/templates/novo_artigo.html
+++ b/templates/novo_artigo.html
@@ -30,13 +30,23 @@
           </div>
 
           <div class="mb-3">
-            <label for="visibilitySelect" class="form-label">Visibilidade</label>
-            <select id="visibilitySelect" class="form-select" multiple size="4">
-              <option value="instituicao">Instituição</option>
-              <option value="estabelecimento">Estabelecimento</option>
-              <option value="setor">Setor</option>
-              <option value="celula">Célula</option>
-            </select>
+            <label class="form-label">Visibilidade</label>
+            <div class="form-check">
+              <input class="form-check-input vis-check" type="checkbox" value="instituicao" id="visInst" data-label="Instituição">
+              <label class="form-check-label" for="visInst">Instituição</label>
+            </div>
+            <div class="form-check">
+              <input class="form-check-input vis-check" type="checkbox" value="estabelecimento" id="visEst" data-label="Estabelecimento">
+              <label class="form-check-label" for="visEst">Estabelecimento</label>
+            </div>
+            <div class="form-check">
+              <input class="form-check-input vis-check" type="checkbox" value="setor" id="visSet" data-label="Setor">
+              <label class="form-check-label" for="visSet">Setor</label>
+            </div>
+            <div class="form-check">
+              <input class="form-check-input vis-check" type="checkbox" value="celula" id="visCel" data-label="Célula" checked>
+              <label class="form-check-label" for="visCel">Célula</label>
+            </div>
             <input type="hidden" name="visibility" id="visibilityInput">
             <div id="visibilityDisplay" class="mt-2"></div>
           </div>
@@ -83,16 +93,16 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  // Visibilidade multi-select → atualiza hidden e badges
-  const visSelect = document.getElementById('visibilitySelect');
+  // Visibilidade por checkboxes → atualiza hidden e badges
+  const visChecks = document.querySelectorAll('.vis-check');
   const visInput = document.getElementById('visibilityInput');
   const visDisplay = document.getElementById('visibilityDisplay');
   function updateVisibility() {
-    const opts = Array.from(visSelect.selectedOptions);
+    const opts = Array.from(visChecks).filter(c => c.checked);
     visInput.value = opts.map(o => o.value).join(',');
-    visDisplay.innerHTML = opts.map(o => `<span class="badge bg-secondary me-1">${o.text}</span>`).join('');
+    visDisplay.innerHTML = opts.map(o => `<span class="badge bg-secondary me-1">${o.dataset.label}</span>`).join('');
   }
-  visSelect.addEventListener('change', updateVisibility);
+  visChecks.forEach(cb => cb.addEventListener('change', updateVisibility));
   updateVisibility();
 
   // Sincroniza conteúdo Quill no campo hidden antes de submeter


### PR DESCRIPTION
## Summary
- renomeia item da sidebar para **Gerenciar Funções**
- usa checkboxes para definir visibilidade na criação e edição de artigos
- exibe visibilidade em badges no formulário
- permite atualizar visibilidade do artigo no backend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6855c3d50b4c832eaed4d13f7f2bb7cd