### PR TITLE
Fix duplicate column error during migration

### DIFF
--- a/migrations/versions/09981b61c779_add_process_tables.py
+++ b/migrations/versions/09981b61c779_add_process_tables.py
@@ -1,4 +1,4 @@
-"""add process tables and notification type
+"""add process tables
 
 Revision ID: 09981b61c779
 Revises: fa23b0c1c9d0
@@ -16,11 +16,7 @@ depends_on = None
 
 
 def upgrade():
-    # 1) add column tipo to notification
-    with op.batch_alter_table('notification') as batch_op:
-        batch_op.add_column(sa.Column('tipo', sa.String(length=50), nullable=False, server_default='geral'))
-
-    # 2) create processo table
+    # 1) create processo table
     op.create_table(
         'processo',
         sa.Column('id', sa.String(length=36), primary_key=True),
@@ -29,7 +25,7 @@ def upgrade():
         sa.Column('ativo', sa.Boolean(), nullable=False, server_default='true'),
     )
 
-    # 3) etapa_processo table
+    # 2) etapa_processo table
     op.create_table(
         'etapa_processo',
         sa.Column('id', sa.String(length=36), primary_key=True),
@@ -41,7 +37,7 @@ def upgrade():
         sa.Column('obrigatoria', sa.Boolean(), nullable=False, server_default='true'),
     )
 
-    # 4) campo_etapa table
+    # 3) campo_etapa table
     op.create_table(
         'campo_etapa',
         sa.Column('id', sa.String(length=36), primary_key=True),
@@ -53,7 +49,7 @@ def upgrade():
         sa.Column('dica', sa.String(length=255), nullable=True),
     )
 
-    # 5) resposta_etapa_os table
+    # 4) resposta_etapa_os table
     op.create_table(
         'resposta_etapa_os',
         sa.Column('id', sa.String(length=36), primary_key=True),
@@ -70,5 +66,3 @@ def downgrade():
     op.drop_table('campo_etapa')
     op.drop_table('etapa_processo')
     op.drop_table('processo')
-    with op.batch_alter_table('notification') as batch_op:
-        batch_op.drop_column('tipo')

--- a/migrations/versions/7322f65d4686_add_notification_tipo.py
+++ b/migrations/versions/7322f65d4686_add_notification_tipo.py
@@ -9,6 +9,14 @@ from alembic import op
 import sqlalchemy as sa
 
 
+def _has_column(table_name: str, column_name: str) -> bool:
+    """Return True if the given column exists in the given table."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns(table_name)}
+    return column_name in cols
+
+
 # revision identifiers, used by Alembic.
 revision = '7322f65d4686'
 down_revision = 'bb1d9e24176f'
@@ -17,19 +25,21 @@ depends_on = None
 
 
 def upgrade():
-    """Add 'tipo' column to notification"""
-    with op.batch_alter_table("notification") as batch_op:
-        batch_op.add_column(
-            sa.Column(
-                "tipo",
-                sa.String(length=20),
-                nullable=False,
-                server_default="geral",
+    """Add 'tipo' column to notification if it doesn't exist."""
+    if not _has_column("notification", "tipo"):
+        with op.batch_alter_table("notification") as batch_op:
+            batch_op.add_column(
+                sa.Column(
+                    "tipo",
+                    sa.String(length=20),
+                    nullable=False,
+                    server_default="geral",
+                )
             )
-        )
 
 
 def downgrade():
-    """Remove 'tipo' column from notification"""
-    with op.batch_alter_table("notification") as batch_op:
-        batch_op.drop_column("tipo")
+    """Remove 'tipo' column from notification if present."""
+    if _has_column("notification", "tipo"):
+        with op.batch_alter_table("notification") as batch_op:
+            batch_op.drop_column("tipo")


### PR DESCRIPTION
## Summary
- prevent double creation of `notification.tipo` by removing the column addition from `09981b61c779`
- add idempotent checks for the `tipo` column in `7322f65d4686`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d0af1f820832e9e26cbc05a385c18