### PR TITLE
Fix enums import when running as package

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,7 +24,10 @@ try:
     from .database import db
 except ImportError:  # pragma: no cover - fallback for direct execution
     from database import db
-from enums import ArticleStatus, ArticleVisibility
+try:
+    from .enums import ArticleStatus, ArticleVisibility
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from enums import ArticleStatus, ArticleVisibility
 
 from models import (
     User,

--- a/models.py
+++ b/models.py
@@ -8,7 +8,10 @@ try:
     from .database import db  # type: ignore  # pragma: no cover
 except ImportError:
     from database import db  # type: ignore
-from enums import ArticleStatus, ArticleVisibility
+try:
+    from .enums import ArticleStatus, ArticleVisibility
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from enums import ArticleStatus, ArticleVisibility
 
 # --- association tables for article visibility ---
 article_extra_celulas = db.Table(

--- a/utils.py
+++ b/utils.py
@@ -164,7 +164,10 @@ def send_email(to_email: str, subject: str, html_content: str) -> None:
 def user_can_view_article(user, article):
     """Verifica se o usuário tem permissão para visualizar o artigo."""
     from models import Article  # import interno para evitar dependência circular
-    from enums import ArticleVisibility
+    try:
+        from .enums import ArticleVisibility
+    except ImportError:  # pragma: no cover - fallback for direct execution
+        from enums import ArticleVisibility
 
     if not isinstance(article, Article):
         return False


### PR DESCRIPTION
## Summary
- support importing enums when the app is executed as a package

## Testing
- `DATABASE_URI=sqlite:///:memory: python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f0539d70832eb81301493bef4d3b