### PR TITLE
Filtro de notificações conforme permissão

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,6 +79,7 @@ try:
         user_can_edit_article,
         user_can_approve_article,
         user_can_review_article,
+        eligible_review_notification_users,
     )
 except ImportError:  # pragma: no cover - fallback for direct execution
     from utils import (
@@ -93,6 +94,7 @@ except ImportError:  # pragma: no cover - fallback for direct execution
         user_can_edit_article,
         user_can_approve_article,
         user_can_review_article,
+        eligible_review_notification_users,
     )
 from mimetypes import guess_type # Se for usar, descomente
 from werkzeug.utils import secure_filename # Útil para uploads, como na sua foto de perfil
@@ -1232,23 +1234,7 @@ def novo_artigo():
 
         # 6) Notifica responsáveis/admins, se necessário
         if status is ArticleStatus.PENDENTE:
-            dest_perms = [
-                Permissao.ARTIGO_REVISAR_CELULA,
-                Permissao.ARTIGO_REVISAR_SETOR,
-                Permissao.ARTIGO_REVISAR_ESTABELECIMENTO,
-                Permissao.ARTIGO_REVISAR_INSTITUICAO,
-                Permissao.ARTIGO_REVISAR_TODAS,
-                Permissao.ARTIGO_APROVAR_CELULA,
-                Permissao.ARTIGO_APROVAR_SETOR,
-                Permissao.ARTIGO_APROVAR_ESTABELECIMENTO,
-                Permissao.ARTIGO_APROVAR_INSTITUICAO,
-                Permissao.ARTIGO_APROVAR_TODAS,
-            ]
-            destinatarios = [
-                u for u in User.query.all()
-                if u.has_permissao('admin')
-                or any(u.has_permissao(p.value) for p in dest_perms)
-            ]
+            destinatarios = eligible_review_notification_users(artigo)
             for dest in destinatarios:
                 notif = Notification(
                     user_id = dest.id,
@@ -1441,23 +1427,7 @@ def editar_artigo(artigo_id):
         if acao == "enviar":
             artigo.status = ArticleStatus.PENDENTE
             # 🔔 notifica responsáveis / admins
-            dest_perms = [
-                Permissao.ARTIGO_REVISAR_CELULA,
-                Permissao.ARTIGO_REVISAR_SETOR,
-                Permissao.ARTIGO_REVISAR_ESTABELECIMENTO,
-                Permissao.ARTIGO_REVISAR_INSTITUICAO,
-                Permissao.ARTIGO_REVISAR_TODAS,
-                Permissao.ARTIGO_APROVAR_CELULA,
-                Permissao.ARTIGO_APROVAR_SETOR,
-                Permissao.ARTIGO_APROVAR_ESTABELECIMENTO,
-                Permissao.ARTIGO_APROVAR_INSTITUICAO,
-                Permissao.ARTIGO_APROVAR_TODAS,
-            ]
-            destinatarios = [
-                u for u in User.query.all()
-                if u.has_permissao('admin')
-                or any(u.has_permissao(p.value) for p in dest_perms)
-            ]
+            destinatarios = eligible_review_notification_users(artigo)
             for dest in destinatarios:
                 n = Notification(
                     user_id = dest.id,

--- a/tests/test_notification_filtering.py
+++ b/tests/test_notification_filtering.py
@@ -1,0 +1,83 @@
+import os
+import pytest
+from io import BytesIO
+
+os.environ.setdefault('SECRET_KEY', 'test_secret')
+os.environ.setdefault('DATABASE_URI', 'sqlite:///:memory:')
+
+from app import app, db
+from models import (
+    Instituicao,
+    Estabelecimento,
+    Setor,
+    Celula,
+    User,
+    Funcao,
+    Notification,
+)
+from enums import Permissao
+
+
+def add_perm(user, code):
+    if isinstance(code, Permissao):
+        code = code.value
+    f = Funcao.query.filter_by(codigo=code).first()
+    if not f:
+        f = Funcao(codigo=code, nome=code)
+        db.session.add(f)
+        db.session.flush()
+    user.permissoes_personalizadas.append(f)
+    db.session.commit()
+
+
+@pytest.fixture
+def client_with_users():
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        inst = Instituicao(nome='Inst')
+        est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao=inst)
+        setor = Setor(nome='S1', estabelecimento=est)
+        cel1 = Celula(nome='C1', estabelecimento=est, setor=setor)
+        cel2 = Celula(nome='C2', estabelecimento=est, setor=setor)
+        db.session.add_all([inst, est, setor, cel1, cel2])
+        db.session.flush()
+        author = User(username='auth', email='a@test', password_hash='x',
+                      estabelecimento=est, setor=setor, celula=cel1)
+        ap1 = User(username='ap1', email='ap1@test', password_hash='x',
+                   estabelecimento=est, setor=setor, celula=cel1)
+        ap2 = User(username='ap2', email='ap2@test', password_hash='x',
+                   estabelecimento=est, setor=setor, celula=cel2)
+        db.session.add_all([author, ap1, ap2])
+        db.session.flush()
+        add_perm(author, 'artigo_criar')
+        add_perm(ap1, Permissao.ARTIGO_APROVAR_CELULA)
+        add_perm(ap2, Permissao.ARTIGO_APROVAR_CELULA)
+        db.session.commit()
+        data = {'author': author, 'ap1': ap1, 'ap2': ap2}
+        with app.test_client() as client:
+            yield client, data
+        db.session.remove()
+        db.drop_all()
+
+
+def login(client, user):
+    with client.session_transaction() as sess:
+        sess['user_id'] = user.id
+        sess['username'] = user.username
+
+
+def test_notification_only_for_allowed_users(client_with_users):
+    client, data = client_with_users
+    login(client, data['author'])
+    resp = client.post('/novo-artigo', data={
+        'titulo': 'T',
+        'texto': '<p>x</p>',
+        'acao': 'enviar',
+        'visibility': 'celula'
+    })
+    assert resp.status_code == 302
+    n1 = Notification.query.filter_by(user_id=data['ap1'].id).count()
+    n2 = Notification.query.filter_by(user_id=data['ap2'].id).count()
+    assert n1 == 1
+    assert n2 == 0

--- a/utils.py
+++ b/utils.py
@@ -370,3 +370,16 @@ def user_can_view_article(user, article):
             return True
 
     return False
+
+
+def eligible_review_notification_users(article):
+    """Retorna os usuários que devem ser notificados sobre a revisão do artigo."""
+    try:
+        from .models import User  # type: ignore  # pragma: no cover
+    except ImportError:  # pragma: no cover - fallback for direct execution
+        from models import User
+
+    return [
+        u for u in User.query.all()
+        if user_can_approve_article(u, article) or user_can_review_article(u, article)
+    ]


### PR DESCRIPTION
## Resumo
- enviar notificações de revisão apenas para usuários com permissão de acesso ao artigo
- adicionar utilitário `eligible_review_notification_users`
- cobrir cenário em novo teste

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c0e03154832e913b128c42a8f952