### PR TITLE
Implement infinite scrolling for notifications

### DIFF
--- a/app.py
+++ b/app.py
@@ -217,6 +217,31 @@ def send_password_email(user: User, action: str) -> None:
     send_email(user.email, 'Definição de Senha', html)
 
 # -------------------------------------------------------------------------
+# NOTIFICAÇÕES - API
+# -------------------------------------------------------------------------
+@app.route('/api/notifications')
+def api_notifications():
+    """Retorna notificações paginadas para o usuário atual."""
+    if 'user_id' not in session:
+        return jsonify({'error': 'unauthorized'}), 401
+
+    offset = int(request.args.get('offset', 0))
+    limit = int(request.args.get('limit', 10))
+    notifs = (
+        Notification.query
+        .filter_by(user_id=session['user_id'], lido=False)
+        .order_by(Notification.created_at.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+
+    return jsonify([
+        {'id': n.id, 'message': n.message, 'url': n.url}
+        for n in notifs
+    ])
+
+# -------------------------------------------------------------------------
 # DECORADORES
 # -------------------------------------------------------------------------
 try:

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -131,3 +131,9 @@ body > .container {
   justify-content: center;
   z-index: 1055;
 }
+
+/* Área de notificações com rolagem */
+#notificationMenu {
+  max-height: 300px;
+  overflow-y: auto;
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -105,6 +105,57 @@ document.addEventListener("DOMContentLoaded", function () {
       // alterados dinamicamente (o que não é o caso agora, mas não prejudica).
       attachClickListeners();
     });
+
+    const menu = document.getElementById("notificationMenu");
+    if (menu) {
+      let offset = menu.querySelectorAll(".notification-link").length;
+      const limit = 10;
+      let loading = false;
+      let endReached = false;
+
+      function appendNotifications(items) {
+        if (items.length === 0) {
+          endReached = true;
+          return;
+        }
+        for (const n of items) {
+          const li = document.createElement("li");
+          const a = document.createElement("a");
+          a.href = n.url;
+          a.textContent = n.message;
+          a.className = "dropdown-item notification-link fw-bold";
+          a.dataset.id = n.id;
+          li.appendChild(a);
+          menu.appendChild(li);
+        }
+        refreshLinks();
+        styleLinks();
+        attachClickListeners();
+      }
+
+      function loadMore() {
+        if (loading || endReached) return;
+        loading = true;
+        fetch(`/api/notifications?offset=${offset}&limit=${limit}`)
+          .then((r) => r.json())
+          .then((data) => {
+            appendNotifications(data);
+            offset += data.length;
+            updateBadge();
+          })
+          .finally(() => {
+            loading = false;
+          });
+      }
+
+      menu.addEventListener("scroll", () => {
+        if (
+          menu.scrollTop + menu.clientHeight >= menu.scrollHeight - 5
+        ) {
+          loadMore();
+        }
+      });
+    }
   }
 
   // --- NOVA FUNÇÃO GLOBAL PARA MARCAR NOTIFICAÇÃO PELA URL ---

--- a/templates/base.html
+++ b/templates/base.html
@@ -147,7 +147,7 @@
                             <i class="bi bi-bell-fill fs-5"></i>
                             <span id="notificationBadge" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" style="font-size: 0.65rem; transform: translate(-100%, 40%) !important; display: none;" data-server-count="{{ notificacoes }}"></span>
                         </a>
-                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="notificationDropdown">
+                        <ul class="dropdown-menu dropdown-menu-end" id="notificationMenu" aria-labelledby="notificationDropdown">
                             {% if notificacoes_list %}{% for n in notificacoes_list %}<li><a href="{{ n.url }}" class="dropdown-item notification-link fw-bold" data-id="{{ n.id }}">{{ n.message }}</a></li>{% endfor %}
                             {% else %}<li><a class="dropdown-item text-muted" href="#">Nenhuma notificação</a></li>{% endif %}
                         </ul>

--- a/tests/test_notification_pagination.py
+++ b/tests/test_notification_pagination.py
@@ -1,0 +1,48 @@
+import pytest
+from app import app, db
+from models import Notification, User, Instituicao, Estabelecimento, Setor, Celula
+
+@pytest.fixture
+def client_with_notifications(app_ctx):
+    with app.app_context():
+        inst = Instituicao(nome='Inst')
+        est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao=inst)
+        setor = Setor(nome='S1', estabelecimento=est)
+        cel = Celula(nome='C1', estabelecimento=est, setor=setor)
+        db.session.add_all([inst, est, setor, cel])
+        db.session.flush()
+        user = User(username='u', email='u@test', password_hash='x',
+                    estabelecimento=est, setor=setor, celula=cel)
+        db.session.add(user)
+        db.session.flush()
+        for i in range(25):
+            n = Notification(user_id=user.id, message=f'N{i}', url='#')
+            db.session.add(n)
+        db.session.commit()
+        with app_ctx.test_client() as client:
+            client.user = user
+            yield client
+
+def login(client):
+    with client.session_transaction() as sess:
+        sess['user_id'] = client.user.id
+        sess['username'] = client.user.username
+
+def test_api_requires_login(client_with_notifications):
+    client = client_with_notifications
+    resp = client.get('/api/notifications')
+    assert resp.status_code == 401
+
+def test_notifications_pagination(client_with_notifications):
+    client = client_with_notifications
+    login(client)
+    resp = client.get('/api/notifications?offset=0&limit=10')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 10
+    resp2 = client.get('/api/notifications?offset=10&limit=10')
+    data2 = resp2.get_json()
+    assert len(data2) == 10
+    resp3 = client.get('/api/notifications?offset=20&limit=10')
+    data3 = resp3.get_json()
+    assert len(data3) == 5


### PR DESCRIPTION
## Summary
- add `/api/notifications` endpoint to serve notifications in pages
- style dropdown menu and enable scrolling
- implement client-side infinite scroll in `main.js`
- adjust base layout to use `notificationMenu` id
- test notifications pagination API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688b67ce9234832e9dc212c964e792ed