### PR TITLE
Implement article permissions via cargos

### DIFF
--- a/docs/TAREFAS_PERMISSOES.md
+++ b/docs/TAREFAS_PERMISSOES.md
@@ -33,10 +33,15 @@ partir das permissões cadastradas em `Funcao` e vinculadas aos `Cargos`.
 
 5. **Lista completa de funções**
    - Criar (ou atualizar) um script de seed que insira na tabela `funcao`
-     todas as funções disponíveis no sistema (por exemplo `artigo_criar`,
-     `artigo_aprovar`, etc.).
-   - Utilizar essa lista para preencher os checkboxes de cargos e dos
-     formulários de usuários.
+     todas as funções disponíveis no sistema. As principais permissões de
+     artigos são:
+       - `artigo_criar`
+       - `artigo_editar`
+       - `artigo_aprovar`
+       - `artigo_revisar`
+       - `artigo_assumir_revisao`
+  - Utilizar essa lista para preencher os checkboxes de cargos e dos
+    formulários de usuários.
 
 Com esses passos, todo o acesso passará a ser concedido
 exclusivamente pelas permissões configuradas nos cargos, sem depender

--- a/seed_funcoes.py
+++ b/seed_funcoes.py
@@ -1,0 +1,25 @@
+from database import db
+from models import Funcao
+from app import app
+
+FUNCOES = [
+    ("admin", "Administrador"),
+    ("colaborador", "Colaborador"),
+    ("editor", "Editor"),
+    ("artigo_criar", "Criar artigo"),
+    ("artigo_editar", "Editar artigo"),
+    ("artigo_aprovar", "Aprovar artigo"),
+    ("artigo_revisar", "Revisar artigo"),
+    ("artigo_assumir_revisao", "Assumir revisão"),
+]
+
+def run():
+    with app.app_context():
+        for codigo, nome in FUNCOES:
+            if not Funcao.query.filter_by(codigo=codigo).first():
+                db.session.add(Funcao(codigo=codigo, nome=nome))
+        db.session.commit()
+        print("Funções criadas/atualizadas.")
+
+if __name__ == "__main__":
+    run()

--- a/templates/base.html
+++ b/templates/base.html
@@ -199,7 +199,11 @@
                                 <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'meus_artigos' else '' }}" href="{{ url_for('meus_artigos') }}"><i class="bi bi-journals me-2"></i> Meus Artigos</a></li>
                                 <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'novo_artigo' else '' }}" href="{{ url_for('novo_artigo') }}"><i class="bi bi-file-earmark-plus-fill me-2"></i> Novo Artigo</a></li>
                                 <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'pesquisar' else '' }}" href="{{ url_for('pesquisar') }}"><i class="bi bi-search me-2"></i> Pesquisar</a></li>
-                                {% if current_user and (current_user.has_permissao('editor') or current_user.has_permissao('admin')) %}
+                                {% if current_user and (
+                                    current_user.has_permissao('admin') or
+                                    current_user.has_permissao('artigo_aprovar') or
+                                    current_user.has_permissao('artigo_revisar')
+                                ) %}
                                     <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'aprovacao' else '' }}" href="{{ url_for('aprovacao') }}"><i class="bi bi-check2-square me-2"></i> Aprovação</a></li>
                                 {% endif %}
                             </ul>

--- a/templates/pagina_inicial.html
+++ b/templates/pagina_inicial.html
@@ -44,7 +44,11 @@
                 </div>
             </div>
         </div>
-        {% if current_user and (current_user.has_permissao('editor') or current_user.has_permissao('admin')) %}
+        {% if current_user and (
+            current_user.has_permissao('admin') or
+            current_user.has_permissao('artigo_aprovar') or
+            current_user.has_permissao('artigo_revisar')
+        ) %}
         <div class="col-md-4 col-lg-3 mb-3">
             <div class="card text-center h-100">
                 <div class="card-body">

--- a/tests/test_article_permissions.py
+++ b/tests/test_article_permissions.py
@@ -1,0 +1,76 @@
+import os
+import pytest
+
+os.environ.setdefault('SECRET_KEY', 'test_secret')
+os.environ.setdefault('DATABASE_URI', 'sqlite:///:memory:')
+
+from app import app, db
+from models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User, Article, ArticleStatus
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        inst = Instituicao(nome='Inst')
+        db.session.add(inst)
+        db.session.flush()
+        est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao_id=inst.id)
+        db.session.add(est)
+        db.session.flush()
+        setor = Setor(nome='Setor', estabelecimento_id=est.id)
+        db.session.add(setor)
+        db.session.flush()
+        cel = Celula(nome='Cel', estabelecimento_id=est.id, setor_id=setor.id)
+        db.session.add(cel)
+        db.session.commit()
+        ids = {'est': est.id, 'setor': setor.id, 'cel': cel.id}
+        with app.test_client() as client:
+            client.base_ids = ids
+            yield client
+        db.session.remove()
+        db.drop_all()
+
+def login_user(client, perms=None):
+    perms = perms or []
+    ids = client.base_ids
+    with app.app_context():
+        db.session.query(User).delete()
+        db.session.commit()
+        funcoes = []
+        for code in perms:
+            f = Funcao.query.filter_by(codigo=code).first()
+            if not f:
+                f = Funcao(codigo=code, nome=code)
+                db.session.add(f)
+                db.session.flush()
+            funcoes.append(f)
+        user = User(username='u', email='u@test', estabelecimento_id=ids['est'], setor_id=ids['setor'], celula_id=ids['cel'])
+        user.set_password('x')
+        for f in funcoes:
+            user.permissoes_personalizadas.append(f)
+        db.session.add(user)
+        db.session.commit()
+        uid = user.id
+    with client.session_transaction() as sess:
+        sess['user_id'] = uid
+
+
+def test_novo_artigo_requires_permission(client):
+    login_user(client, [])
+    resp = client.get('/novo-artigo')
+    assert resp.status_code == 302
+    assert '/meus-artigos' in resp.headers['Location']
+
+    login_user(client, ['artigo_criar'])
+    resp = client.get('/novo-artigo')
+    assert resp.status_code == 200
+
+def test_aprovacao_requires_permission(client):
+    login_user(client, [])
+    resp = client.get('/aprovacao')
+    assert resp.status_code == 302
+
+    login_user(client, ['artigo_aprovar'])
+    resp = client.get('/aprovacao')
+    assert resp.status_code == 200

--- a/utils.py
+++ b/utils.py
@@ -169,7 +169,14 @@ def user_can_view_article(user, article):
     if not isinstance(article, Article):
         return False
 
-    if user.has_permissao("admin") or user.has_permissao("editor") or user.id == article.user_id:
+    if (
+        user.has_permissao("admin")
+        or user.has_permissao("artigo_aprovar")
+        or user.has_permissao("artigo_revisar")
+        or user.has_permissao("artigo_editar")
+        or user.has_permissao("editor")
+        or user.id == article.user_id
+    ):
         return True
 
     # Extras concedidos especificamente


### PR DESCRIPTION
## Summary
- add seed for core article permissions
- gate new article creation and editing with permissions
- update approval routes to consider new permissions
- adjust templates to show approval link based on permissions
- document article permission codes
- add tests for permission enforcement

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ea2eb708832eae7f86feedad5301