### PR TITLE
Atualiza documentação sobre permissões

### DIFF
--- a/docs/DOCUMENTACAO_DO_SISTEMA.md
+++ b/docs/DOCUMENTACAO_DO_SISTEMA.md
@@ -147,8 +147,8 @@ ORQUETASK_PROJECT_ROOT/
 Uma visão geral dos principais modelos de dados implementados e planejados:
 
 * **User:**
-    * Campos: `id`, `username`, `email`, `password_hash`, `nome_completo`, `foto`, `role` (papel base), `matricula`, `cpf`, `rg`, `ramal`, `data_nascimento`, `data_admissao`, `telefone_contato`, `ativo` (status do usuário).
-    * Relacionamentos: `estabelecimento_id`, `setor_id`, `celula_id`, `cargo_id`. Liga-se a Artigos (autor), Notificações, Comentários, etc.
+    * Campos: `id`, `username`, `email`, `password_hash`, `nome_completo`, `foto`, `matricula`, `cpf`, `rg`, `ramal`, `data_nascimento`, `data_admissao`, `telefone_contato`, `ativo` (status do usuário).
+    * Relacionamentos: `estabelecimento_id`, `setor_id`, `celula_id`, `cargo_id`. Liga-se a Artigos (autor), Notificações, Comentários, etc. As permissões disponíveis para o usuário derivam do cargo e das funções extras cadastradas para ele.
 * **Estabelecimento:**
     * Campos: `id`, `codigo`, `nome_fantasia`, `razao_social`, `cnpj`, `inscricao_estadual`, `inscricao_municipal`, `tipo_estabelecimento`, `cep`, `logradouro`, `numero`, `complemento`, `bairro`, `cidade`, `estado`, `telefone_principal`, `email_contato`, `data_abertura`, `observacoes`, `ativo`.
 * **Setor:**
@@ -163,7 +163,7 @@ Uma visão geral dos principais modelos de dados implementados e planejados:
     * Campos: `id`, `titulo`, `texto`, `status` (Enum: Rascunho, Pendente, Aprovado, etc.), `user_id` (autor), `created_at`, `updated_at`.
     * Relacionamentos: Anexos, Comentários de Revisão.
 * **Attachment, Comment, Notification, RevisionRequest:** (Existentes, conforme detalhado anteriormente).
-* **Funcao (Permissão):** `id`, `codigo`, `nome`. Associada a `Cargo` e personalizações de `User`.
+* **Funcao (Permissão):** `id`, `codigo`, `nome`. Associada a `Cargo` e personalizações de `User`. Os códigos de permissão são definidos no enum `Permissao` (`enums.py`) e seguem o nível hierárquico em que a ação se aplica.
 * **(Futuro - Fase 3) OrdemServico, TarefaOS, etc.**
 * **(Futuro - Fase 4) Comunicado, Classificado, MensagemChat, etc.**
 

--- a/docs/TAREFAS_PERMISSOES.md
+++ b/docs/TAREFAS_PERMISSOES.md
@@ -33,14 +33,16 @@ partir das permissões cadastradas em `Funcao` e vinculadas aos `Cargos`.
 
 5. **Lista completa de funções**
    - Criar (ou atualizar) um script de seed que insira na tabela `funcao`
-     todas as funções disponíveis no sistema. As principais permissões de
-     artigos são:
-       - `artigo_criar`
-       - `artigo_editar`
-       - `artigo_aprovar`
-       - `artigo_revisar`
-       - `artigo_assumir_revisao`
-  - Utilizar essa lista para preencher os checkboxes de cargos e dos formulários de usuários.
+     todas as funções disponíveis no sistema. As permissões ligadas a
+     artigos agora são definidas pelo enum `Permissao` em `enums.py`, que
+     diferencia cada ação conforme o nível da hierarquia. Exemplos de
+     códigos:
+       - `ARTIGO_EDITAR_CELULA`
+       - `ARTIGO_APROVAR_SETOR`
+       - `ARTIGO_REVISAR_ESTABELECIMENTO`
+       - `ARTIGO_ASSUMIR_REVISAO_INSTITUICAO`
+   - Utilize essa lista para preencher os checkboxes de cargos e dos
+     formulários de usuários.
 6. **Reorganizar página de Cargos**
    - Alterar `admin/cargos.html` para exibir os cargos seguindo o fluxo de permissão:
      **Instituição → Estabelecimento → Setor → Célula → Cargo**.

--- a/docs/fluxo_permissoes.md
+++ b/docs/fluxo_permissoes.md
@@ -18,19 +18,26 @@ As permissões de cada usuário resultam das permissões do cargo somadas às pe
 
 ## Funções como Permissões
 
-Cada `Funcao` registrada no banco equivale a uma permissão específica, como `artigo_ler`, `artigo_criar` ou `artigo_aprovar_celula`. Um mesmo **Cargo** pode ter várias dessas funções associadas, assim como um usuário pode receber permissões extras além das herdadas do cargo. As checagens de acesso (em rotas ou templates) devem chamar `user.has_permissao(<codigo>)`.
+Cada `Funcao` registrada no banco equivale a uma permissão específica.
+O arquivo `enums.py` define o enum `Permissao`, que concentra todos os
+códigos ligados a artigos e diferencia cada ação pelo nível hierárquico
+em que se aplica. Um mesmo **Cargo** pode ter várias dessas funções
+associadas e o usuário ainda pode receber permissões extras além das
+herdadas do cargo. As checagens de acesso (em rotas ou templates) devem
+chamar `user.has_permissao(<codigo>)`.
 
 ```python
-# Criação de funções
-ler = Funcao(codigo="artigo_ler", nome="Ler artigos")
-criar = Funcao(codigo="artigo_criar", nome="Criar artigos")
-aprovar = Funcao(codigo="artigo_aprovar_celula", nome="Aprovar artigos na célula")
+# Criação de funções básicas de edição e aprovação
+from enums import Permissao
 
-db.session.add_all([ler, criar, aprovar])
+f1 = Funcao(codigo=Permissao.ARTIGO_EDITAR_CELULA.value, nome="Editar na célula")
+f2 = Funcao(codigo=Permissao.ARTIGO_APROVAR_SETOR.value, nome="Aprovar no setor")
+
+db.session.add_all([f1, f2])
 db.session.commit()
 
 # Associação das permissões a um cargo
-# (exemplo de associação de permissões a um cargo)
+# (exemplo de associação utilizando o enum)
 ```
 
 Para uma visão passo a passo das alterações pendentes e ações necessárias para consolidar esse modelo de permissões, consulte o documento [TAREFAS_PERMISSOES.md](./TAREFAS_PERMISSOES.md).


### PR DESCRIPTION
## Summary
- ajusta lista de permissões documentadas
- descreve enum `Permissao` e nova hierarquia de acesso
- remove referência ao campo `role` no modelo de usuário

## Testing
- `pytest -q` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685d321585c8832ead896b539499cad6