### PR TITLE
Add admin dashboard charts

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -84,7 +84,33 @@ admin_bp = Blueprint('admin_bp', __name__)
 @admin_bp.route('/admin/dashboard')
 @admin_required
 def admin_dashboard():
-    return render_template('admin/dashboard.html')
+    """Exibe o dashboard administrativo com estatísticas básicas."""
+    user_total = User.query.count()
+    users_active = User.query.filter_by(ativo=True).count()
+    users_inactive = user_total - users_active
+
+    status_counts = dict(
+        db.session.query(Article.status, func.count(Article.id))
+        .group_by(Article.status)
+        .all()
+    )
+    status_counts = {
+        (s.value if hasattr(s, "value") else s): status_counts.get(s, 0)
+        for s in ArticleStatus
+    }
+
+    notifications_unread = Notification.query.filter_by(lido=False).count()
+    notifications_read = Notification.query.filter_by(lido=True).count()
+
+    return render_template(
+        "admin/dashboard.html",
+        user_total=user_total,
+        users_active=users_active,
+        users_inactive=users_inactive,
+        article_status_counts=status_counts,
+        notifications_unread=notifications_unread,
+        notifications_read=notifications_read,
+    )
 
 @admin_bp.route('/admin/instituicoes', methods=['GET', 'POST'])
 @admin_required

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -4,32 +4,58 @@
 {% block title %}Dashboard{% endblock %}
 
 {% block content %}
-    <div class="container-fluid"> {# Ou só um div normal, como preferir #}
-        <h1 class="h3 mb-4 text-gray-800">Dashboard</h1> {# Estilo de título de exemplo #}
-        
-        <p>Bem-vindo à sua central de comando!</p>
-        <p>Por enquanto, este espaço está aguardando suas ideias brilhantes para exibir informações úteis.</p>
-        
-        {# No futuro, aqui podem entrar cards com estatísticas, gráficos, atalhos, etc. #}
-        {# Exemplo de como poderia ser:
+    <div class="container-fluid">
+        <h1 class="h3 mb-4 text-gray-800">Dashboard</h1>
+
         <div class="row">
-            <div class="col-xl-3 col-md-6 mb-4">
-                <div class="card border-left-primary shadow h-100 py-2">
+            <div class="col-md-6 mb-4">
+                <div class="card">
+                    <div class="card-header">Usuários Ativos</div>
                     <div class="card-body">
-                        <div class="row no-gutters align-items-center">
-                            <div class="col mr-2">
-                                <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">
-                                    Artigos Pendentes</div>
-                                <div class="h5 mb-0 font-weight-bold text-gray-800">0</div>
-                            </div>
-                            <div class="col-auto">
-                                <i class="bi bi-journal-text fs-2 text-gray-300"></i>
-                            </div>
-                        </div>
+                        <canvas id="usersChart" height="200"></canvas>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6 mb-4">
+                <div class="card">
+                    <div class="card-header">Artigos por Status</div>
+                    <div class="card-body">
+                        <canvas id="articlesChart" height="200"></canvas>
                     </div>
                 </div>
             </div>
         </div>
-        #}
     </div>
+{% endblock %}
+
+{% block extra_js %}
+    {{ super() }}
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        const usersData = {
+            labels: ['Ativos', 'Inativos'],
+            datasets: [{
+                data: [{{ users_active }}, {{ users_inactive }}],
+                backgroundColor: ['#198754', '#dc3545']
+            }]
+        };
+        new Chart(document.getElementById('usersChart'), {
+            type: 'doughnut',
+            data: usersData
+        });
+
+        const articleData = {{ article_status_counts|tojson }};
+        new Chart(document.getElementById('articlesChart'), {
+            type: 'bar',
+            data: {
+                labels: Object.keys(articleData),
+                datasets: [{
+                    label: 'Artigos',
+                    data: Object.values(articleData),
+                    backgroundColor: 'rgba(54, 162, 235, 0.6)'
+                }]
+            },
+            options: {scales: {y: {beginAtZero: true}}}
+        });
+    </script>
 {% endblock %}

--- a/tests/test_admin_dashboard.py
+++ b/tests/test_admin_dashboard.py
@@ -1,0 +1,54 @@
+import pytest
+
+from app import app, db
+from models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User
+
+
+@pytest.fixture
+def client(app_ctx):
+    with app.app_context():
+        inst = Instituicao(nome='Inst')
+        db.session.add(inst)
+        db.session.flush()
+        est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao_id=inst.id)
+        db.session.add(est)
+        db.session.flush()
+        setor = Setor(nome='Set', estabelecimento_id=est.id)
+        db.session.add(setor)
+        db.session.flush()
+        cel = Celula(nome='Cel', estabelecimento_id=est.id, setor_id=setor.id)
+        db.session.add(cel)
+        db.session.commit()
+        with app_ctx.test_client() as client:
+            client.base_ids = {'est': est.id, 'setor': setor.id, 'cel': cel.id}
+            yield client
+
+
+def login_admin(client):
+    ids = client.base_ids
+    with app.app_context():
+        f = Funcao.query.filter_by(codigo='admin').first()
+        if not f:
+            f = Funcao(codigo='admin', nome='Admin')
+            db.session.add(f)
+            db.session.commit()
+        u = User(
+            username='adm',
+            email='adm@test',
+            estabelecimento_id=ids['est'],
+            setor_id=ids['setor'],
+            celula_id=ids['cel'],
+        )
+        u.set_password('x')
+        u.permissoes_personalizadas.append(f)
+        db.session.add(u)
+        db.session.commit()
+        uid = u.id
+    with client.session_transaction() as sess:
+        sess['user_id'] = uid
+
+
+def test_admin_dashboard(client):
+    login_admin(client)
+    resp = client.get('/admin/dashboard')
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- display system statistics on admin dashboard
- use Chart.js to render user and article charts
- expose counts in admin dashboard route
- test dashboard availability for admins

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d17b54230832e888f4fa982375c6f