### PR TITLE
Replace Tesseract with PaddleOCR

### DIFF
--- a/docs/GUIA_DE_INSTALACAO.md
+++ b/docs/GUIA_DE_INSTALACAO.md
@@ -10,7 +10,7 @@ Antes de iniciar, certifique-se de que possui os seguintes softwares instalados 
 * **Git:** Para controle de versão e clonagem do repositório.
 * **PostgreSQL:** Sistema de gerenciamento de banco de dados, versão 12 ou superior.
 * **pgAdmin 4:** Interface gráfica para gerenciar o PostgreSQL (geralmente instalada junto com o PostgreSQL).
-* **Tesseract OCR:** Necessário para reconhecer texto em PDFs digitalizados.
+* **PaddleOCR:** Dependência para reconhecer texto em PDFs digitalizados.
 * Um **editor de código** de sua preferência (ex: VS Code, PyCharm, Sublime Text).
 * **Acesso à Internet.**
 * **Permissões de Administrador** no Windows (podem ser necessárias para algumas instalações).

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ Para rodar este projeto em um ambiente de desenvolvimento, você precisará ter 
 * Git
 * PostgreSQL (versão 12 ou superior)
 * (Opcional, mas recomendado para gerenciamento do DB) pgAdmin 4
-* Tesseract OCR instalado no sistema
+* Dependências do PaddleOCR instaladas (paddleocr, paddlepaddle, numpy)
 
 ## Como Rodar o Projeto (Desenvolvimento)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,5 +28,6 @@ Werkzeug==3.1.3
 xlrd==2.0.1
 sendgrid==6.10.0
 pytest==8.1.1
-pytesseract==0.3.10
+paddleocr==2.7.0.3
 pdf2image==1.17.0
+numpy==1.26.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,10 +18,18 @@ if 'pdf2image' not in sys.modules:
     pdf2image.convert_from_path = lambda path: []
     sys.modules['pdf2image'] = pdf2image
 
-if 'pytesseract' not in sys.modules:
-    pytesseract = types.ModuleType('pytesseract')
-    pytesseract.image_to_string = lambda img: ''
-    sys.modules['pytesseract'] = pytesseract
+if 'paddleocr' not in sys.modules:
+    paddleocr = types.ModuleType('paddleocr')
+
+    class DummyOCR:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def ocr(self, img, cls=False):
+            return []
+
+    paddleocr.PaddleOCR = DummyOCR
+    sys.modules['paddleocr'] = paddleocr
 
 import pytest
 from app import app, db

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,11 +43,15 @@ def test_extract_text_image_pdf(monkeypatch, tmp_path):
 
     monkeypatch.setattr("utils.convert_from_path", fake_convert)
 
-    def fake_ocr(img, **kwargs):
-        calls.append(img)
-        return "Texto1" if img == "img1" else "Texto2"
+    class FakeOCR:
+        def ocr(self, img, **kwargs):
+            calls.append(img)
+            if img == "img1":
+                return [[(None, ("", "Texto1"))]]
+            return [[(None, ("", "Texto2"))]]
 
-    monkeypatch.setattr("utils.pytesseract.image_to_string", fake_ocr)
+    monkeypatch.setattr("utils.paddle_ocr", FakeOCR())
+    monkeypatch.setattr("utils.np", types.SimpleNamespace(array=lambda x: x))
 
     text = extract_text(str(pdf_file))
 


### PR DESCRIPTION
## Summary
- switch OCR engine from pytesseract to PaddleOCR
- adjust utils to run PaddleOCR on PDF images
- update tests to stub PaddleOCR usage
- update installation docs for PaddleOCR
- update dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68890d09138c832ebfaa642c3160c2a6