### PR TITLE
Atualiza documentação e migrações

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -5,7 +5,7 @@ Este documento descreve os passos para implantar a aplicação **OrqueTask** em 
 Esta versão inclui o módulo **Processos**, que define fluxos compostos por etapas e campos dinâmicos. Certifique-se de aplicar as migrações mais recentes antes de executar o sistema.
 
 ## 1. Pré-requisitos
-- Python 3.9 ou superior
+ - Python 3.11 (ou 3.10) instalado
 - Git
 - PostgreSQL 12 ou superior (recomenda-se o uso do pgAdmin para administração)
 - Poppler para conversão de PDFs

--- a/docs/DOCUMENTACAO_DO_SISTEMA.md
+++ b/docs/DOCUMENTACAO_DO_SISTEMA.md
@@ -74,7 +74,7 @@ O **Orquetask** é um sistema web integrado, desenvolvido em Python com o framew
 ## 3. Arquitetura e Tecnologias
 
 * **Backend:**
-    * Linguagem: Python (3.9+)
+    * Linguagem: Python (3.11+)
     * Framework: Flask
 * **Frontend:**
     * HTML5, CSS3, JavaScript (Vanilla)

--- a/docs/GUIA_DE_INSTALACAO.md
+++ b/docs/GUIA_DE_INSTALACAO.md
@@ -6,7 +6,7 @@ Este guia detalha os passos necessários para configurar e executar o projeto Or
 
 Antes de iniciar, certifique-se de que possui os seguintes softwares instalados em sua máquina:
 
-* **Python:** Versão 3.9 ou superior.
+* **Python:** Versão 3.11 (recomendado) ou 3.10.
 * **Git:** Para controle de versão e clonagem do repositório.
 * **PostgreSQL:** Sistema de gerenciamento de banco de dados, versão 12 ou superior.
 * **pgAdmin 4:** Interface gráfica para gerenciar o PostgreSQL (geralmente instalada junto com o PostgreSQL).
@@ -171,6 +171,9 @@ configurá-las corretamente.
 Com o ambiente virtual (`venv`) ativo:
 ```bash
 pip install -r requirements.txt
+# Se ocorrerem erros de compilação (lxml, numpy ou opencv),
+# execute a reinstalação a seguir para Python 3.11:
+pip install --force-reinstall lxml "numpy<2" opencv-python python-docx
 ```
 
 ## 10. Configurar Variáveis de Ambiente Essenciais (no Windows)

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ Orquetask é um sistema web integrado construído com Flask e Python, projetado 
 ## Pré-requisitos
 
 Para rodar este projeto em um ambiente de desenvolvimento, você precisará ter instalado:
-* Python (versão 3.9 ou superior recomendado)
+* Python (versão 3.11 recomendada – 3.10 também é compatível)
 * Git
 * PostgreSQL (versão 12 ou superior)
 * (Opcional, mas recomendado para gerenciamento do DB) pgAdmin 4
@@ -74,6 +74,9 @@ Consulte o passo a passo de instalação dessas dependências e a configuração
 3.  **Instale as dependências:**
     ```bash
     pip install -r requirements.txt
+    # Caso ocorra erro envolvendo NumPy ou lxml em Python 3.11,
+    # reinstale os pacotes compilados:
+    pip install --force-reinstall lxml "numpy<2" opencv-python python-docx
     ```
 
 4.  **Configure o Banco de Dados PostgreSQL e Variáveis de Ambiente:**
@@ -85,6 +88,8 @@ Consulte o passo a passo de instalação dessas dependências e a configuração
     ```bash
     flask db upgrade
     ```
+    > A pasta `migrations/` já inclui uma revisão de merge para que o comando funcione
+    > em um repositório recém-clonado sem conflitos de cabeças.
     > Se suas migrações incluírem novas colunas com `nullable=True` em tabelas já existentes (ex.: `User`), remova os registros atuais ou defina o campo como `nullable=False` temporariamente para que a migração execute sem erros. Depois do `flask db upgrade`, ajuste o campo para permitir nulos, se for o caso.
 
 6.  **(Opcional) Popule dados de exemplo (funções, organização, usuários e artigos):**

--- a/migrations/versions/0d1288f8e4f7_merge_heads.py
+++ b/migrations/versions/0d1288f8e4f7_merge_heads.py
@@ -1,0 +1,24 @@
+"""merge heads
+
+Revision ID: 0d1288f8e4f7
+Revises: 09981b61c779, 7322f65d4686
+Create Date: 2025-08-01 18:24:12.596471
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0d1288f8e4f7'
+down_revision = ('09981b61c779', '7322f65d4686')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
## Summary
- documenta Python 3.11 como recomendado
- adiciona dica de reinstalação de dependências compiladas
- avisa que as migrações já contêm merge
- adiciona revisão de merge às migrações

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cf9a7131c832ea8f4e67836af7a98