### PR TITLE
Add detailed metadata to approval list

### DIFF
--- a/app.py
+++ b/app.py
@@ -1527,8 +1527,15 @@ def aprovacao():
 
     for lista in (pendentes, revisados):
         for art in lista:
-            dt = art.updated_at or art.created_at
-            art.local_dt = dt.astimezone(ZoneInfo("America/Sao_Paulo"))
+            dt_created = art.created_at or datetime.now(timezone.utc)
+            if dt_created.tzinfo is None:
+                dt_created = dt_created.replace(tzinfo=timezone.utc)
+            art.local_created = dt_created.astimezone(ZoneInfo("America/Sao_Paulo"))
+
+            dt_updated = art.updated_at or dt_created
+            if dt_updated.tzinfo is None:
+                dt_updated = dt_updated.replace(tzinfo=timezone.utc)
+            art.local_updated = dt_updated.astimezone(ZoneInfo("America/Sao_Paulo"))
 
     return render_template(
         "aprovacao.html",

--- a/templates/partials/lista_aprovacao.html
+++ b/templates/partials/lista_aprovacao.html
@@ -8,7 +8,16 @@
            class="list-group-item list-group-item-action d-flex justify-content-between align-items-start">
           <div>
             <div class="fw-bold">{{ art.titulo }}</div>
-            <small class="text-muted">{{ art.local_dt.strftime('%d/%m/%Y %H:%M') }}</small>
+            <small class="text-muted">
+              <span class="fw-bold">Criado em:</span>
+              {{ art.local_created.strftime('%d/%m/%Y %H:%M') }} |
+              <span class="fw-bold">Atualizado em:</span>
+              {{ art.local_updated.strftime('%d/%m/%Y %H:%M') }} |
+              <span class="fw-bold">Autor:</span>
+              {{ art.author.nome_completo or art.author.username }} |
+              <span class="fw-bold">Setor:</span>
+              {{ art.author.setor.nome }}
+            </small>
           </div>
           <span class="badge rounded-pill bg-{{ st.color }} text-{{ st.text_color }}">
             {{ st.label }}


### PR DESCRIPTION
## Summary
- display more details in article approval list
- compute creation and update dates for approval view

## Testing
- `pytest -q` *(fails: OperationalError connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6883b3fe934c832ebced5b2010e40c4d