### PR TITLE
Refactor seeding of Funcao permissions

### DIFF
--- a/migrations/versions/bb1d9e24176f_seed_specific_article_permissions.py
+++ b/migrations/versions/bb1d9e24176f_seed_specific_article_permissions.py
@@ -1,0 +1,37 @@
+"""seed scoped article permissions"""
+
+from alembic import op
+import sqlalchemy as sa
+
+try:
+    from enums import Permissao
+except ImportError:  # pragma: no cover - fallback
+    from ..enums import Permissao
+
+revision = 'bb1d9e24176f'
+down_revision = 'fa23b0c1c9d0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+    perms = [(p.value, p.value.replace('_', ' ').capitalize()) for p in Permissao]
+    for codigo, nome in perms:
+        res = connection.execute(
+            sa.text("SELECT id FROM funcao WHERE codigo=:c"), {"c": codigo}
+        ).first()
+        if not res:
+            connection.execute(
+                sa.text("INSERT INTO funcao (codigo, nome) VALUES (:c, :n)"),
+                {"c": codigo, "n": nome},
+            )
+
+
+def downgrade():
+    connection = op.get_bind()
+    codes = [p.value for p in Permissao]
+    connection.execute(
+        sa.text("DELETE FROM funcao WHERE codigo = ANY(:codes)"),
+        {"codes": codes},
+    )

--- a/seed_funcoes.py
+++ b/seed_funcoes.py
@@ -7,30 +7,24 @@ try:
 except ImportError:  # pragma: no cover - fallback for direct execution
     from models import Funcao
 from app import app
+try:
+    from .enums import Permissao  # pragma: no cover
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from enums import Permissao
 
-FUNCOES = [
+# Permissões que não fazem parte do Enum Permissao
+EXTRA_FUNCOES = [
     ("admin", "Administrador"),
-    ("colaborador", "Colaborador"),
     ("artigo_criar", "Criar artigo"),
-    ("artigo_editar", "Editar artigo"),
-    ("artigo_editar_celula", "Editar artigo na célula"),
-    ("artigo_editar_setor", "Editar artigo no setor"),
-    ("artigo_editar_estabelecimento", "Editar artigo no estabelecimento"),
-    ("artigo_editar_instituicao", "Editar artigo na instituição"),
-    ("artigo_editar_todas", "Editar todos os artigos"),
-    ("artigo_aprovar", "Aprovar artigo"),
-    ("artigo_aprovar_celula", "Aprovar artigo na célula"),
-    ("artigo_aprovar_setor", "Aprovar artigo no setor"),
-    ("artigo_aprovar_estabelecimento", "Aprovar artigo no estabelecimento"),
-    ("artigo_aprovar_instituicao", "Aprovar artigo na instituição"),
-    ("artigo_aprovar_todas", "Aprovar todos os artigos"),
     ("artigo_revisar", "Revisar artigo"),
     ("artigo_assumir_revisao", "Assumir revisão"),
 ]
 
 def run():
+    funcoes = [(p.value, p.value.replace("_", " ").capitalize()) for p in Permissao]
+    funcoes.extend(EXTRA_FUNCOES)
     with app.app_context():
-        for codigo, nome in FUNCOES:
+        for codigo, nome in funcoes:
             if not Funcao.query.filter_by(codigo=codigo).first():
                 db.session.add(Funcao(codigo=codigo, nome=nome))
         db.session.commit()


### PR DESCRIPTION
## Summary
- simplify `seed_funcoes` to use `Permissao` enum
- remove deprecated codes from the seed list
- add Alembic migration seeding every enum value

## Testing
- `PYTHONPATH=. pytest -q` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685be3952f94832e9276b4b91a7432e3