### PR TITLE
Impedir remover permissões padrão do cargo

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -167,9 +167,15 @@ document.addEventListener("DOMContentLoaded", function () {
 
   const cargoDefaults = window.cargoDefaults || {};
 
+  function setCargoFuncoesDisabled(prefix, cargoId) {
+    const defs = cargoDefaults[cargoId] || { funcoes: [] };
+    document.querySelectorAll(`input[id^='${prefix}func']`).forEach((chk) => {
+      chk.disabled = defs.funcoes.includes(parseInt(chk.value));
+    });
+  }
+
   function applyCargoDefaults(prefix, cargoId) {
-    const defs = cargoDefaults[cargoId];
-    if (!defs) return;
+    const defs = cargoDefaults[cargoId] || { setores: [], celulas: [], funcoes: [] };
     document.querySelectorAll(`input[id^='${prefix}setor']`).forEach((chk) => {
       chk.checked = defs.setores.includes(parseInt(chk.value));
     });
@@ -177,7 +183,9 @@ document.addEventListener("DOMContentLoaded", function () {
       chk.checked = defs.celulas.includes(parseInt(chk.value));
     });
     document.querySelectorAll(`input[id^='${prefix}func']`).forEach((chk) => {
-      chk.checked = defs.funcoes.includes(parseInt(chk.value));
+      const isDefault = defs.funcoes.includes(parseInt(chk.value));
+      chk.checked = isDefault;
+      chk.disabled = isDefault;
     });
   }
 
@@ -187,5 +195,8 @@ document.addEventListener("DOMContentLoaded", function () {
   document.getElementById('edit_cargo_id')?.addEventListener('change', (e) => {
     applyCargoDefaults('edit_', e.target.value);
   });
+
+  // Expose helper for inline scripts
+  window.setCargoFuncoesDisabled = setCargoFuncoesDisabled;
 
 });

--- a/templates/admin/usuarios.html
+++ b/templates/admin/usuarios.html
@@ -329,7 +329,7 @@
                         <div class="card-body">
                             {% for f in funcoes %}
                                 <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="edit_func{{ f.id }}" name="funcao_ids" value="{{ f.id }}" {% if (request.form.getlist('funcao_ids') and f.id|string in request.form.getlist('funcao_ids')) or (not request.form.getlist('funcao_ids') and (f in user_editar.permissoes_personalizadas.all() or (user_editar.cargo and f in user_editar.cargo.permissoes.all()))) %}checked{% endif %}>
+                                    <input class="form-check-input" type="checkbox" id="edit_func{{ f.id }}" name="funcao_ids" value="{{ f.id }}" {% if (request.form.getlist('funcao_ids') and f.id|string in request.form.getlist('funcao_ids')) or (not request.form.getlist('funcao_ids') and (f in user_editar.permissoes_personalizadas.all() or (user_editar.cargo and f in user_editar.cargo.permissoes.all()))) %}checked{% endif %} {% if user_editar.cargo and f in user_editar.cargo.permissoes.all() %}disabled{% endif %}>
                                     <label class="form-check-label" for="edit_func{{ f.id }}">{{ f.nome }}</label>
                                 </div>
                             {% endfor %}
@@ -371,6 +371,7 @@ window.cargoDefaults = {{ cargo_defaults|safe }};
 document.addEventListener('DOMContentLoaded', function() {
     var modal = new bootstrap.Modal(document.getElementById('modalEditarUsuario'));
     modal.show();
+    setCargoFuncoesDisabled('edit_', {{ user_editar.cargo_id or 'null' }});
 });
 </script>
 {% endif %}


### PR DESCRIPTION
## Summary
- bloqueia na interface as funções que vêm do cargo
- carrega bloqueio quando o modal de edição abre
- aplica a lógica de bloqueio através de JavaScript

## Testing
- `pytest -q` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6856e6046270832e81f7def18f6c0768