### PR TITLE
Fix db module imports for Flask

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,7 +20,10 @@ from werkzeug.security import check_password_hash, generate_password_hash # gene
 from sqlalchemy import or_, func
 from functools import wraps # Essencial para decoradores, você já tinha
 
-from database import db
+try:
+    from .database import db
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from database import db
 from enums import ArticleStatus, ArticleVisibility
 
 from models import (

--- a/models.py
+++ b/models.py
@@ -4,7 +4,10 @@ from sqlalchemy import Enum as SQLAEnum, Column, Text, ForeignKey, Date, Boolean
 from sqlalchemy.orm import relationship
 from werkzeug.security import generate_password_hash, check_password_hash # Mantendo seus imports de User
 
-from database import db # Seu objeto db
+try:
+    from .database import db  # type: ignore  # pragma: no cover
+except ImportError:
+    from database import db  # type: ignore
 from enums import ArticleStatus, ArticleVisibility
 
 # --- association tables for article visibility ---

--- a/seed_funcoes.py
+++ b/seed_funcoes.py
@@ -1,4 +1,7 @@
-from database import db
+try:
+    from .database import db  # pragma: no cover
+except ImportError:
+    from database import db
 from models import Funcao
 from app import app
 

--- a/seed_organizacao.py
+++ b/seed_organizacao.py
@@ -1,4 +1,7 @@
-from database import db
+try:
+    from .database import db  # pragma: no cover
+except ImportError:
+    from database import db
 from models import Instituicao, Estabelecimento, Setor, Celula
 from app import app
 

--- a/seed_users.py
+++ b/seed_users.py
@@ -1,6 +1,9 @@
 # seed_users.py
 from werkzeug.security import generate_password_hash
-from database import db
+try:
+    from .database import db  # pragma: no cover
+except ImportError:
+    from database import db
 from models import User, Celula
 from app import app      # importa o Flask já configurado
 # from datetime import date # Se você for adicionar datas como data_admissao


### PR DESCRIPTION
## Summary
- support package or direct execution by importing database with fallback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6855edaf2704832ebe39dba1810de85a