### PR TITLE
Improve OCR workflow with OpenCV

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ sendgrid==6.10.0
 pytest==8.1.1
 pdf2image==1.17.0
 pytesseract==0.3.10
+opencv-python==4.10.0.82

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,9 +22,11 @@ def test_extract_text_image_pdf(monkeypatch, tmp_path):
     pdf_file = tmp_path / "dummy.pdf"
     pdf_file.write_bytes(b"%PDF-1.4")
 
-    img1 = object()
-    img2 = object()
-    monkeypatch.setattr("utils.convert_from_path", lambda p, dpi=200: [img1, img2])
+    from PIL import Image
+
+    img1 = Image.new("RGB", (10, 10), color="white")
+    img2 = Image.new("RGB", (10, 10), color="black")
+    monkeypatch.setattr("utils.convert_from_path", lambda p, dpi=300: [img1, img2])
 
     calls = []
 
@@ -33,7 +35,7 @@ def test_extract_text_image_pdf(monkeypatch, tmp_path):
         return "Texto1" if len(calls) == 1 else "Texto2"
 
     monkeypatch.setattr("utils.pytesseract", types.SimpleNamespace(image_to_string=dummy_image_to_string))
-    monkeypatch.setattr("utils.Image", object())
+    monkeypatch.setattr("utils.preprocess_image", lambda img, **k: img)
 
     text = extract_text(str(pdf_file))
 


### PR DESCRIPTION
## Summary
- add opencv-python dependency
- preprocess PDF pages with OpenCV before OCR
- expose `preprocess_image` and `extract_text_from_image`
- update tests to use real images and new OCR flow

## Testing
- `pip install -r requirements.txt` *(fails: Could not find opencv-python due to network restrictions)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bd69cd148832ea9590e35f6748a8a