### PR TITLE
Implement OCR fallback for PDF attachments

### DIFF
--- a/docs/GUIA_DE_INSTALACAO.md
+++ b/docs/GUIA_DE_INSTALACAO.md
@@ -10,6 +10,7 @@ Antes de iniciar, certifique-se de que possui os seguintes softwares instalados 
 * **Git:** Para controle de versão e clonagem do repositório.
 * **PostgreSQL:** Sistema de gerenciamento de banco de dados, versão 12 ou superior.
 * **pgAdmin 4:** Interface gráfica para gerenciar o PostgreSQL (geralmente instalada junto com o PostgreSQL).
+* **Tesseract OCR:** Necessário para reconhecer texto em PDFs digitalizados.
 * Um **editor de código** de sua preferência (ex: VS Code, PyCharm, Sublime Text).
 * **Acesso à Internet.**
 * **Permissões de Administrador** no Windows (podem ser necessárias para algumas instalações).

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ Para rodar este projeto em um ambiente de desenvolvimento, você precisará ter 
 * Git
 * PostgreSQL (versão 12 ou superior)
 * (Opcional, mas recomendado para gerenciamento do DB) pgAdmin 4
+* Tesseract OCR instalado no sistema
 
 ## Como Rodar o Projeto (Desenvolvimento)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,5 @@ Werkzeug==3.1.3
 xlrd==2.0.1
 sendgrid==6.10.0
 pytest==8.1.1
+pytesseract==0.3.10
+pdf2image==1.17.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,3 +5,15 @@ import sys
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
+
+# Stub external OCR dependencies when not available
+import types
+if 'pdf2image' not in sys.modules:
+    pdf2image = types.ModuleType('pdf2image')
+    pdf2image.convert_from_path = lambda path: []
+    sys.modules['pdf2image'] = pdf2image
+
+if 'pytesseract' not in sys.modules:
+    pytesseract = types.ModuleType('pytesseract')
+    pytesseract.image_to_string = lambda img: ''
+    sys.modules['pytesseract'] = pytesseract

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
-from utils import sanitize_html
+from utils import sanitize_html, extract_text
+import types
 
 
 def test_sanitize_html_removes_disallowed_tags():
@@ -15,3 +16,37 @@ def test_sanitize_html_removes_disallowed_tags():
     assert "<script" not in cleaned
     assert "<span" not in cleaned
     assert "<div" not in cleaned
+
+
+def test_extract_text_image_pdf(monkeypatch, tmp_path):
+    pdf_file = tmp_path / "dummy.pdf"
+    pdf_file.write_bytes(b"%PDF-1.4")
+
+    class DummyPage:
+        def extract_text(self):
+            return None
+
+    class DummyReader:
+        def __init__(self, path):
+            pass
+
+        @property
+        def pages(self):
+            return [DummyPage(), DummyPage()]
+
+    monkeypatch.setattr("utils.PdfReader", DummyReader)
+    monkeypatch.setattr("utils.convert_from_path", lambda path: ["img1", "img2"])
+
+    calls = []
+
+    def fake_ocr(img):
+        calls.append(img)
+        return "Texto1" if img == "img1" else "Texto2"
+
+    monkeypatch.setattr("utils.pytesseract.image_to_string", fake_ocr)
+
+    text = extract_text(str(pdf_file))
+
+    assert "Texto1" in text
+    assert "Texto2" in text
+    assert calls == ["img1", "img2"]


### PR DESCRIPTION
## Summary
- add `pytesseract` and `pdf2image` dependencies
- allow extracting text from scanned PDFs via OCR
- document the need for Tesseract OCR
- provide stubs for OCR libs in tests
- test OCR code path for image PDFs

## Testing
- `pytest -q` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6887e2627b48832e8bcfd1cd2898040b