### PR TITLE
Add setup script

### DIFF
--- a/docs/GUIA_DE_INSTALACAO.md
+++ b/docs/GUIA_DE_INSTALACAO.md
@@ -114,8 +114,21 @@ Após instalar o PostgreSQL, vamos criar um banco de dados dedicado e um usuári
     ```
 4.  Entre na pasta do projeto que foi clonada:
     ```bash
-    cd NOME_DA_PASTA_DO_PROJETO_ORQUETASK
-    ```
+cd NOME_DA_PASTA_DO_PROJETO_ORQUETASK
+```
+
+### (Opcional) Configuração rápida com script
+Se estiver em um ambiente baseado em Unix ou usando o **Git Bash**, você pode
+executar todas as etapas de criação do ambiente virtual, instalação das
+dependências, aplicação das migrações e popular os dados de exemplo com um único
+comando:
+
+```bash
+./setup.sh
+```
+
+O script não define as variáveis de ambiente, portanto siga a próxima seção para
+configurá-las corretamente.
 
 ## 7. Configurar o Ambiente Virtual Python (venv)
 1.  Dentro da pasta raiz do projeto, no terminal:

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,16 @@ Para rodar este projeto em um ambiente de desenvolvimento, você precisará ter 
     cd NOME_DA_PASTA_DO_PROJETO
     ```
 
+    > **Dica Rápida:** em sistemas Unix ou usando o Git Bash você pode
+    > automatizar os passos de criação do ambiente virtual, instalação das
+    > dependências, aplicação de migrações e inclusão de dados de exemplo
+    > executando:
+    > ```bash
+    > ./setup.sh
+    > ```
+    > Após a execução do script, lembre-se apenas de configurar suas variáveis
+    > de ambiente conforme o guia.
+
 2.  **Crie e ative um ambiente virtual Python:**
     ```bash
     python -m venv venv

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+# Create virtual environment
+python -m venv venv
+
+# Activate virtual environment
+source venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
+
+# Apply database migrations
+flask db upgrade
+
+# Seed initial data (optional but recommended)
+python seed_users.py
+python seed_organizacao.py
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- add setup.sh helper to create venv, install packages and run migrations
- document how to execute setup script in install guide
- mention setup script in project README

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_6855e28d3240832e9a9f359605a6f9ae