### PR TITLE
feat: separa notificacoes de ordens de servico

### DIFF
--- a/migrations/versions/7322f65d4686_add_notification_tipo.py
+++ b/migrations/versions/7322f65d4686_add_notification_tipo.py
@@ -1,0 +1,35 @@
+"""add notification tipo
+
+Revision ID: 7322f65d4686
+Revises: bb1d9e24176f
+Create Date: 2025-08-01 17:15:20.814777
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '7322f65d4686'
+down_revision = 'bb1d9e24176f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Add 'tipo' column to notification"""
+    with op.batch_alter_table("notification") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "tipo",
+                sa.String(length=20),
+                nullable=False,
+                server_default="geral",
+            )
+        )
+
+
+def downgrade():
+    """Remove 'tipo' column from notification"""
+    with op.batch_alter_table("notification") as batch_op:
+        batch_op.drop_column("tipo")

--- a/models.py
+++ b/models.py
@@ -392,6 +392,7 @@ class Notification(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False) # Para quem é a notificação
     message = db.Column(db.String(255), nullable=False)
     url = db.Column(db.String(255), nullable=False) # nullable=False conforme última migration
+    tipo = db.Column(db.String(20), nullable=False, default='geral', server_default='geral')
     lido = db.Column(db.Boolean, nullable=False, default=False, server_default='false')
     created_at = db.Column(db.DateTime(timezone=True), server_default=func.now(), nullable=False)
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -152,6 +152,18 @@
                             {% else %}<li><a class="dropdown-item text-muted" href="#">Nenhuma notificação</a></li>{% endif %}
                         </ul>
                     </li>
+
+                    {# Notificações de Ordens de Serviço #}
+                    <li class="nav-item dropdown me-2">
+                        <a class="nav-link position-relative" href="#" id="osNotificationDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            <i class="bi bi-clipboard-check fs-5"></i>
+                            <span id="osNotificationBadge" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" style="font-size: 0.65rem; transform: translate(-100%, 40%) !important; display: none;" data-server-count="{{ os_notificacoes }}"></span>
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-end" id="osNotificationMenu" aria-labelledby="osNotificationDropdown">
+                            {% if os_notificacoes_list %}{% for n in os_notificacoes_list %}<li><a href="{{ n.url }}" class="dropdown-item os-notification-link fw-bold" data-id="{{ n.id }}">{{ n.message }}</a></li>{% endfor %}
+                            {% else %}<li><a class="dropdown-item text-muted" href="#">Nenhuma notificação</a></li>{% endif %}
+                        </ul>
+                    </li>
                     
                     {# Foto/Nome do Usuário como LINK DIRETO para o Perfil #}
                     <li class="nav-item">


### PR DESCRIPTION
## Summary
- categorize `Notification` model by adding `tipo`
- create API endpoint for OS notifications
- support OS notification dropdown in base template
- manage OS notifications in JS
- add migration for new column

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cd5ba5d98832eb31fb269adb5b930