### PR TITLE
Switch PDF OCR to pdf2image

### DIFF
--- a/docs/DOCUMENTACAO_DO_SISTEMA.md
+++ b/docs/DOCUMENTACAO_DO_SISTEMA.md
@@ -95,7 +95,7 @@ O **Orquetask** é um sistema web integrado, desenvolvido em Python com o framew
     * `openpyxl` (Extração de texto de arquivos `.xlsx`)
     * `xlrd` (Extração de texto de arquivos `.xls` antigos)
     * `odfpy` (Extração de texto de arquivos `.ods`)
-    * `PyMuPDF` (Leitura e renderização de arquivos `.pdf`)
+    * `pdf2image` (Conversão de PDFs em imagens para OCR)
     * `PaddleOCR` (OCR para PDFs escaneados)
 
 ## 4. Estrutura de Diretórios Principal

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ Orquetask é um sistema web integrado construído com Flask e Python, projetado 
 * **Frontend:** HTML5, CSS3 (Bootstrap 5), JavaScript (Vanilla JS), Quill.js
 * **Banco de Dados:** PostgreSQL
 * **ORM / Migrations:** SQLAlchemy, Alembic (via Flask-SQLAlchemy, Flask-Migrate)
-* **Principais Bibliotecas:** Werkzeug, Jinja2, psycopg2-binary, python-docx, openpyxl, xlrd, odfpy, PyMuPDF, PaddleOCR, Bleach, python-dotenv.
+* **Principais Bibliotecas:** Werkzeug, Jinja2, psycopg2-binary, python-docx, openpyxl, xlrd, odfpy, pdf2image, PaddleOCR, Bleach, python-dotenv.
 
 ## Pré-requisitos
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,7 @@ Werkzeug==3.1.3
 xlrd==2.0.1
 sendgrid==6.10.0
 pytest==8.1.1
+pdf2image==1.17.0
+paddleocr==2.7.0.3
+paddlepaddle==2.6.1
+Pillow==10.3.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,10 +13,10 @@ os.environ['DATABASE_URI'] = 'sqlite:///:memory:'
 
 # Stub external OCR dependencies when not available
 import types
-if 'fitz' not in sys.modules:
-    fitz = types.ModuleType('fitz')
-    fitz.open = lambda path: None
-    sys.modules['fitz'] = fitz
+if 'pdf2image' not in sys.modules:
+    pdf2image = types.ModuleType('pdf2image')
+    pdf2image.convert_from_path = lambda *a, **k: []
+    sys.modules['pdf2image'] = pdf2image
 
 if 'paddleocr' not in sys.modules:
     paddleocr = types.ModuleType('paddleocr')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,28 +22,9 @@ def test_extract_text_image_pdf(monkeypatch, tmp_path):
     pdf_file = tmp_path / "dummy.pdf"
     pdf_file.write_bytes(b"%PDF-1.4")
 
-    class DummyPage:
-        def get_text(self):
-            return ""
-
-        def get_pixmap(self, dpi=200):
-            class Pix:
-                def tobytes(self, fmt):
-                    return b"data"
-
-            return Pix()
-
-    class DummyDoc:
-        def __init__(self, path):
-            pass
-
-        def __iter__(self):
-            return iter([DummyPage(), DummyPage()])
-
-        def close(self):
-            pass
-
-    monkeypatch.setattr("utils.fitz.open", lambda p: DummyDoc(p))
+    img1 = object()
+    img2 = object()
+    monkeypatch.setattr("utils.convert_from_path", lambda p, dpi=200: [img1, img2])
 
     calls = []
 
@@ -53,9 +34,8 @@ def test_extract_text_image_pdf(monkeypatch, tmp_path):
             return [[None, ("Texto1" if len(calls) == 1 else "Texto2", 1.0)]]
 
     monkeypatch.setattr("utils.get_ocr_engine", lambda: DummyOCR())
-    monkeypatch.setattr("utils.Image", types.SimpleNamespace(open=lambda b: b))
-    monkeypatch.setattr("utils.BytesIO", lambda b: b)
     monkeypatch.setattr("utils.np", types.SimpleNamespace(array=lambda x: x))
+    monkeypatch.setattr("utils.Image", object())
 
     text = extract_text(str(pdf_file))
 


### PR DESCRIPTION
## Summary
- replace PyMuPDF usage with pdf2image
- fall back when optional packages are missing
- adjust OCR function and unit tests
- document the new libraries
- update requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889354175e0832ea9c66a8cec9c4c32