### PR TITLE
Atualiza aviso de herança de permissões

### DIFF
--- a/docs/fluxo_permissoes.md
+++ b/docs/fluxo_permissoes.md
@@ -10,6 +10,12 @@ funções do cargo com as personalizadas do usuário. Decisões de acesso,
 como o decorador `admin_required`, utilizam `user.get_permissoes()` para
 validar se o usuário possui a permissão de código `admin`.
 
+## Hierarquia do Sistema
+
+Instituição → Estabelecimento → Setor → Célula → Cargo → Usuário
+
+As permissões de cada usuário resultam das permissões do cargo somadas às permissões extras que possam ser atribuídas a ele.
+
 ## Funções como Permissões
 
 Cada `Funcao` registrada no banco equivale a uma permissão específica, como `artigo_ler`, `artigo_criar` ou `artigo_aprovar_celula`. Um mesmo **Cargo** pode ter várias dessas funções associadas, assim como um usuário pode receber permissões extras além das herdadas do cargo. As checagens de acesso (em rotas ou templates) devem chamar `user.has_permissao(<codigo>)`.

--- a/templates/admin/usuarios.html
+++ b/templates/admin/usuarios.html
@@ -186,6 +186,7 @@
                         <div class="card mb-3">
                         <div class="card-header"><h6 class="mb-0">Permissões (Funções)</h6></div>
                         <div class="card-body">
+                            <p class="text-muted mb-2">Permissões herdadas do cargo já vêm marcadas e não podem ser desmarcadas.</p>
                             {% for f in funcoes %}
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" id="func{{ f.id }}" name="funcao_ids" value="{{ f.id }}" {% if f.id|string in request.form.getlist('funcao_ids') %}checked{% endif %}>
@@ -327,6 +328,7 @@
                     <div class="card mb-3">
                         <div class="card-header"><h6 class="mb-0">Permissões (Funções)</h6></div>
                         <div class="card-body">
+                            <p class="text-muted mb-2">Permissões herdadas do cargo já vêm marcadas e não podem ser desmarcadas.</p>
                             {% for f in funcoes %}
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" id="edit_func{{ f.id }}" name="funcao_ids" value="{{ f.id }}" {% if (request.form.getlist('funcao_ids') and f.id|string in request.form.getlist('funcao_ids')) or (not request.form.getlist('funcao_ids') and (f in user_editar.permissoes_personalizadas.all() or (user_editar.cargo and f in user_editar.cargo.permissoes.all()))) %}checked{% endif %} {% if user_editar.cargo and f in user_editar.cargo.permissoes.all() %}disabled{% endif %}>


### PR DESCRIPTION
## Summary
- explica herança de permissões em `templates/admin/usuarios.html`
- documenta hierarquia e combinação de permissões em `docs/fluxo_permissoes.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6858394f28d4832e891f4b7aab6db39b