### PR TITLE
Add Processos menu and sort sidebar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -197,6 +197,58 @@
 
                     <hr class="my-2">
 
+                    {# Bloco ADMINISTRAÇÃO (Só para Admins) #}
+                    {% if current_user.is_authenticated and current_user.has_permissao('admin') %}
+                        <li class="nav-item">
+                            <a class="nav-link d-flex justify-content-between align-items-center {{ 'active' if request.endpoint.startswith('admin_') else '' }} {{ 'collapsed' if not request.endpoint.startswith('admin_') }}"
+                            data-bs-toggle="collapse" href="#collapseAdministracao" role="button"
+                            aria-expanded="{{ 'true' if request.endpoint.startswith('admin_') else 'false' }}"
+                            aria-controls="collapseAdministracao">
+                                <span><i class="bi bi-gear-fill me-2"></i> Administração</span>
+                                <i class="bi bi-chevron-down small"></i>
+                            </a>
+                            <div class="collapse {{ 'show' if request.endpoint.startswith('admin_') }}" id="collapseAdministracao">
+                                <ul class="nav flex-column ps-3">
+                                    <li class="nav-item">
+                                        <a class="nav-link d-flex justify-content-between align-items-center {{ 'active' if request.endpoint.startswith('admin_instituicoes') or request.endpoint.startswith('admin_estabelecimentos') or request.endpoint.startswith('admin_setores') or request.endpoint.startswith('admin_celulas') or request.endpoint.startswith('admin_cargos') else '' }} {{ 'collapsed' if not (request.endpoint.startswith('admin_instituicoes') or request.endpoint.startswith('admin_estabelecimentos') or request.endpoint.startswith('admin_setores') or request.endpoint.startswith('admin_celulas') or request.endpoint.startswith('admin_cargos')) }}"
+                                        data-bs-toggle="collapse" href="#collapseCadastrosOrgSub" role="button"
+                                        aria-expanded="{{ 'true' if request.endpoint.startswith('admin_instituicoes') or request.endpoint.startswith('admin_estabelecimentos') or request.endpoint.startswith('admin_setores') or request.endpoint.startswith('admin_celulas') or request.endpoint.startswith('admin_cargos') else 'false' }}"
+                                        aria-controls="collapseCadastrosOrgSub">
+                                            <i class="bi bi-buildings-fill me-2"></i> Cadastros Base
+                                            <i class="bi bi-chevron-down small ms-auto"></i>
+                                        </a>
+                                        <div class="collapse {{ 'show' if request.endpoint.startswith('admin_instituicoes') or request.endpoint.startswith('admin_estabelecimentos') or request.endpoint.startswith('admin_setores') or request.endpoint.startswith('admin_celulas') or request.endpoint.startswith('admin_cargos') else '' }}" id="collapseCadastrosOrgSub">
+                                            <ul class="nav flex-column ps-3">
+                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_cargos' else '' }}" href="{{ url_for('admin_cargos') }}"><i class="bi bi-person-badge-fill me-2"></i> Cargos</a></li>
+                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_celulas' else '' }}" href="{{ url_for('admin_celulas') }}"><i class="bi bi-diagram-2-fill me-2"></i> Células</a></li>
+                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_estabelecimentos' else '' }}" href="{{ url_for('admin_estabelecimentos') }}"><i class="bi bi-building me-2"></i> Estabelecimentos</a></li>
+                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_instituicoes' else '' }}" href="{{ url_for('admin_instituicoes') }}"><i class="bi bi-bank me-2"></i> Instituições</a></li>
+                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_setores' else '' }}" href="{{ url_for('admin_setores') }}"><i class="bi bi-tags-fill me-2"></i> Setores</a></li>
+                                            </ul>
+                                        </div>
+                                    </li>
+                                    <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_dashboard' else '' }}" href="{{ url_for('admin_dashboard') }}"><i class="bi bi-speedometer2 me-2"></i> Dashboard Admin</a></li>
+                                    <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint.startswith('admin_processos') or request.endpoint.startswith('admin_etapas') or request.endpoint.startswith('admin_campos') else '' }}" href="{{ url_for('admin_processos') }}"><i class="bi bi-diagram-3-fill me-2"></i> Processos</a></li>
+                                    <li class="nav-item">
+                                        <a class="nav-link d-flex justify-content-between align-items-center {{ 'active' if request.endpoint.startswith('admin_usuarios') else '' }} {{ 'collapsed' if not request.endpoint.startswith('admin_usuarios') }}"
+                                        data-bs-toggle="collapse" href="#collapseSegurancaSub" role="button"
+                                        aria-expanded="{{ 'true' if request.endpoint.startswith('admin_usuarios') else 'false' }}"
+                                        aria-controls="collapseSegurancaSub">
+                                            <i class="bi bi-shield-lock-fill me-2"></i> Segurança
+                                            <i class="bi bi-chevron-down small ms-auto"></i>
+                                        </a>
+                                        <div class="collapse {{ 'show' if request.endpoint.startswith('admin_usuarios') else '' }}" id="collapseSegurancaSub">
+                                            <ul class="nav flex-column ps-3">
+                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_usuarios' else '' }}" href="{{ url_for('admin_usuarios') }}"><i class="bi bi-people-fill me-2"></i> Gerenciar Usuários</a></li>
+                                            </ul>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                        <hr class="my-2">
+                    {% endif %} {# Fim do if admin permission #}
+
                     {# Bloco BIBLIOTECA #}
                     <li class="nav-item">
                         <a class="nav-link d-flex justify-content-between align-items-center {{ 'active' if request.endpoint in ['meus_artigos', 'novo_artigo', 'pesquisar', 'aprovacao', 'artigo', 'editar_artigo'] and not request.endpoint.startswith('admin_') else '' }} {{ 'collapsed' if not (request.endpoint in ['meus_artigos', 'novo_artigo', 'pesquisar', 'aprovacao', 'artigo', 'editar_artigo'] and not request.endpoint.startswith('admin_')) }}"
@@ -208,9 +260,6 @@
                         </a>
                         <div class="collapse {{ 'show' if request.endpoint in ['meus_artigos', 'novo_artigo', 'pesquisar', 'aprovacao', 'artigo', 'editar_artigo'] and not request.endpoint.startswith('admin_') }}" id="collapseBiblioteca">
                             <ul class="nav flex-column ps-3">
-                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'meus_artigos' else '' }}" href="{{ url_for('meus_artigos') }}"><i class="bi bi-journals me-2"></i> Meus Artigos</a></li>
-                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'novo_artigo' else '' }}" href="{{ url_for('novo_artigo') }}"><i class="bi bi-file-earmark-plus-fill me-2"></i> Novo Artigo</a></li>
-                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'pesquisar' else '' }}" href="{{ url_for('pesquisar') }}"><i class="bi bi-search me-2"></i> Pesquisar</a></li>
                                 {% if current_user.is_authenticated %}
                                     {% set codes = [
                                         Permissao.ARTIGO_APROVAR_CELULA.value,
@@ -234,6 +283,9 @@
                                         <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'aprovacao' else '' }}" href="{{ url_for('aprovacao') }}"><i class="bi bi-check2-square me-2"></i> Aprovação</a></li>
                                     {% endif %}
                                 {% endif %}
+                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'meus_artigos' else '' }}" href="{{ url_for('meus_artigos') }}"><i class="bi bi-journals me-2"></i> Meus Artigos</a></li>
+                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'novo_artigo' else '' }}" href="{{ url_for('novo_artigo') }}"><i class="bi bi-file-earmark-plus-fill me-2"></i> Novo Artigo</a></li>
+                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'pesquisar' else '' }}" href="{{ url_for('pesquisar') }}"><i class="bi bi-search me-2"></i> Pesquisar</a></li>
                             </ul>
                         </div>
                     </li>
@@ -250,62 +302,12 @@
                         <div class="collapse" id="collapseOSGlobal">
                             <ul class="nav flex-column ps-3">
                                 <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-plus-circle-dotted me-2"></i> Abrir Nova OS</a></li>
-                                <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-person-lines-fill me-2"></i> Minhas OS</a></li>
                                 <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-binoculars-fill me-2"></i> Consultar OS</a></li>
+                                <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-person-lines-fill me-2"></i> Minhas OS</a></li>
                             </ul>
                         </div>
                     </li>
 
-                    {# Bloco ADMINISTRAÇÃO (Só para Admins) #}
-                    {% if current_user.is_authenticated and current_user.has_permissao('admin') %}
-                        <hr class="my-2">
-                        <li class="nav-item">
-                            <a class="nav-link d-flex justify-content-between align-items-center {{ 'active' if request.endpoint.startswith('admin_') else '' }} {{ 'collapsed' if not request.endpoint.startswith('admin_') }}"
-                            data-bs-toggle="collapse" href="#collapseAdministracao" role="button" 
-                            aria-expanded="{{ 'true' if request.endpoint.startswith('admin_') else 'false' }}" 
-                            aria-controls="collapseAdministracao">
-                                <span><i class="bi bi-gear-fill me-2"></i> Administração</span>
-                                <i class="bi bi-chevron-down small"></i>
-                            </a>
-                            <div class="collapse {{ 'show' if request.endpoint.startswith('admin_') }}" id="collapseAdministracao">
-                                <ul class="nav flex-column ps-3">
-                                    <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_dashboard' else '' }}" href="{{ url_for('admin_dashboard') }}"><i class="bi bi-speedometer2 me-2"></i> Dashboard Admin</a></li>
-                                    <li class="nav-item">
-                                        <a class="nav-link d-flex justify-content-between align-items-center {{ 'active' if request.endpoint.startswith('admin_instituicoes') or request.endpoint.startswith('admin_estabelecimentos') or request.endpoint.startswith('admin_setores') or request.endpoint.startswith('admin_celulas') or request.endpoint.startswith('admin_cargos') else '' }} {{ 'collapsed' if not (request.endpoint.startswith('admin_instituicoes') or request.endpoint.startswith('admin_estabelecimentos') or request.endpoint.startswith('admin_setores') or request.endpoint.startswith('admin_celulas') or request.endpoint.startswith('admin_cargos')) }}"
-                                        data-bs-toggle="collapse" href="#collapseCadastrosOrgSub" role="button"
-                                        aria-expanded="{{ 'true' if request.endpoint.startswith('admin_instituicoes') or request.endpoint.startswith('admin_estabelecimentos') or request.endpoint.startswith('admin_setores') or request.endpoint.startswith('admin_celulas') or request.endpoint.startswith('admin_cargos') else 'false' }}"
-                                        aria-controls="collapseCadastrosOrgSub">
-                                            <i class="bi bi-buildings-fill me-2"></i> Cadastros Base 
-                                            <i class="bi bi-chevron-down small ms-auto"></i>
-                                        </a>
-                                        <div class="collapse {{ 'show' if request.endpoint.startswith('admin_instituicoes') or request.endpoint.startswith('admin_estabelecimentos') or request.endpoint.startswith('admin_setores') or request.endpoint.startswith('admin_celulas') or request.endpoint.startswith('admin_cargos') else '' }}" id="collapseCadastrosOrgSub">
-                                            <ul class="nav flex-column ps-3">
-                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_instituicoes' else '' }}" href="{{ url_for('admin_instituicoes') }}"><i class="bi bi-bank me-2"></i> Instituições</a></li>
-                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_estabelecimentos' else '' }}" href="{{ url_for('admin_estabelecimentos') }}"><i class="bi bi-building me-2"></i> Estabelecimentos</a></li>
-                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_setores' else '' }}" href="{{ url_for('admin_setores') }}"><i class="bi bi-tags-fill me-2"></i> Setores</a></li>
-                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_celulas' else '' }}" href="{{ url_for('admin_celulas') }}"><i class="bi bi-diagram-2-fill me-2"></i> Células</a></li>
-                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_cargos' else '' }}" href="{{ url_for('admin_cargos') }}"><i class="bi bi-person-badge-fill me-2"></i> Cargos</a></li>
-                                            </ul>
-                                        </div>
-                                    </li>
-                                    <li class="nav-item">
-                                        <a class="nav-link d-flex justify-content-between align-items-center {{ 'active' if request.endpoint.startswith('admin_usuarios') else '' }} {{ 'collapsed' if not request.endpoint.startswith('admin_usuarios') }}"
-                                        data-bs-toggle="collapse" href="#collapseSegurancaSub" role="button"
-                                        aria-expanded="{{ 'true' if request.endpoint.startswith('admin_usuarios') else 'false' }}"
-                                        aria-controls="collapseSegurancaSub">
-                                            <i class="bi bi-shield-lock-fill me-2"></i> Segurança
-                                            <i class="bi bi-chevron-down small ms-auto"></i>
-                                        </a>
-                                        <div class="collapse {{ 'show' if request.endpoint.startswith('admin_usuarios') else '' }}" id="collapseSegurancaSub">
-                                            <ul class="nav flex-column ps-3">
-                                                <li class="nav-item"><a class="nav-link {{ 'active' if request.endpoint == 'admin_usuarios' else '' }}" href="{{ url_for('admin_usuarios') }}"><i class="bi bi-people-fill me-2"></i> Gerenciar Usuários</a></li>
-                                            </ul>
-                                        </div>
-                                    </li>
-                                </ul>
-                            </div>
-                        </li>
-                    {% endif %} {# Fim do if admin permission #}
 
                     {# Item de Sair - no final da sidebar #}
                     <hr class="my-2" style="margin-top: auto !important;"> 


### PR DESCRIPTION
## Summary
- add `Processos` option in the Administration menu
- reorganize sidebar items alphabetically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1d092620832ebdd79497142edf0c