### PR TITLE
Improve cargos listing layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -933,6 +933,23 @@ def admin_cargos():
     setores = Setor.query.order_by(Setor.nome).all()
     celulas = Celula.query.order_by(Celula.nome).all()
     funcoes = Funcao.query.order_by(Funcao.nome).all()
+
+    instituicoes = Instituicao.query.order_by(Instituicao.nome).all()
+    estrutura = []
+    for inst in instituicoes:
+        est_list = []
+        for est in inst.estabelecimentos.order_by(Estabelecimento.nome_fantasia).all():
+            setor_list = []
+            for setor in est.setores.order_by(Setor.nome).all():
+                celula_list = []
+                for cel in setor.celulas.order_by(Celula.nome).all():
+                    cargos_cel = [c for c in todos_cargos if cel in c.default_celulas]
+                    celula_list.append({'obj': cel, 'cargos': cargos_cel})
+                cargos_setor = [c for c in todos_cargos if c.default_celulas.count() == 0 and setor in c.default_setores]
+                setor_list.append({'obj': setor, 'celulas': celula_list, 'cargos': cargos_setor})
+            est_list.append({'obj': est, 'setores': setor_list})
+        estrutura.append({'obj': inst, 'estabelecimentos': est_list})
+
     return render_template(
         'admin/cargos.html',
         cargos=todos_cargos,
@@ -941,6 +958,7 @@ def admin_cargos():
         setores=setores,
         celulas=celulas,
         funcoes=funcoes,
+        estrutura=estrutura,
     )
 
 

--- a/docs/TAREFAS_PERMISSOES.md
+++ b/docs/TAREFAS_PERMISSOES.md
@@ -40,8 +40,12 @@ partir das permissões cadastradas em `Funcao` e vinculadas aos `Cargos`.
        - `artigo_aprovar`
        - `artigo_revisar`
        - `artigo_assumir_revisao`
-  - Utilizar essa lista para preencher os checkboxes de cargos e dos
-    formulários de usuários.
+  - Utilizar essa lista para preencher os checkboxes de cargos e dos formulários de usuários.
+6. **Reorganizar página de Cargos**
+   - Alterar `admin/cargos.html` para exibir os cargos seguindo o fluxo de permissão:
+     **Instituição → Estabelecimento → Setor → Célula → Cargo**.
+   - Cada nível deve agrupar visualmente o próximo para facilitar a localização dos cargos e sua relação dentro da estrutura organizacional.
+
 
 Com esses passos, todo o acesso passará a ser concedido
 exclusivamente pelas permissões configuradas nos cargos, sem depender

--- a/templates/admin/cargos.html
+++ b/templates/admin/cargos.html
@@ -26,56 +26,70 @@
                             <h5 class="mb-0"><i class="bi bi-list-ul me-2"></i>Cargos Cadastrados ({{ cargos|length }})</h5>
                         </div>
                         <div class="card-body">
-                            {% if cargos %}
-                                <div class="table-responsive">
-                                    <table class="table table-hover table-sm align-middle">
-                                        <thead>
-                                            <tr>
-                                                <th>Nome</th>
-                                                <th>Nível</th>
-                                                <th>Status</th>
-                                                <th style="width: 200px;" class="text-end">Ações</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {% for nivel, lista in cargos|groupby('nivel_hierarquico') %}
-                                            <tr class="table-secondary">
-                                                <th colspan="4">{{ NOME_NIVEL_CARGO.get(nivel, '--') }}</th>
-                                            </tr>
-                                                {% for cargo in lista %}
-                                                <tr class="{{ 'table-light text-muted' if not cargo.ativo else '' }} clickable-row" data-href="{{ url_for('admin_cargos', edit_id=cargo.id) }}">
-                                                    <td>{{ cargo.nome }}</td>
-                                                    <td>{{ NOME_NIVEL_CARGO.get(cargo.nivel_hierarquico, '--') }}</td>
-                                                    <td>
-                                                        {% if cargo.ativo %}
-                                                            <span class="badge bg-success">Ativo</span>
-                                                        {% else %}
-                                                            <span class="badge bg-secondary">Inativo</span>
+                            {% if estrutura %}
+                                <div class="ms-2">
+                                    {% for inst in estrutura %}
+                                        <h5>{{ inst.obj.nome }}</h5>
+                                        {% for est in inst.estabelecimentos %}
+                                            <div class="ms-3">
+                                                <h6>{{ est.obj.nome_fantasia }}</h6>
+                                                {% for setor in est.setores %}
+                                                    <div class="ms-3 mb-2">
+                                                        <strong>{{ setor.obj.nome }}</strong>
+                                                        {% if setor.cargos %}
+                                                            <ul class="list-group list-group-flush ms-3 mb-2">
+                                                                {% for cargo in setor.cargos %}
+                                                                <li class="list-group-item d-flex justify-content-between align-items-center {{ 'text-muted' if not cargo.ativo else '' }} clickable-row" data-href="{{ url_for('admin_cargos', edit_id=cargo.id) }}">
+                                                                    <span>{{ cargo.nome }}</span>
+                                                                    <span>
+                                                                        <a href="{{ url_for('admin_cargos', edit_id=cargo.id) }}" class="btn btn-sm btn-outline-primary me-1" title="Editar"><i class="bi bi-pencil-fill"></i></a>
+                                                                        {% set confirm_message_text = 'DESATIVAR' if cargo.ativo else 'ATIVAR' %}
+                                                                        {% set cargo_nome_js = cargo.nome | tojson %}
+                                                                        <form action="{{ url_for('admin_toggle_ativo_cargo', id=cargo.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_message_text }} o cargo ' + {{ cargo_nome_js }} + '?');">
+                                                                            {% if cargo.ativo %}
+                                                                                <button type="submit" class="btn btn-sm btn-outline-warning" title="Desativar"><i class="bi bi-archive-fill"></i></button>
+                                                                            {% else %}
+                                                                                <button type="submit" class="btn btn-sm btn-outline-success" title="Ativar"><i class="bi bi-archive-restore-fill"></i></button>
+                                                                            {% endif %}
+                                                                        </form>
+                                                                    </span>
+                                                                </li>
+                                                                {% endfor %}
+                                                            </ul>
                                                         {% endif %}
-                                                    </td>
-                                                    <td class="text-end">
-                                                        <a href="{{ url_for('admin_cargos', edit_id=cargo.id) }}" class="btn btn-sm btn-outline-primary me-1" title="Editar">
-                                                            <i class="bi bi-pencil-fill"></i>
-                                                        </a>
-                                                        {% set confirm_message_text = 'DESATIVAR' if cargo.ativo else 'ATIVAR' %}
-                                                        {% set cargo_nome_js = cargo.nome | tojson %}
-                                                        <form action="{{ url_for('admin_toggle_ativo_cargo', id=cargo.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_message_text }} o cargo ' + {{ cargo_nome_js }} + '?');">
-                                                            {% if cargo.ativo %}
-                                                                <button type="submit" class="btn btn-sm btn-outline-warning" title="Desativar">
-                                                                    <i class="bi bi-archive-fill"></i> Desativar
-                                                                </button>
-                                                            {% else %}
-                                                                <button type="submit" class="btn btn-sm btn-outline-success" title="Ativar">
-                                                                    <i class="bi bi-archive-restore-fill"></i> Ativar
-                                                                </button>
-                                                            {% endif %}
-                                                        </form>
-                                                    </td>
-                                                </tr>
+                                                        {% for cel in setor.celulas %}
+                                                            <div class="ms-3 mb-1">
+                                                                <span class="fw-bold">{{ cel.obj.nome }}</span>
+                                                                {% if cel.cargos %}
+                                                                    <ul class="list-group list-group-flush ms-3">
+                                                                        {% for cargo in cel.cargos %}
+                                                                        <li class="list-group-item d-flex justify-content-between align-items-center {{ 'text-muted' if not cargo.ativo else '' }} clickable-row" data-href="{{ url_for('admin_cargos', edit_id=cargo.id) }}">
+                                                                            <span>{{ cargo.nome }}</span>
+                                                                            <span>
+                                                                                <a href="{{ url_for('admin_cargos', edit_id=cargo.id) }}" class="btn btn-sm btn-outline-primary me-1" title="Editar"><i class="bi bi-pencil-fill"></i></a>
+                                                                                {% set confirm_message_text = 'DESATIVAR' if cargo.ativo else 'ATIVAR' %}
+                                                                                {% set cargo_nome_js = cargo.nome | tojson %}
+                                                                                <form action="{{ url_for('admin_toggle_ativo_cargo', id=cargo.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_message_text }} o cargo ' + {{ cargo_nome_js }} + '?');">
+                                                                                    {% if cargo.ativo %}
+                                                                                        <button type="submit" class="btn btn-sm btn-outline-warning" title="Desativar"><i class="bi bi-archive-fill"></i></button>
+                                                                                    {% else %}
+                                                                                        <button type="submit" class="btn btn-sm btn-outline-success" title="Ativar"><i class="bi bi-archive-restore-fill"></i></button>
+                                                                                    {% endif %}
+                                                                                </form>
+                                                                            </span>
+                                                                        </li>
+                                                                        {% endfor %}
+                                                                    </ul>
+                                                                {% else %}
+                                                                    <p class="text-muted ms-3">Nenhum cargo nesta célula.</p>
+                                                                {% endif %}
+                                                            </div>
+                                                        {% endfor %}
+                                                    </div>
                                                 {% endfor %}
-                                            {% endfor %}
-                                        </tbody>
-                                    </table>
+                                            </div>
+                                        {% endfor %}
+                                    {% endfor %}
                                 </div>
                             {% else %}
                                 <p class="text-muted">Nenhum cargo cadastrado ainda. Adicione um acima!</p>


### PR DESCRIPTION
## Summary
- reorganize cargos page layout to show hierarchy Institution → Establishment → Sector → Cell
- compute hierarchical structure in the admin route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_685848fa4408832e9f6a1339af86047b