### PR TITLE
Remove perfil field from user forms

### DIFF
--- a/app.py
+++ b/app.py
@@ -463,7 +463,6 @@ def admin_usuarios():
         id_para_atualizar = request.form.get('id_para_atualizar')
         username = request.form.get('username', '').strip()
         email = request.form.get('email', '').strip()
-        role = request.form.get('role', 'colaborador').strip() or 'colaborador'
         ativo = request.form.get('ativo_check') == 'on'
         password = request.form.get('password')
 
@@ -527,7 +526,6 @@ def admin_usuarios():
                     usr = User.query.get_or_404(id_para_atualizar)
                     usr.username = username
                     usr.email = email
-                    usr.role = role
                     usr.ativo = ativo
                     usr.nome_completo = nome_completo or None
                     usr.matricula = matricula or None
@@ -556,7 +554,6 @@ def admin_usuarios():
                     usr = User(
                         username=username,
                         email=email,
-                        role=role,
                         ativo=ativo,
                         nome_completo=nome_completo or None,
                         matricula=matricula or None,

--- a/templates/admin/usuarios.html
+++ b/templates/admin/usuarios.html
@@ -98,10 +98,6 @@
                                         <label for="email" class="form-label">Email <span class="text-danger">*</span></label>
                                         <input type="email" class="form-control form-control-sm" id="email" name="email" value="{{ request.form.get('email', '') }}" required maxlength="120">
                                     </div>
-                                    <div class="col-md-4 mb-1">
-                                        <label for="role" class="form-label">Perfil</label>
-                                        <input type="text" class="form-control form-control-sm" id="role" name="role" value="{{ request.form.get('role', 'colaborador') }}" maxlength="50">
-                                    </div>
                                 </div>
                                 <div class="row">
                                     <div class="col-md-6 mb-1">
@@ -240,10 +236,6 @@
                                 <div class="col-md-4 mb-1">
                                     <label for="edit_email" class="form-label">Email <span class="text-danger">*</span></label>
                                     <input type="email" class="form-control form-control-sm" id="edit_email" name="email" value="{{ request.form.get('email', user_editar.email) }}" required maxlength="120">
-                                </div>
-                                <div class="col-md-4 mb-1">
-                                    <label for="edit_role" class="form-label">Perfil</label>
-                                    <input type="text" class="form-control form-control-sm" id="edit_role" name="role" value="{{ request.form.get('role', user_editar.role) }}" maxlength="50">
                                 </div>
                             </div>
                             <div class="row">

--- a/tests/test_admin_usuarios.py
+++ b/tests/test_admin_usuarios.py
@@ -62,7 +62,6 @@ def test_create_user(client):
     response = client.post('/admin/usuarios', data={
         'username': 'newuser',
         'email': 'new@example.com',
-        'role': 'colaborador',
         'ativo_check': 'on',
         'estabelecimento_id': ids['est'],
         'setor_ids': [str(ids['setor'])],
@@ -114,7 +113,6 @@ def test_create_user_with_celula(client):
     response = client.post('/admin/usuarios', data={
         'username': 'celuser',
         'email': 'cel@example.com',
-        'role': 'colaborador',
         'ativo_check': 'on',
         'estabelecimento_id': est.id,
         'setor_ids': [str(setor.id)],
@@ -143,7 +141,6 @@ def test_user_defaults_from_cargo(client):
     response = client.post('/admin/usuarios', data={
         'username': 'gestor',
         'email': 'gestor@example.com',
-        'role': 'colaborador',
         'ativo_check': 'on',
         'cargo_id': cargo_id
     }, follow_redirects=True)
@@ -199,7 +196,6 @@ def test_create_user_with_custom_permissions(client):
     response = client.post('/admin/usuarios', data={
         'username': 'uperm',
         'email': 'uperm@example.com',
-        'role': 'colaborador',
         'ativo_check': 'on',
         'cargo_id': cargo_id,
         'estabelecimento_id': ids['est'],


### PR DESCRIPTION
## Summary
- drop `role` input field from user create/edit templates
- remove role handling from `/admin/usuarios` route
- adjust admin user tests to match new form

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855c4a7b340832ebb046dd37053d886