### PR TITLE
Use Permissao enum throughout article permission checks

### DIFF
--- a/templates/admin/cargos.html
+++ b/templates/admin/cargos.html
@@ -158,7 +158,29 @@
                     <div class="card mb-3">
                         <div class="card-header"><h6 class="mb-0">Permissões de Artigos</h6></div>
                         <div class="card-body">
-                            {% set article_codes = ['artigo_criar','artigo_editar','artigo_aprovar','artigo_revisar','artigo_assumir_revisao'] %}
+                            {% set article_codes = [
+                                'artigo_criar',
+                                Permissao.ARTIGO_EDITAR_CELULA.value,
+                                Permissao.ARTIGO_EDITAR_SETOR.value,
+                                Permissao.ARTIGO_EDITAR_ESTABELECIMENTO.value,
+                                Permissao.ARTIGO_EDITAR_INSTITUICAO.value,
+                                Permissao.ARTIGO_EDITAR_TODAS.value,
+                                Permissao.ARTIGO_APROVAR_CELULA.value,
+                                Permissao.ARTIGO_APROVAR_SETOR.value,
+                                Permissao.ARTIGO_APROVAR_ESTABELECIMENTO.value,
+                                Permissao.ARTIGO_APROVAR_INSTITUICAO.value,
+                                Permissao.ARTIGO_APROVAR_TODAS.value,
+                                Permissao.ARTIGO_REVISAR_CELULA.value,
+                                Permissao.ARTIGO_REVISAR_SETOR.value,
+                                Permissao.ARTIGO_REVISAR_ESTABELECIMENTO.value,
+                                Permissao.ARTIGO_REVISAR_INSTITUICAO.value,
+                                Permissao.ARTIGO_REVISAR_TODAS.value,
+                                Permissao.ARTIGO_ASSUMIR_REVISAO_CELULA.value,
+                                Permissao.ARTIGO_ASSUMIR_REVISAO_SETOR.value,
+                                Permissao.ARTIGO_ASSUMIR_REVISAO_ESTABELECIMENTO.value,
+                                Permissao.ARTIGO_ASSUMIR_REVISAO_INSTITUICAO.value,
+                                Permissao.ARTIGO_ASSUMIR_REVISAO_TODAS.value
+                            ] %}
                             {% for f in funcoes if f.codigo in article_codes %}
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" id="c_funcao{{ f.id }}" name="funcao_ids" value="{{ f.id }}" {% if f.id|string in request.form.getlist('funcao_ids') %}checked{% endif %}>
@@ -265,7 +287,29 @@
                     <div class="card mb-3">
                         <div class="card-header"><h6 class="mb-0">Permissões de Artigos</h6></div>
                         <div class="card-body">
-                            {% set article_codes = ['artigo_criar','artigo_editar','artigo_aprovar','artigo_revisar','artigo_assumir_revisao'] %}
+                            {% set article_codes = [
+                                'artigo_criar',
+                                Permissao.ARTIGO_EDITAR_CELULA.value,
+                                Permissao.ARTIGO_EDITAR_SETOR.value,
+                                Permissao.ARTIGO_EDITAR_ESTABELECIMENTO.value,
+                                Permissao.ARTIGO_EDITAR_INSTITUICAO.value,
+                                Permissao.ARTIGO_EDITAR_TODAS.value,
+                                Permissao.ARTIGO_APROVAR_CELULA.value,
+                                Permissao.ARTIGO_APROVAR_SETOR.value,
+                                Permissao.ARTIGO_APROVAR_ESTABELECIMENTO.value,
+                                Permissao.ARTIGO_APROVAR_INSTITUICAO.value,
+                                Permissao.ARTIGO_APROVAR_TODAS.value,
+                                Permissao.ARTIGO_REVISAR_CELULA.value,
+                                Permissao.ARTIGO_REVISAR_SETOR.value,
+                                Permissao.ARTIGO_REVISAR_ESTABELECIMENTO.value,
+                                Permissao.ARTIGO_REVISAR_INSTITUICAO.value,
+                                Permissao.ARTIGO_REVISAR_TODAS.value,
+                                Permissao.ARTIGO_ASSUMIR_REVISAO_CELULA.value,
+                                Permissao.ARTIGO_ASSUMIR_REVISAO_SETOR.value,
+                                Permissao.ARTIGO_ASSUMIR_REVISAO_ESTABELECIMENTO.value,
+                                Permissao.ARTIGO_ASSUMIR_REVISAO_INSTITUICAO.value,
+                                Permissao.ARTIGO_ASSUMIR_REVISAO_TODAS.value
+                            ] %}
                             {% for f in funcoes if f.codigo in article_codes %}
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" id="e_funcao{{ f.id }}" name="funcao_ids" value="{{ f.id }}" {% if (request.form.getlist('funcao_ids') and f.id|string in request.form.getlist('funcao_ids')) or (not request.form.getlist('funcao_ids') and (f in cargo_editar.permissoes.all())) %}checked{% endif %}>

--- a/templates/base.html
+++ b/templates/base.html
@@ -201,8 +201,16 @@
                                 <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'pesquisar' else '' }}" href="{{ url_for('pesquisar') }}"><i class="bi bi-search me-2"></i> Pesquisar</a></li>
                                 {% if current_user and (
                                     current_user.has_permissao('admin') or
-                                    current_user.has_permissao('artigo_aprovar') or
-                                    current_user.has_permissao('artigo_revisar')
+                                    current_user.has_permissao(Permissao.ARTIGO_APROVAR_CELULA.value) or
+                                    current_user.has_permissao(Permissao.ARTIGO_APROVAR_SETOR.value) or
+                                    current_user.has_permissao(Permissao.ARTIGO_APROVAR_ESTABELECIMENTO.value) or
+                                    current_user.has_permissao(Permissao.ARTIGO_APROVAR_INSTITUICAO.value) or
+                                    current_user.has_permissao(Permissao.ARTIGO_APROVAR_TODAS.value) or
+                                    current_user.has_permissao(Permissao.ARTIGO_REVISAR_CELULA.value) or
+                                    current_user.has_permissao(Permissao.ARTIGO_REVISAR_SETOR.value) or
+                                    current_user.has_permissao(Permissao.ARTIGO_REVISAR_ESTABELECIMENTO.value) or
+                                    current_user.has_permissao(Permissao.ARTIGO_REVISAR_INSTITUICAO.value) or
+                                    current_user.has_permissao(Permissao.ARTIGO_REVISAR_TODAS.value)
                                 ) %}
                                     <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'aprovacao' else '' }}" href="{{ url_for('aprovacao') }}"><i class="bi bi-check2-square me-2"></i> Aprovação</a></li>
                                 {% endif %}

--- a/templates/pagina_inicial.html
+++ b/templates/pagina_inicial.html
@@ -46,8 +46,16 @@
         </div>
         {% if current_user and (
             current_user.has_permissao('admin') or
-            current_user.has_permissao('artigo_aprovar') or
-            current_user.has_permissao('artigo_revisar')
+            current_user.has_permissao(Permissao.ARTIGO_APROVAR_CELULA.value) or
+            current_user.has_permissao(Permissao.ARTIGO_APROVAR_SETOR.value) or
+            current_user.has_permissao(Permissao.ARTIGO_APROVAR_ESTABELECIMENTO.value) or
+            current_user.has_permissao(Permissao.ARTIGO_APROVAR_INSTITUICAO.value) or
+            current_user.has_permissao(Permissao.ARTIGO_APROVAR_TODAS.value) or
+            current_user.has_permissao(Permissao.ARTIGO_REVISAR_CELULA.value) or
+            current_user.has_permissao(Permissao.ARTIGO_REVISAR_SETOR.value) or
+            current_user.has_permissao(Permissao.ARTIGO_REVISAR_ESTABELECIMENTO.value) or
+            current_user.has_permissao(Permissao.ARTIGO_REVISAR_INSTITUICAO.value) or
+            current_user.has_permissao(Permissao.ARTIGO_REVISAR_TODAS.value)
         ) %}
         <div class="col-md-4 col-lg-3 mb-3">
             <div class="card text-center h-100">

--- a/tests/test_article_permissions.py
+++ b/tests/test_article_permissions.py
@@ -6,6 +6,7 @@ os.environ.setdefault('DATABASE_URI', 'sqlite:///:memory:')
 
 from app import app, db
 from models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User, Article, ArticleStatus
+from enums import Permissao
 
 @pytest.fixture
 def client():
@@ -71,6 +72,6 @@ def test_aprovacao_requires_permission(client):
     resp = client.get('/aprovacao')
     assert resp.status_code == 302
 
-    login_user(client, ['artigo_aprovar'])
+    login_user(client, [Permissao.ARTIGO_APROVAR_CELULA.value])
     resp = client.get('/aprovacao')
     assert resp.status_code == 200

--- a/utils.py
+++ b/utils.py
@@ -132,6 +132,11 @@ from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail
 import os
 
+try:
+    from .enums import Permissao  # type: ignore  # pragma: no cover
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from enums import Permissao
+
 def generate_token(user_id: int, action: str, expires_sec: int = 3600) -> str:
     """Gera um token seguro para ações como reset ou criação de senha."""
     serializer = URLSafeTimedSerializer(current_app.secret_key)
@@ -174,26 +179,26 @@ def user_can_edit_article(user, article):
     if user.has_permissao("admin") or user.id == article.user_id:
         return True
 
-    if user.has_permissao("artigo_editar_todas") or user.has_permissao("artigo_editar"):
+    if user.has_permissao(Permissao.ARTIGO_EDITAR_TODAS.value):
         return True
 
-    if user.has_permissao("artigo_editar_instituicao"):
+    if user.has_permissao(Permissao.ARTIGO_EDITAR_INSTITUICAO.value):
         user_est = user.estabelecimento or (user.celula.estabelecimento if user.celula else None)
         if user_est and article.instituicao_id == user_est.instituicao_id:
             return True
 
-    if user.has_permissao("artigo_editar_estabelecimento"):
+    if user.has_permissao(Permissao.ARTIGO_EDITAR_ESTABELECIMENTO.value):
         user_est = user.estabelecimento or (user.celula.estabelecimento if user.celula else None)
         if user_est and article.estabelecimento_id == user_est.id:
             return True
 
-    if user.has_permissao("artigo_editar_setor"):
+    if user.has_permissao(Permissao.ARTIGO_EDITAR_SETOR.value):
         if article.setor_id == user.setor_id:
             return True
         if user.extra_setores.filter_by(id=article.setor_id).count():
             return True
 
-    if user.has_permissao("artigo_editar_celula"):
+    if user.has_permissao(Permissao.ARTIGO_EDITAR_CELULA.value):
         if article.celula_id == user.celula_id:
             return True
         if user.extra_celulas.filter_by(id=article.celula_id).count():
@@ -218,12 +223,44 @@ def user_can_view_article(user, article):
     if user_can_edit_article(user, article):
         return True
 
+    if user.has_permissao("admin"):
+        return True
+
     if (
-        user.has_permissao("admin")
-        or user.has_permissao("artigo_aprovar")
-        or user.has_permissao("artigo_revisar")
+        user.has_permissao(Permissao.ARTIGO_APROVAR_TODAS.value)
+        or user.has_permissao(Permissao.ARTIGO_REVISAR_TODAS.value)
     ):
         return True
+
+    if (
+        user.has_permissao(Permissao.ARTIGO_APROVAR_INSTITUICAO.value)
+        or user.has_permissao(Permissao.ARTIGO_REVISAR_INSTITUICAO.value)
+    ):
+        user_est = user.estabelecimento or (user.celula.estabelecimento if user.celula else None)
+        if user_est and article.instituicao_id == user_est.instituicao_id:
+            return True
+
+    if (
+        user.has_permissao(Permissao.ARTIGO_APROVAR_ESTABELECIMENTO.value)
+        or user.has_permissao(Permissao.ARTIGO_REVISAR_ESTABELECIMENTO.value)
+    ):
+        user_est = user.estabelecimento or (user.celula.estabelecimento if user.celula else None)
+        if user_est and article.estabelecimento_id == user_est.id:
+            return True
+
+    if (
+        user.has_permissao(Permissao.ARTIGO_APROVAR_SETOR.value)
+        or user.has_permissao(Permissao.ARTIGO_REVISAR_SETOR.value)
+    ):
+        if article.setor_id == user.setor_id or user.extra_setores.filter_by(id=article.setor_id).count():
+            return True
+
+    if (
+        user.has_permissao(Permissao.ARTIGO_APROVAR_CELULA.value)
+        or user.has_permissao(Permissao.ARTIGO_REVISAR_CELULA.value)
+    ):
+        if article.celula_id == user.celula_id or user.extra_celulas.filter_by(id=article.celula_id).count():
+            return True
 
     # Extras concedidos especificamente
     if article.extra_users.filter_by(id=user.id).count():


### PR DESCRIPTION
## Summary
- reference new `Permissao` enum instead of raw strings
- update permission logic in utils
- expose `Permissao` enum to templates
- adjust templates and tests for enum based permissions

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be67a7d28832e8cdb8c7d039c7d16