### PR TITLE
Implement article meta info

### DIFF
--- a/app.py
+++ b/app.py
@@ -1284,6 +1284,10 @@ def meus_artigos():
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
         art.local_created = dt.astimezone(ZoneInfo("America/Sao_Paulo"))
+        dt2 = art.updated_at or dt
+        if dt2.tzinfo is None:
+            dt2 = dt2.replace(tzinfo=timezone.utc)
+        art.local_updated = dt2.astimezone(ZoneInfo("America/Sao_Paulo"))
     return render_template(
         'meus_artigos.html',
         artigos=artigos,

--- a/templates/meus_artigos.html
+++ b/templates/meus_artigos.html
@@ -20,7 +20,8 @@
                 <div>
                   <div class="fw-bold">{{ artigo.titulo }}</div>
                   <small class="text-muted">
-                    {{ artigo.local_created.strftime('%d/%m/%Y %H:%M') }} |
+                    Criado em: {{ artigo.local_created.strftime('%d/%m/%Y %H:%M') }} |
+                    Atualizado em: {{ artigo.local_updated.strftime('%d/%m/%Y %H:%M') }} |
                     Visibilidade: {{ artigo.visibility.label }}
                   </small>
                 </div>

--- a/templates/pesquisar.html
+++ b/templates/pesquisar.html
@@ -24,7 +24,9 @@
             <div class="fw-bold">{{ artigo.titulo }}</div>
             <small class="text-muted">
               Criado em: {{ artigo.local_created.strftime('%d/%m/%Y %H:%M') }} |
-              Aprovado em: {{ artigo.local_aprovado.strftime('%d/%m/%Y %H:%M') }}
+              Aprovado em: {{ artigo.local_aprovado.strftime('%d/%m/%Y %H:%M') }} |
+              Autor: {{ artigo.author.nome_completo or artigo.author.username }} |
+              Setor: {{ artigo.author.setor.nome }}
             </small>
           </div>
 


### PR DESCRIPTION
## Summary
- show creation and update dates on the My Articles page
- display author and sector in search results

## Testing
- `pytest -q` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68839c365900832e9bb080ec753bdf1c