### PR TITLE
Fix blueprint import errors for Flask run

### DIFF
--- a/app.py
+++ b/app.py
@@ -219,7 +219,10 @@ def send_password_email(user: User, action: str) -> None:
 # -------------------------------------------------------------------------
 # DECORADORES
 # -------------------------------------------------------------------------
-from decorators import admin_required
+try:
+    from .decorators import admin_required
+except ImportError:  # pragma: no cover
+    from decorators import admin_required
 
 # -------------------------------------------------------------------------
 # Context Processors

--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -42,17 +42,32 @@ try:
 except ImportError:
     from enums import ArticleStatus
 
-from decorators import admin_required
-from utils import (
-    DEFAULT_NEW_USER_PASSWORD,
-    send_email,
-    generate_token,
-    eligible_review_notification_users,
-    user_can_view_article,
-    user_can_edit_article,
-    user_can_approve_article,
-    user_can_review_article,
-)
+try:
+    from ..decorators import admin_required
+except ImportError:  # pragma: no cover
+    from decorators import admin_required
+try:
+    from ..utils import (
+        DEFAULT_NEW_USER_PASSWORD,
+        send_email,
+        generate_token,
+        eligible_review_notification_users,
+        user_can_view_article,
+        user_can_edit_article,
+        user_can_approve_article,
+        user_can_review_article,
+    )
+except ImportError:  # pragma: no cover
+    from utils import (
+        DEFAULT_NEW_USER_PASSWORD,
+        send_email,
+        generate_token,
+        eligible_review_notification_users,
+        user_can_view_article,
+        user_can_edit_article,
+        user_can_approve_article,
+        user_can_review_article,
+    )
 import json
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo

--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -16,7 +16,26 @@ try:
 except ImportError:
     from enums import ArticleStatus, ArticleVisibility, Permissao
 
-from utils import sanitize_html, extract_text, eligible_review_notification_users, user_can_view_article, user_can_edit_article, user_can_approve_article, user_can_review_article
+try:
+    from ..utils import (
+        sanitize_html,
+        extract_text,
+        eligible_review_notification_users,
+        user_can_view_article,
+        user_can_edit_article,
+        user_can_approve_article,
+        user_can_review_article,
+    )
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from utils import (
+        sanitize_html,
+        extract_text,
+        eligible_review_notification_users,
+        user_can_view_article,
+        user_can_edit_article,
+        user_can_approve_article,
+        user_can_review_article,
+    )
 import time
 from zoneinfo import ZoneInfo
 from datetime import datetime, timezone

--- a/blueprints/auth.py
+++ b/blueprints/auth.py
@@ -9,7 +9,10 @@ try:
 except ImportError:
     from models import User
 
-from utils import generate_token, confirm_token, send_email, password_meets_requirements
+try:
+    from ..utils import generate_token, confirm_token, send_email, password_meets_requirements
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from utils import generate_token, confirm_token, send_email, password_meets_requirements
 
 auth_bp = Blueprint('auth_bp', __name__)
 


### PR DESCRIPTION
## Summary
- fix decorator imports in Flask app and admin blueprint
- adjust utils imports to fallback for direct execution
- fix relative imports for auth and article blueprints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887f7b790ec832ebf34e52e310c67c6