### PR TITLE
Atualiza listagem de permissões nos templates

### DIFF
--- a/templates/admin/cargos.html
+++ b/templates/admin/cargos.html
@@ -158,34 +158,55 @@
                     <div class="card mb-3">
                         <div class="card-header"><h6 class="mb-0">Permissões de Artigos</h6></div>
                         <div class="card-body">
-                            {% set article_codes = [
-                                'artigo_criar',
-                                Permissao.ARTIGO_EDITAR_CELULA.value,
-                                Permissao.ARTIGO_EDITAR_SETOR.value,
-                                Permissao.ARTIGO_EDITAR_ESTABELECIMENTO.value,
-                                Permissao.ARTIGO_EDITAR_INSTITUICAO.value,
-                                Permissao.ARTIGO_EDITAR_TODAS.value,
-                                Permissao.ARTIGO_APROVAR_CELULA.value,
-                                Permissao.ARTIGO_APROVAR_SETOR.value,
-                                Permissao.ARTIGO_APROVAR_ESTABELECIMENTO.value,
-                                Permissao.ARTIGO_APROVAR_INSTITUICAO.value,
-                                Permissao.ARTIGO_APROVAR_TODAS.value,
-                                Permissao.ARTIGO_REVISAR_CELULA.value,
-                                Permissao.ARTIGO_REVISAR_SETOR.value,
-                                Permissao.ARTIGO_REVISAR_ESTABELECIMENTO.value,
-                                Permissao.ARTIGO_REVISAR_INSTITUICAO.value,
-                                Permissao.ARTIGO_REVISAR_TODAS.value,
-                                Permissao.ARTIGO_ASSUMIR_REVISAO_CELULA.value,
-                                Permissao.ARTIGO_ASSUMIR_REVISAO_SETOR.value,
-                                Permissao.ARTIGO_ASSUMIR_REVISAO_ESTABELECIMENTO.value,
-                                Permissao.ARTIGO_ASSUMIR_REVISAO_INSTITUICAO.value,
-                                Permissao.ARTIGO_ASSUMIR_REVISAO_TODAS.value
+                            {% set grupos = [
+                                ('Célula', [
+                                    Permissao.ARTIGO_EDITAR_CELULA.value,
+                                    Permissao.ARTIGO_APROVAR_CELULA.value,
+                                    Permissao.ARTIGO_REVISAR_CELULA.value,
+                                    Permissao.ARTIGO_ASSUMIR_REVISAO_CELULA.value
+                                ]),
+                                ('Setor', [
+                                    Permissao.ARTIGO_EDITAR_SETOR.value,
+                                    Permissao.ARTIGO_APROVAR_SETOR.value,
+                                    Permissao.ARTIGO_REVISAR_SETOR.value,
+                                    Permissao.ARTIGO_ASSUMIR_REVISAO_SETOR.value
+                                ]),
+                                ('Estabelecimento', [
+                                    Permissao.ARTIGO_EDITAR_ESTABELECIMENTO.value,
+                                    Permissao.ARTIGO_APROVAR_ESTABELECIMENTO.value,
+                                    Permissao.ARTIGO_REVISAR_ESTABELECIMENTO.value,
+                                    Permissao.ARTIGO_ASSUMIR_REVISAO_ESTABELECIMENTO.value
+                                ]),
+                                ('Instituição', [
+                                    Permissao.ARTIGO_EDITAR_INSTITUICAO.value,
+                                    Permissao.ARTIGO_APROVAR_INSTITUICAO.value,
+                                    Permissao.ARTIGO_REVISAR_INSTITUICAO.value,
+                                    Permissao.ARTIGO_ASSUMIR_REVISAO_INSTITUICAO.value
+                                ]),
+                                ('Todas as Unidades', [
+                                    Permissao.ARTIGO_EDITAR_TODAS.value,
+                                    Permissao.ARTIGO_APROVAR_TODAS.value,
+                                    Permissao.ARTIGO_REVISAR_TODAS.value,
+                                    Permissao.ARTIGO_ASSUMIR_REVISAO_TODAS.value
+                                ])
                             ] %}
-                            {% for f in funcoes if f.codigo in article_codes %}
+
+                            {# Permissão para criar artigos - não faz parte de um grupo #}
+                            {% for f in funcoes if f.codigo == 'artigo_criar' %}
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" id="c_funcao{{ f.id }}" name="funcao_ids" value="{{ f.id }}" {% if f.id|string in request.form.getlist('funcao_ids') %}checked{% endif %}>
                                     <label class="form-check-label" for="c_funcao{{ f.id }}">{{ f.nome }}</label>
                                 </div>
+                            {% endfor %}
+
+                            {% for label, codes in grupos %}
+                                <div class="mt-2"><strong>{{ label }}</strong></div>
+                                {% for f in funcoes if f.codigo in codes %}
+                                    <div class="form-check ms-3">
+                                        <input class="form-check-input" type="checkbox" id="c_funcao{{ f.id }}" name="funcao_ids" value="{{ f.id }}" {% if f.id|string in request.form.getlist('funcao_ids') %}checked{% endif %}>
+                                        <label class="form-check-label" for="c_funcao{{ f.id }}">{{ f.nome }}</label>
+                                    </div>
+                                {% endfor %}
                             {% endfor %}
                         </div>
                     </div>
@@ -286,35 +307,55 @@
                     </div>
                     <div class="card mb-3">
                         <div class="card-header"><h6 class="mb-0">Permissões de Artigos</h6></div>
-                        <div class="card-body">
-                            {% set article_codes = [
-                                'artigo_criar',
-                                Permissao.ARTIGO_EDITAR_CELULA.value,
-                                Permissao.ARTIGO_EDITAR_SETOR.value,
-                                Permissao.ARTIGO_EDITAR_ESTABELECIMENTO.value,
-                                Permissao.ARTIGO_EDITAR_INSTITUICAO.value,
-                                Permissao.ARTIGO_EDITAR_TODAS.value,
-                                Permissao.ARTIGO_APROVAR_CELULA.value,
-                                Permissao.ARTIGO_APROVAR_SETOR.value,
-                                Permissao.ARTIGO_APROVAR_ESTABELECIMENTO.value,
-                                Permissao.ARTIGO_APROVAR_INSTITUICAO.value,
-                                Permissao.ARTIGO_APROVAR_TODAS.value,
-                                Permissao.ARTIGO_REVISAR_CELULA.value,
-                                Permissao.ARTIGO_REVISAR_SETOR.value,
-                                Permissao.ARTIGO_REVISAR_ESTABELECIMENTO.value,
-                                Permissao.ARTIGO_REVISAR_INSTITUICAO.value,
-                                Permissao.ARTIGO_REVISAR_TODAS.value,
-                                Permissao.ARTIGO_ASSUMIR_REVISAO_CELULA.value,
-                                Permissao.ARTIGO_ASSUMIR_REVISAO_SETOR.value,
-                                Permissao.ARTIGO_ASSUMIR_REVISAO_ESTABELECIMENTO.value,
-                                Permissao.ARTIGO_ASSUMIR_REVISAO_INSTITUICAO.value,
-                                Permissao.ARTIGO_ASSUMIR_REVISAO_TODAS.value
+                    <div class="card-body">
+                            {% set grupos = [
+                                ('Célula', [
+                                    Permissao.ARTIGO_EDITAR_CELULA.value,
+                                    Permissao.ARTIGO_APROVAR_CELULA.value,
+                                    Permissao.ARTIGO_REVISAR_CELULA.value,
+                                    Permissao.ARTIGO_ASSUMIR_REVISAO_CELULA.value
+                                ]),
+                                ('Setor', [
+                                    Permissao.ARTIGO_EDITAR_SETOR.value,
+                                    Permissao.ARTIGO_APROVAR_SETOR.value,
+                                    Permissao.ARTIGO_REVISAR_SETOR.value,
+                                    Permissao.ARTIGO_ASSUMIR_REVISAO_SETOR.value
+                                ]),
+                                ('Estabelecimento', [
+                                    Permissao.ARTIGO_EDITAR_ESTABELECIMENTO.value,
+                                    Permissao.ARTIGO_APROVAR_ESTABELECIMENTO.value,
+                                    Permissao.ARTIGO_REVISAR_ESTABELECIMENTO.value,
+                                    Permissao.ARTIGO_ASSUMIR_REVISAO_ESTABELECIMENTO.value
+                                ]),
+                                ('Instituição', [
+                                    Permissao.ARTIGO_EDITAR_INSTITUICAO.value,
+                                    Permissao.ARTIGO_APROVAR_INSTITUICAO.value,
+                                    Permissao.ARTIGO_REVISAR_INSTITUICAO.value,
+                                    Permissao.ARTIGO_ASSUMIR_REVISAO_INSTITUICAO.value
+                                ]),
+                                ('Todas as Unidades', [
+                                    Permissao.ARTIGO_EDITAR_TODAS.value,
+                                    Permissao.ARTIGO_APROVAR_TODAS.value,
+                                    Permissao.ARTIGO_REVISAR_TODAS.value,
+                                    Permissao.ARTIGO_ASSUMIR_REVISAO_TODAS.value
+                                ])
                             ] %}
-                            {% for f in funcoes if f.codigo in article_codes %}
+
+                            {% for f in funcoes if f.codigo == 'artigo_criar' %}
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" id="e_funcao{{ f.id }}" name="funcao_ids" value="{{ f.id }}" {% if (request.form.getlist('funcao_ids') and f.id|string in request.form.getlist('funcao_ids')) or (not request.form.getlist('funcao_ids') and (f in cargo_editar.permissoes.all())) %}checked{% endif %}>
                                     <label class="form-check-label" for="e_funcao{{ f.id }}">{{ f.nome }}</label>
                                 </div>
+                            {% endfor %}
+
+                            {% for label, codes in grupos %}
+                                <div class="mt-2"><strong>{{ label }}</strong></div>
+                                {% for f in funcoes if f.codigo in codes %}
+                                    <div class="form-check ms-3">
+                                        <input class="form-check-input" type="checkbox" id="e_funcao{{ f.id }}" name="funcao_ids" value="{{ f.id }}" {% if (request.form.getlist('funcao_ids') and f.id|string in request.form.getlist('funcao_ids')) or (not request.form.getlist('funcao_ids') and (f in cargo_editar.permissoes.all())) %}checked{% endif %}>
+                                        <label class="form-check-label" for="e_funcao{{ f.id }}">{{ f.nome }}</label>
+                                    </div>
+                                {% endfor %}
                             {% endfor %}
                         </div>
                     </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -156,7 +156,7 @@
                     {# Foto/Nome do Usuário como LINK DIRETO para o Perfil #}
                     <li class="nav-item">
                         <a class="nav-link d-flex align-items-center p-0" href="{{ url_for('perfil') }}" title="Meu Perfil"> {# Link direto para o perfil #}
-                            {% if current_user and current_user.foto %}
+                            {% if current_user.is_authenticated and current_user.foto %}
                                 <img src="{{ url_for('profile_pics', filename=current_user.foto) }}" class="rounded-circle" style="width:32px; height:32px; object-fit:cover; margin-right: 8px;" alt="{{ current_user.username }}">
                             {% else %}
                                 <i class="bi bi-person-circle fs-4 me-2"></i>
@@ -199,20 +199,28 @@
                                 <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'meus_artigos' else '' }}" href="{{ url_for('meus_artigos') }}"><i class="bi bi-journals me-2"></i> Meus Artigos</a></li>
                                 <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'novo_artigo' else '' }}" href="{{ url_for('novo_artigo') }}"><i class="bi bi-file-earmark-plus-fill me-2"></i> Novo Artigo</a></li>
                                 <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'pesquisar' else '' }}" href="{{ url_for('pesquisar') }}"><i class="bi bi-search me-2"></i> Pesquisar</a></li>
-                                {% if current_user and (
-                                    current_user.has_permissao('admin') or
-                                    current_user.has_permissao(Permissao.ARTIGO_APROVAR_CELULA.value) or
-                                    current_user.has_permissao(Permissao.ARTIGO_APROVAR_SETOR.value) or
-                                    current_user.has_permissao(Permissao.ARTIGO_APROVAR_ESTABELECIMENTO.value) or
-                                    current_user.has_permissao(Permissao.ARTIGO_APROVAR_INSTITUICAO.value) or
-                                    current_user.has_permissao(Permissao.ARTIGO_APROVAR_TODAS.value) or
-                                    current_user.has_permissao(Permissao.ARTIGO_REVISAR_CELULA.value) or
-                                    current_user.has_permissao(Permissao.ARTIGO_REVISAR_SETOR.value) or
-                                    current_user.has_permissao(Permissao.ARTIGO_REVISAR_ESTABELECIMENTO.value) or
-                                    current_user.has_permissao(Permissao.ARTIGO_REVISAR_INSTITUICAO.value) or
-                                    current_user.has_permissao(Permissao.ARTIGO_REVISAR_TODAS.value)
-                                ) %}
-                                    <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'aprovacao' else '' }}" href="{{ url_for('aprovacao') }}"><i class="bi bi-check2-square me-2"></i> Aprovação</a></li>
+                                {% if current_user.is_authenticated %}
+                                    {% set codes = [
+                                        Permissao.ARTIGO_APROVAR_CELULA.value,
+                                        Permissao.ARTIGO_APROVAR_SETOR.value,
+                                        Permissao.ARTIGO_APROVAR_ESTABELECIMENTO.value,
+                                        Permissao.ARTIGO_APROVAR_INSTITUICAO.value,
+                                        Permissao.ARTIGO_APROVAR_TODAS.value,
+                                        Permissao.ARTIGO_REVISAR_CELULA.value,
+                                        Permissao.ARTIGO_REVISAR_SETOR.value,
+                                        Permissao.ARTIGO_REVISAR_ESTABELECIMENTO.value,
+                                        Permissao.ARTIGO_REVISAR_INSTITUICAO.value,
+                                        Permissao.ARTIGO_REVISAR_TODAS.value
+                                    ] %}
+                                    {% set ns = namespace(show=current_user.has_permissao('admin')) %}
+                                    {% for c in codes %}
+                                        {% if current_user.has_permissao(c) %}
+                                            {% set ns.show = True %}
+                                        {% endif %}
+                                    {% endfor %}
+                                    {% if ns.show %}
+                                        <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'aprovacao' else '' }}" href="{{ url_for('aprovacao') }}"><i class="bi bi-check2-square me-2"></i> Aprovação</a></li>
+                                    {% endif %}
                                 {% endif %}
                             </ul>
                         </div>
@@ -237,7 +245,7 @@
                     </li>
 
                     {# Bloco ADMINISTRAÇÃO (Só para Admins) #}
-                    {% if current_user and current_user.has_permissao('admin') %}
+                    {% if current_user.is_authenticated and current_user.has_permissao('admin') %}
                         <hr class="my-2">
                         <li class="nav-item">
                             <a class="nav-link d-flex justify-content-between align-items-center {{ 'active' if request.endpoint.startswith('admin_') else '' }} {{ 'collapsed' if not request.endpoint.startswith('admin_') }}"

--- a/templates/pagina_inicial.html
+++ b/templates/pagina_inicial.html
@@ -44,19 +44,26 @@
                 </div>
             </div>
         </div>
-        {% if current_user and (
-            current_user.has_permissao('admin') or
-            current_user.has_permissao(Permissao.ARTIGO_APROVAR_CELULA.value) or
-            current_user.has_permissao(Permissao.ARTIGO_APROVAR_SETOR.value) or
-            current_user.has_permissao(Permissao.ARTIGO_APROVAR_ESTABELECIMENTO.value) or
-            current_user.has_permissao(Permissao.ARTIGO_APROVAR_INSTITUICAO.value) or
-            current_user.has_permissao(Permissao.ARTIGO_APROVAR_TODAS.value) or
-            current_user.has_permissao(Permissao.ARTIGO_REVISAR_CELULA.value) or
-            current_user.has_permissao(Permissao.ARTIGO_REVISAR_SETOR.value) or
-            current_user.has_permissao(Permissao.ARTIGO_REVISAR_ESTABELECIMENTO.value) or
-            current_user.has_permissao(Permissao.ARTIGO_REVISAR_INSTITUICAO.value) or
-            current_user.has_permissao(Permissao.ARTIGO_REVISAR_TODAS.value)
-        ) %}
+        {% if current_user.is_authenticated %}
+            {% set codes = [
+                Permissao.ARTIGO_APROVAR_CELULA.value,
+                Permissao.ARTIGO_APROVAR_SETOR.value,
+                Permissao.ARTIGO_APROVAR_ESTABELECIMENTO.value,
+                Permissao.ARTIGO_APROVAR_INSTITUICAO.value,
+                Permissao.ARTIGO_APROVAR_TODAS.value,
+                Permissao.ARTIGO_REVISAR_CELULA.value,
+                Permissao.ARTIGO_REVISAR_SETOR.value,
+                Permissao.ARTIGO_REVISAR_ESTABELECIMENTO.value,
+                Permissao.ARTIGO_REVISAR_INSTITUICAO.value,
+                Permissao.ARTIGO_REVISAR_TODAS.value
+            ] %}
+            {% set ns = namespace(show=current_user.has_permissao('admin')) %}
+            {% for c in codes %}
+                {% if current_user.has_permissao(c) %}
+                    {% set ns.show = True %}
+                {% endif %}
+            {% endfor %}
+            {% if ns.show %}
         <div class="col-md-4 col-lg-3 mb-3">
             <div class="card text-center h-100">
                 <div class="card-body">
@@ -67,6 +74,7 @@
                 </div>
             </div>
         </div>
+            {% endif %}
         {% endif %}
     </div>
 

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -8,7 +8,7 @@
       <div class="card shadow-sm">
         <div class="card-body">
           <h3>Upload de Arquivo</h3>
-          {% if current_user and current_user.has_permissao('admin') %}
+          {% if current_user.is_authenticated %}
             <form method="POST" enctype="multipart/form-data">
               <div class="mb-3">
                 <input type="file" name="file" class="form-control" required>
@@ -16,9 +16,13 @@
               <button type="submit" class="btn btn-primary">Enviar</button>
             </form>
           {% else %}
-            <p class="text-muted">Você não possui permissão para enviar arquivos.</p>
+            <p class="text-muted">Faça login para enviar arquivos.</p>
           {% endif %}
-          <a href="{{ url_for('logout') }}" class="btn btn-link mt-3">Sair</a>
+          {% if current_user.is_authenticated %}
+            <a href="{{ url_for('logout') }}" class="btn btn-link mt-3">Sair</a>
+          {% else %}
+            <a href="{{ url_for('login') }}" class="btn btn-link mt-3">Entrar</a>
+          {% endif %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- reorganize permission checkboxes in `admin/cargos.html`
- simplify access checks for navigation and home page
- allow uploads for qualquer usuário logado
- refine authentication checks in various templates

## Testing
- `pytest -q` *(fails: OperationalError connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685c2b29deb8832ea34bb7633a86d4fd