### PR TITLE
Atualiza OCR de PDFs com PyMuPDF e PaddleOCR

### DIFF
--- a/docs/DOCUMENTACAO_DO_SISTEMA.md
+++ b/docs/DOCUMENTACAO_DO_SISTEMA.md
@@ -95,7 +95,8 @@ O **Orquetask** é um sistema web integrado, desenvolvido em Python com o framew
     * `openpyxl` (Extração de texto de arquivos `.xlsx`)
     * `xlrd` (Extração de texto de arquivos `.xls` antigos)
     * `odfpy` (Extração de texto de arquivos `.ods`)
-    * `PyPDF2` (Extração de texto de arquivos `.pdf`)
+    * `PyMuPDF` (Leitura e renderização de arquivos `.pdf`)
+    * `PaddleOCR` (OCR para PDFs escaneados)
 
 ## 4. Estrutura de Diretórios Principal
 ```text

--- a/docs/GUIA_DE_INSTALACAO.md
+++ b/docs/GUIA_DE_INSTALACAO.md
@@ -10,7 +10,6 @@ Antes de iniciar, certifique-se de que possui os seguintes softwares instalados 
 * **Git:** Para controle de versão e clonagem do repositório.
 * **PostgreSQL:** Sistema de gerenciamento de banco de dados, versão 12 ou superior.
 * **pgAdmin 4:** Interface gráfica para gerenciar o PostgreSQL (geralmente instalada junto com o PostgreSQL).
-* **Tesseract OCR:** Necessário para reconhecer texto em PDFs digitalizados.
 * Um **editor de código** de sua preferência (ex: VS Code, PyCharm, Sublime Text).
 * **Acesso à Internet.**
 * **Permissões de Administrador** no Windows (podem ser necessárias para algumas instalações).

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ Orquetask é um sistema web integrado construído com Flask e Python, projetado 
 * **Frontend:** HTML5, CSS3 (Bootstrap 5), JavaScript (Vanilla JS), Quill.js
 * **Banco de Dados:** PostgreSQL
 * **ORM / Migrations:** SQLAlchemy, Alembic (via Flask-SQLAlchemy, Flask-Migrate)
-* **Principais Bibliotecas:** Werkzeug, Jinja2, psycopg2-binary, python-docx, openpyxl, xlrd, odfpy, PyPDF2, Bleach, python-dotenv.
+* **Principais Bibliotecas:** Werkzeug, Jinja2, psycopg2-binary, python-docx, openpyxl, xlrd, odfpy, PyMuPDF, PaddleOCR, Bleach, python-dotenv.
 
 ## Pré-requisitos
 
@@ -38,7 +38,6 @@ Para rodar este projeto em um ambiente de desenvolvimento, você precisará ter 
 * Git
 * PostgreSQL (versão 12 ou superior)
 * (Opcional, mas recomendado para gerenciamento do DB) pgAdmin 4
-* Tesseract OCR instalado no sistema
 
 ## Como Rodar o Projeto (Desenvolvimento)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ MarkupSafe==3.0.2
 odfpy==1.4.1
 openpyxl==3.1.5
 psycopg2-binary==2.9.10
-PyPDF2==3.0.1
 python-docx==1.1.2
 SQLAlchemy==2.0.41
 tinycss2==1.4.0
@@ -28,5 +27,6 @@ Werkzeug==3.1.3
 xlrd==2.0.1
 sendgrid==6.10.0
 pytest==8.1.1
-pytesseract==0.3.10
-pdf2image==1.17.0
+pymupdf==1.23.22
+paddleocr==2.7.0.3
+paddlepaddle==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,6 @@ Werkzeug==3.1.3
 xlrd==2.0.1
 sendgrid==6.10.0
 pytest==8.1.1
-pymupdf==1.23.22
+pymupdf==1.20.2
 paddleocr==2.7.0.3
 paddlepaddle==2.6.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,15 +13,24 @@ os.environ['DATABASE_URI'] = 'sqlite:///:memory:'
 
 # Stub external OCR dependencies when not available
 import types
-if 'pdf2image' not in sys.modules:
-    pdf2image = types.ModuleType('pdf2image')
-    pdf2image.convert_from_path = lambda path: []
-    sys.modules['pdf2image'] = pdf2image
+if 'fitz' not in sys.modules:
+    fitz = types.ModuleType('fitz')
+    fitz.open = lambda path: None
+    sys.modules['fitz'] = fitz
 
-if 'pytesseract' not in sys.modules:
-    pytesseract = types.ModuleType('pytesseract')
-    pytesseract.image_to_string = lambda img: ''
-    sys.modules['pytesseract'] = pytesseract
+if 'paddleocr' not in sys.modules:
+    paddleocr = types.ModuleType('paddleocr')
+
+    class DummyOCR:
+        def __init__(self, *a, **k):
+            pass
+
+        def ocr(self, img, **k):
+            return []
+
+    paddleocr.PaddleOCR = DummyOCR
+    sys.modules['paddleocr'] = paddleocr
+
 
 import pytest
 from app import app, db


### PR DESCRIPTION
## Resumo
- remove pdf2image, pytesseract e PyPDF2
- utiliza PyMuPDF para ler PDFs
- integra PaddleOCR para OCR de páginas sem texto
- ajusta testes para novas dependências
- atualiza documentação e requirements

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688912f2b1a0832e8ab5e5b68a9b6d75