### PR TITLE
Remove editor permission

### DIFF
--- a/app.py
+++ b/app.py
@@ -1187,14 +1187,13 @@ def novo_artigo():
         # 5) Persiste tudo num único commit
         db.session.commit()
 
-        # 6) Notifica editores/admins, se necessário
+        # 6) Notifica responsáveis/admins, se necessário
         if status is ArticleStatus.PENDENTE:
             destinatarios = [
                 u for u in User.query.all()
                 if u.has_permissao('admin')
                 or u.has_permissao('artigo_revisar')
                 or u.has_permissao('artigo_aprovar')
-                or u.has_permissao('editor')
             ]
             for dest in destinatarios:
                 notif = Notification(
@@ -1383,15 +1382,14 @@ def editar_artigo(artigo_id):
         # se usuário clicou “Enviar para revisão”
         if acao == "enviar":
             artigo.status = ArticleStatus.PENDENTE
-            # 🔔 notifica editores / admins
-            editors = [
+            # 🔔 notifica responsáveis / admins
+            destinatarios = [
                 u for u in User.query.all()
                 if u.has_permissao('admin')
                 or u.has_permissao('artigo_revisar')
                 or u.has_permissao('artigo_aprovar')
-                or u.has_permissao('editor')
             ]
-            for dest in editors:
+            for dest in destinatarios:
                 n = Notification(
                     user_id = dest.id,
                     message = f"Novo artigo pendente para revisão: “{artigo.titulo}”",
@@ -1514,7 +1512,7 @@ def aprovacao_detail(artigo_id):
         db.session.add(notif)
         db.session.commit()
 
-        # 4) Mensagem para o editor e redirecionamento ------------------------
+        # 4) Mensagem de confirmação e redirecionamento -----------------------
         flash(msg, 'success')
         return redirect(url_for('aprovacao'))
 

--- a/docs/DOCUMENTACAO_DO_SISTEMA.md
+++ b/docs/DOCUMENTACAO_DO_SISTEMA.md
@@ -21,7 +21,7 @@ O **Orquetask** é um sistema web integrado, desenvolvido em Python com o framew
     * Criação e edição de rascunhos de artigos utilizando um editor de texto rico (Quill.js).
     * Submissão de artigos finalizados para um fluxo de revisão e aprovação.
     * Capacidade de anexar múltiplos arquivos relevantes (documentos, planilhas, PDFs, imagens) aos artigos.
-* **Editores/Administradores de Artigos:**
+* **Administradores de Artigos:**
     * Acesso a uma fila de artigos pendentes de aprovação.
     * Ferramentas para revisar o conteúdo e os anexos dos artigos submetidos.
     * Opções para aprovar artigos para publicação, solicitar ajustes específicos ao autor, ou rejeitar artigos com feedback.
@@ -172,7 +172,7 @@ Uma visão geral dos principais modelos de dados implementados e planejados:
 * **Autenticação:** Usuário acessa `/login`, insere credenciais. Se válidas, é redirecionado para `/inicio`. Sessão é criada. Logout via link na navbar/sidebar.
 * **Visualização/Edição de Perfil:** Usuário acessa `/perfil`, visualiza seus dados. Pode editar campos permitidos e alterar foto ou senha.
 * **Criação de Artigo:** Usuário (colaborador) acessa `/novo_artigo`, preenche formulário, anexa arquivos, salva como rascunho ou envia para revisão.
-* **Aprovação de Artigo:** Editor/Admin acessa `/aprovacao`, visualiza artigos pendentes, abre um artigo (`/aprovacao_detail`), revisa, comenta, e aprova, rejeita ou solicita ajustes. Autor é notificado.
+* **Aprovação de Artigo:** Administrador acessa `/aprovacao`, visualiza artigos pendentes, abre um artigo (`/aprovacao_detail`), revisa, comenta, e aprova, rejeita ou solicita ajustes. Autor é notificado.
 * **Administração de Estabelecimentos (Exemplo de CRUD Admin):** Admin acessa `/admin/dashboard`, navega para "Gerenciar Estabelecimentos". Visualiza lista, clica para adicionar novo ou editar existente. Formulário é preenchido/submetido. Lista é atualizada. Pode ativar/desativar.
 * **(Futuro) Abertura de OS:** Usuário acessa formulário de OS, preenche detalhes, OS é criada com status inicial e atribuída ou entra em fila para triagem/atribuição. Notificações são geradas.
 

--- a/docs/fluxo_permissoes.md
+++ b/docs/fluxo_permissoes.md
@@ -24,10 +24,7 @@ db.session.add_all([ler, criar, aprovar])
 db.session.commit()
 
 # Associação das permissões a um cargo
-cargo_editor = Cargo(nome="Editor")
-cargo_editor.permissoes.extend([ler, criar, aprovar])
-db.session.add(cargo_editor)
-db.session.commit()
+# (exemplo de associação de permissões a um cargo)
 ```
 
 Para uma visão passo a passo das alterações pendentes e ações necessárias para consolidar esse modelo de permissões, consulte o documento [TAREFAS_PERMISSOES.md](./TAREFAS_PERMISSOES.md).

--- a/models.py
+++ b/models.py
@@ -313,7 +313,7 @@ class Article(db.Model):
     created_at = db.Column(db.DateTime(timezone=True), nullable=False, server_default=func.now())
     updated_at = db.Column(db.DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
     arquivos = db.Column(db.Text, nullable=True)  # JSON list of filenames (se for o caso, ou remover se Attachment substitui)
-    review_comment = db.Column(db.Text, nullable=True) # Comentário da última revisão do editor
+    review_comment = db.Column(db.Text, nullable=True) # Comentário da última revisão
     
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     author = db.relationship('User', back_populates='articles')
@@ -349,14 +349,14 @@ class RevisionRequest(db.Model):
         return f"<RevisionRequest artigo={self.artigo_id} user={self.user_id}>"
 
 class Comment(db.Model):
-    __tablename__ = "comment" # Comentários feitos por editores/admins durante o fluxo de aprovação
+    __tablename__ = "comment" # Comentários feitos durante o fluxo de aprovação
     id = db.Column(db.Integer, primary_key=True)
     artigo_id = db.Column(db.Integer, db.ForeignKey("article.id"), nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False) # Editor/Admin que comentou
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False) # Usuário responsável pelo comentário
     texto = db.Column(db.Text, nullable=False)
     created_at = db.Column(db.DateTime(timezone=True), server_default=func.now(), nullable=True) # Conforme migration
 
-    autor = db.relationship("User", foreign_keys=[user_id], back_populates="comments") # Editor/Admin
+    autor = db.relationship("User", foreign_keys=[user_id], back_populates="comments")
     artigo = db.relationship("Article", back_populates="comments")
 
     def __repr__(self):

--- a/seed_funcoes.py
+++ b/seed_funcoes.py
@@ -11,7 +11,6 @@ from app import app
 FUNCOES = [
     ("admin", "Administrador"),
     ("colaborador", "Colaborador"),
-    ("editor", "Editor"),
     ("artigo_criar", "Criar artigo"),
     ("artigo_editar", "Editar artigo"),
     ("artigo_aprovar", "Aprovar artigo"),

--- a/seed_users.py
+++ b/seed_users.py
@@ -30,18 +30,6 @@ def run():
             # ramal="1000"
         ),
         dict(
-            username="editor",
-            email="editor@seudominio.com", # E-mail adicionado
-            password_hash=generate_password_hash("Editor123!"),
-            funcoes=["editor"],
-            nome_completo="Maria Oliveira",
-            matricula="EDT001",
-            cpf="111.111.111-11", # Exemplo
-            estabelecimento_id=None,
-            setor_id=None,
-            cargo_id=None,
-        ),
-        dict(
             username="colaborador",
             email="colaborador@seudominio.com", # E-mail adicionado
             password_hash=generate_password_hash("Colab123!"),

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -8,7 +8,7 @@
       <div class="card shadow-sm">
         <div class="card-body">
           <h3>Upload de Arquivo</h3>
-          {% if current_user and (current_user.has_permissao('colaborador') or current_user.has_permissao('editor') or current_user.has_permissao('admin')) %}
+          {% if current_user and (current_user.has_permissao('colaborador') or current_user.has_permissao('admin')) %}
             <form method="POST" enctype="multipart/form-data">
               <div class="mb-3">
                 <input type="file" name="file" class="form-control" required>

--- a/utils.py
+++ b/utils.py
@@ -177,7 +177,6 @@ def user_can_view_article(user, article):
         or user.has_permissao("artigo_aprovar")
         or user.has_permissao("artigo_revisar")
         or user.has_permissao("artigo_editar")
-        or user.has_permissao("editor")
         or user.id == article.user_id
     ):
         return True


### PR DESCRIPTION
## Summary
- drop `editor` from role seeds
- remove sample editor user
- clean checks for `editor` permission and update notifications
- update docs and comments to stop referencing editor role
- adjust template permission checks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68560269115c832eb11d3fae84354d55