### PR TITLE
Improve notification badge count

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -49,10 +49,12 @@ document.addEventListener("DOMContentLoaded", function () {
   function updateBadge() {
     if (!badge) return;
     // Não precisa chamar refreshLinks() aqui se já foi chamado antes de styleLinks e updateBadge
-    const unread = links.reduce(
+    const serverCount = parseInt(badge.dataset.serverCount || '0', 10);
+    const domCount = links.reduce(
       (acc, link) => acc + (readIds.includes(link.dataset.id) ? 0 : 1),
       0
     );
+    const unread = Math.max(serverCount, domCount);
     badge.style.display = unread > 0 ? "inline-block" : "none";
     badge.textContent = unread;
   }
@@ -62,6 +64,14 @@ document.addEventListener("DOMContentLoaded", function () {
     if (!readIds.includes(notificationId)) {
       readIds.push(notificationId);
       localStorage.setItem(READ_KEY, JSON.stringify(readIds));
+      if (badge && badge.dataset.serverCount) {
+        const c = parseInt(badge.dataset.serverCount, 10);
+        if (c > 0) {
+          badge.dataset.serverCount = String(c - 1);
+        }
+      }
+      // Persiste no servidor
+      fetch(`/api/notifications/${notificationId}/read`, { method: 'POST' });
     }
     if (linkElement) {
       linkElement.classList.remove("fw-bold");

--- a/tests/test_notification_read.py
+++ b/tests/test_notification_read.py
@@ -1,0 +1,48 @@
+import pytest
+from app import app, db
+from models import Notification, User, Instituicao, Estabelecimento, Setor, Celula
+
+@pytest.fixture
+def client_with_notification(app_ctx):
+    with app.app_context():
+        inst = Instituicao(nome='Inst')
+        est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao=inst)
+        setor = Setor(nome='S1', estabelecimento=est)
+        cel = Celula(nome='C1', estabelecimento=est, setor=setor)
+        db.session.add_all([inst, est, setor, cel])
+        db.session.flush()
+        user = User(username='u', email='u@test', password_hash='x',
+                    estabelecimento=est, setor=setor, celula=cel)
+        db.session.add(user)
+        db.session.flush()
+        notif = Notification(user_id=user.id, message='N', url='#')
+        db.session.add(notif)
+        db.session.commit()
+        with app_ctx.test_client() as client:
+            client.user = user
+            client.notification = notif
+            yield client
+
+
+def login(client):
+    with client.session_transaction() as sess:
+        sess['user_id'] = client.user.id
+        sess['username'] = client.user.username
+
+
+def test_mark_notification_read(client_with_notification):
+    client = client_with_notification
+    login(client)
+    nid = client.notification.id
+    resp = client.post(f'/api/notifications/{nid}/read')
+    assert resp.status_code == 200
+    with app.app_context():
+        n = Notification.query.get(nid)
+        assert n.lido is True
+
+
+def test_mark_notification_read_requires_login(client_with_notification):
+    client = client_with_notification
+    nid = client.notification.id
+    resp = client.post(f'/api/notifications/{nid}/read')
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- show real unread notification count in context
- display server-provided count from DOM when rendering badge
- decrement server count when marking notifications read
- refine parsing for badge data attributes
- persist read state on server via new endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b77890794832ea814d1fa7b80e5db