### PR TITLE
Improve card layout on search and user article pages

### DIFF
--- a/templates/meus_artigos.html
+++ b/templates/meus_artigos.html
@@ -6,7 +6,7 @@
 <div class="container-fluid px-5">
   <div class="row">
     <div class="col-md-10 mx-auto">
-    <div class="card shadow-sm">
+    <div class="card shadow-sm aprovacao-list">
       <div class="card-body">
         <h3>Meus Artigos</h3>
 

--- a/templates/pesquisar.html
+++ b/templates/pesquisar.html
@@ -16,11 +16,13 @@
       </div>
 
       {% if artigos %}
-      <div class="list-group">
-        {% for artigo in artigos %}
-        <a href="{{ url_for('artigo', artigo_id=artigo.id) }}"
-          class="list-group-item list-group-item-action d-flex justify-content-between align-items-start position-relative">
-          <div>
+      <div class="card shadow-sm mb-4 aprovacao-list">
+        <div class="card-body">
+        <div class="list-group">
+          {% for artigo in artigos %}
+          <a href="{{ url_for('artigo', artigo_id=artigo.id) }}"
+            class="list-group-item list-group-item-action d-flex justify-content-between align-items-start position-relative">
+            <div>
             <div class="fw-bold">{{ artigo.titulo }}</div>
             <small class="text-muted">
               <strong>Criado em:</strong>
@@ -43,8 +45,10 @@
           <i class="bi bi-copy text-secondary copy-link-icon"
             data-url="{{ url_for('artigo', artigo_id=artigo.id, _external=True) }}"
             style="position:absolute; bottom:5px; right:10px; cursor:pointer; font-size:1.2rem;"></i>
-        </a>
-        {% endfor %}
+          </a>
+          {% endfor %}
+        </div>
+        </div>
       </div>
       {% else %}
       <p class="text-muted mt-3">Nenhum artigo encontrado.</p>


### PR DESCRIPTION
## Summary
- update `pesquisar.html` to wrap results in a card with `aprovacao-list` styling
- add `aprovacao-list` class to card container in `meus_artigos.html`

## Testing
- `pytest -q` *(fails: OperationalError connecting to PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_6883b62fb3a8832eb873a9701aeb1010