### PR TITLE
Improve notification badge count

### DIFF
--- a/app.py
+++ b/app.py
@@ -257,14 +257,16 @@ def inject_notificacoes():
     if 'user_id' in session: # Usar user_id é mais seguro que username para buscar no banco
         user = User.query.get(session['user_id']) # Usar .get() é mais direto para PK
         if user:
-            notifs = (Notification.query
-                      .filter_by(user_id=user.id, lido=False)
-                      .order_by(Notification.created_at.desc())
-                      .limit(10)
-                      .all())
+            q = Notification.query.filter_by(user_id=user.id, lido=False)
+            total_unread = q.count()
+            notifs = (
+                q.order_by(Notification.created_at.desc())
+                 .limit(10)
+                 .all()
+            )
             return {
-                'notificacoes': len(notifs), # Passa a contagem diretamente
-                'notificacoes_list': notifs
+                'notificacoes': total_unread,
+                'notificacoes_list': notifs,
             }
     return {'notificacoes': 0, 'notificacoes_list': []}
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -49,10 +49,12 @@ document.addEventListener("DOMContentLoaded", function () {
   function updateBadge() {
     if (!badge) return;
     // Não precisa chamar refreshLinks() aqui se já foi chamado antes de styleLinks e updateBadge
-    const unread = links.reduce(
+    const serverCount = parseInt(badge.dataset.serverCount || '0');
+    const domCount = links.reduce(
       (acc, link) => acc + (readIds.includes(link.dataset.id) ? 0 : 1),
       0
     );
+    const unread = Math.max(serverCount, domCount);
     badge.style.display = unread > 0 ? "inline-block" : "none";
     badge.textContent = unread;
   }
@@ -62,6 +64,12 @@ document.addEventListener("DOMContentLoaded", function () {
     if (!readIds.includes(notificationId)) {
       readIds.push(notificationId);
       localStorage.setItem(READ_KEY, JSON.stringify(readIds));
+      if (badge && badge.dataset.serverCount) {
+        const c = parseInt(badge.dataset.serverCount);
+        if (c > 0) {
+          badge.dataset.serverCount = c - 1;
+        }
+      }
     }
     if (linkElement) {
       linkElement.classList.remove("fw-bold");


### PR DESCRIPTION
## Summary
- show real unread notification count in context
- display server-provided count from DOM when rendering badge
- decrement server count when marking notifications read

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b77890794832ea814d1fa7b80e5db