### PR TITLE
Refatorar permissões por cargo

### DIFF
--- a/migrations/versions/e3b1a2c4d5f6_remove_role_column.py
+++ b/migrations/versions/e3b1a2c4d5f6_remove_role_column.py
@@ -1,0 +1,19 @@
+"""remove role column from user"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'e3b1a2c4d5f6'
+down_revision = 'd9c4b82b9ae3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user') as batch_op:
+        batch_op.drop_column('role')
+
+
+def downgrade():
+    with op.batch_alter_table('user') as batch_op:
+        batch_op.add_column(sa.Column('role', sa.String(length=50), nullable=False, server_default='colaborador'))

--- a/models.py
+++ b/models.py
@@ -203,7 +203,6 @@ class User(db.Model):
     password_hash = db.Column(db.String(256), nullable=False)
     nome_completo = db.Column(db.String(255), nullable=True)
     foto = db.Column(db.String(255), nullable=True)
-    role = db.Column(db.String(50), nullable=False, default='colaborador') # Campo role existente
 
     # Novos campos para cadastro completo
     matricula = db.Column(db.String(50), unique=True, nullable=True)

--- a/seed_users.py
+++ b/seed_users.py
@@ -11,7 +11,7 @@ def run():
             username="admin",
             email="admin@seudominio.com", # E-mail adicionado
             password_hash=generate_password_hash("Admin123!"),
-            role="admin",
+            funcoes=["admin"],
             nome_completo="Admin de Souza",
             matricula="ADM001",
             cpf="000.000.000-00", # Exemplo, coloque dados fictícios
@@ -27,7 +27,7 @@ def run():
             username="editor",
             email="editor@seudominio.com", # E-mail adicionado
             password_hash=generate_password_hash("Editor123!"),
-            role="editor",
+            funcoes=["editor"],
             nome_completo="Maria Oliveira",
             matricula="EDT001",
             cpf="111.111.111-11", # Exemplo
@@ -39,7 +39,7 @@ def run():
             username="colaborador",
             email="colaborador@seudominio.com", # E-mail adicionado
             password_hash=generate_password_hash("Colab123!"),
-            role="colaborador",
+            funcoes=["colaborador"],
             nome_completo="João Silva",
             matricula="COL001",
             cpf="222.222.222-22", # Exemplo
@@ -60,7 +60,12 @@ def run():
                 if celula:
                     user_data["celula_id"] = celula.id
 
+                perms = user_data.pop("funcoes", [])
                 new_user = User(**user_data)
+                for code in perms:
+                    func = Funcao.query.filter_by(codigo=code).first()
+                    if func:
+                        new_user.permissoes_personalizadas.append(func)
                 db.session.add(new_user)
                 print(f"Usuário {user_data['username']} criado.")
             else:

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -164,33 +164,6 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   });
 
-  function updatePermList(roleInputId, listId) {
-    const input = document.getElementById(roleInputId);
-    const list = document.getElementById(listId);
-    if (!input || !list) return;
-    const role = (input.value || '').trim().toLowerCase();
-    let items = [];
-    if (role === 'admin') {
-      items = [
-        'Gerenciar usuários e cadastros base',
-        'Aprovar ou rejeitar artigos',
-        'Criar e editar seus próprios artigos'
-      ];
-    } else if (role === 'editor') {
-      items = [
-        'Revisar e aprovar artigos de outros usuários',
-        'Criar e editar seus próprios artigos'
-      ];
-    } else {
-      items = ['Criar e gerenciar seus próprios artigos'];
-    }
-    list.innerHTML = items.map((t) => `<li>${t}</li>`).join('');
-  }
-
-  updatePermList('role', 'permResumoNovo');
-  updatePermList('edit_role', 'permResumoEdit');
-  document.getElementById('role')?.addEventListener('input', () => updatePermList('role', 'permResumoNovo'));
-  document.getElementById('edit_role')?.addEventListener('input', () => updatePermList('edit_role', 'permResumoEdit'));
 
   const cargoDefaults = window.cargoDefaults || {};
 

--- a/templates/admin/usuarios.html
+++ b/templates/admin/usuarios.html
@@ -33,7 +33,7 @@
                                             <tr>
                                                 <th>Usuário</th>
                                                 <th>Email</th>
-                                                <th>Perfil</th>
+                                                <th>Cargo</th>
                                                 <th>Status</th>
                                                 <th style="width: 200px;" class="text-end">Ações</th>
                                             </tr>
@@ -43,7 +43,7 @@
                                             <tr class="{{ 'table-light text-muted' if not u.ativo else '' }} clickable-row" data-href="{{ url_for('admin_usuarios', edit_id=u.id) }}">
                                                 <td>{{ u.username }}</td>
                                                 <td>{{ u.email }}</td>
-                                                <td>{{ u.role }}</td>
+                                                <td>{{ u.cargo.nome if u.cargo else '-' }}</td>
                                                 <td>
                                                     {% if u.ativo %}
                                                         <span class="badge bg-success">Ativo</span>

--- a/templates/perfil.html
+++ b/templates/perfil.html
@@ -264,8 +264,6 @@ width: 30px; /* Ajuste a largura conforme necessário */
           <dt class="col-sm-4">Cargo:</dt>
           <dd class="col-sm-8">{{ current_user.cargo.nome if current_user.cargo else 'N/A' }}</dd>
 
-          <dt class="col-sm-4">Tipo de Usuário:</dt>
-          <dd class="col-sm-8">{{ current_user.role }}</dd>
 
           <dt class="col-sm-4">Status:</dt>
           <dd class="col-sm-8"><span class="badge bg-{{ 'success' if current_user.ativo else 'danger' }}">{{ 'Ativo' if


### PR DESCRIPTION
## Summary
- remove `role` field from users
- drop role references in app logic and UI
- update seed generation to attach permissions via `Funcao`
- clean up JS helper
- add migration to drop column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6855d8a98004832eba0629fe3dcdcc74