### PR TITLE
Add form builder module and OS permissions

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,6 +79,7 @@ try:
         user_can_approve_article,
         user_can_review_article,
         eligible_review_notification_users,
+        user_can_access_form_builder,
     )
 except ImportError:  # pragma: no cover - fallback for direct execution
     from utils import (
@@ -94,6 +95,7 @@ except ImportError:  # pragma: no cover - fallback for direct execution
         user_can_approve_article,
         user_can_review_article,
         eligible_review_notification_users,
+        user_can_access_form_builder,
     )
 from mimetypes import guess_type # Se for usar, descomente
 from werkzeug.utils import secure_filename # Útil para uploads, como na sua foto de perfil
@@ -170,20 +172,23 @@ try:
     from .blueprints.auth import auth_bp
     from .blueprints.articles import articles_bp
     from .blueprints.processos import processos_bp
+    from .blueprints.formularios import formularios_bp
 except ImportError:  # pragma: no cover - fallback for direct execution
     from blueprints.admin import admin_bp
     from blueprints.auth import auth_bp
     from blueprints.articles import articles_bp
     from blueprints.processos import processos_bp
+    from blueprints.formularios import formularios_bp
 
 
 app.register_blueprint(admin_bp)
 app.register_blueprint(auth_bp)
 app.register_blueprint(articles_bp)
 app.register_blueprint(processos_bp)
+app.register_blueprint(formularios_bp)
 
 for rule in list(app.url_map.iter_rules()):
-    if rule.endpoint.startswith('admin_bp.') or rule.endpoint.startswith('auth_bp.') or rule.endpoint.startswith('articles_bp.') or rule.endpoint.startswith('processos_bp.'):
+    if rule.endpoint.startswith('admin_bp.') or rule.endpoint.startswith('auth_bp.') or rule.endpoint.startswith('articles_bp.') or rule.endpoint.startswith('processos_bp.') or rule.endpoint.startswith('formularios_bp.'):
         app.add_url_rule(
             rule.rule,
             endpoint=rule.endpoint.split('.',1)[-1],
@@ -346,4 +351,9 @@ def inject_zoneinfo():
 def inject_niveis_cargo():
     """Disponibiliza o mapeamento de níveis hierárquicos para todos os templates."""
     return dict(NOME_NIVEL_CARGO=NOME_NIVEL_CARGO, NIVEIS_HIERARQUICOS=NIVEIS_HIERARQUICOS)
+
+
+@app.context_processor
+def inject_form_builder_permission():
+    return dict(user_can_access_form_builder=user_can_access_form_builder)
 

--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -753,6 +753,7 @@ def admin_cargos():
         descricao = request.form.get('descricao', '').strip()
         nivel_hierarquico = request.form.get('nivel_hierarquico', type=int)
         ativo = request.form.get('ativo_check') == 'on'
+        atende_os = request.form.get('atende_ordem_servico') == 'on'
         setor_ids = list({int(s) for s in request.form.getlist('setor_ids') if s})
         celula_ids = list({int(c) for c in request.form.getlist('celula_ids') if c})
         funcao_ids = list({int(f) for f in request.form.getlist('funcao_ids') if f})
@@ -774,6 +775,7 @@ def admin_cargos():
                     cargo.descricao = descricao
                     cargo.nivel_hierarquico = nivel_hierarquico
                     cargo.ativo = ativo
+                    cargo.atende_ordem_servico = atende_os
                     action_msg = 'atualizado'
                 else:
                     cargo = Cargo(
@@ -781,6 +783,7 @@ def admin_cargos():
                         descricao=descricao,
                         nivel_hierarquico=nivel_hierarquico,
                         ativo=ativo,
+                        atende_ordem_servico=atende_os,
                     )
                     db.session.add(cargo)
                     action_msg = 'criado'

--- a/blueprints/formularios.py
+++ b/blueprints/formularios.py
@@ -1,0 +1,53 @@
+from flask import Blueprint, render_template, request, redirect, url_for, flash
+try:
+    from .models import Formulario
+    from .database import db
+    from .decorators import form_builder_required
+except ImportError:  # pragma: no cover
+    from models import Formulario
+    from database import db
+    from decorators import form_builder_required
+
+formularios_bp = Blueprint('formularios_bp', __name__, url_prefix='/ordem-servico/formularios')
+
+
+@formularios_bp.route('/')
+@form_builder_required
+def listar_formularios():
+    formularios = Formulario.query.order_by(Formulario.created_at.desc()).all()
+    return render_template('formularios/lista.html', formularios=formularios)
+
+
+@formularios_bp.route('/novo', methods=['GET', 'POST'])
+@form_builder_required
+def novo_formulario():
+    if request.method == 'POST':
+        nome = request.form.get('nome', '').strip()
+        estrutura = request.form.get('estrutura', '').strip()
+        if not nome:
+            flash('Nome é obrigatório.', 'danger')
+        else:
+            f = Formulario(nome=nome, estrutura=estrutura)
+            db.session.add(f)
+            db.session.commit()
+            flash('Formulário criado com sucesso!', 'success')
+            return redirect(url_for('listar_formularios'))
+    return render_template('formularios/form.html', formulario=None)
+
+
+@formularios_bp.route('/<int:id>/editar', methods=['GET', 'POST'])
+@form_builder_required
+def editar_formulario(id):
+    formulario = Formulario.query.get_or_404(id)
+    if request.method == 'POST':
+        nome = request.form.get('nome', '').strip()
+        estrutura = request.form.get('estrutura', '').strip()
+        if not nome:
+            flash('Nome é obrigatório.', 'danger')
+        else:
+            formulario.nome = nome
+            formulario.estrutura = estrutura
+            db.session.commit()
+            flash('Formulário atualizado!', 'success')
+            return redirect(url_for('listar_formularios'))
+    return render_template('formularios/form.html', formulario=formulario)

--- a/decorators.py
+++ b/decorators.py
@@ -1,9 +1,13 @@
 from functools import wraps
-from flask import session, redirect, url_for, flash
+from flask import session, redirect, url_for, flash, request
 try:
     from .models import User
 except ImportError:  # pragma: no cover
     from models import User
+try:
+    from .utils import user_can_access_form_builder
+except ImportError:  # pragma: no cover
+    from utils import user_can_access_form_builder
 
 
 def admin_required(f):
@@ -16,5 +20,19 @@ def admin_required(f):
         if not user or not user.has_permissao('admin'):
             flash('Acesso negado. Você precisa ser um administrador para acessar esta página.', 'danger')
             return redirect(url_for('meus_artigos'))
+        return f(*args, **kwargs)
+    return decorated_function
+
+
+def form_builder_required(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if 'user_id' not in session:
+            flash('Por favor, faça login para acessar esta página.', 'warning')
+            return redirect(url_for('login', next=request.url))
+        user = User.query.get(session['user_id'])
+        if not user_can_access_form_builder(user):
+            flash('Acesso negado.', 'danger')
+            return redirect(url_for('pagina_inicial'))
         return f(*args, **kwargs)
     return decorated_function

--- a/docs/TAREFAS_CRIADOR_DE_FORMULARIOS.md
+++ b/docs/TAREFAS_CRIADOR_DE_FORMULARIOS.md
@@ -1,0 +1,63 @@
+# Tarefas para Implementar o Criador de Formulários
+
+## 1. Planejamento & Configuração Inicial
+- Definir branch de desenvolvimento e alinhar padrões de código/permissões.
+- Revisar versões de dependências (Flask, Alembic, JS libs) para garantir compatibilidade.
+
+## 2. Modelagem e Migrações do Banco
+### 2.1 Cargo
+- Atualizar `models.py` adicionando campo `atende_ordem_servico` (Boolean, default False).
+- Gerar e aplicar a migration que inclui o campo em cargos.
+
+### 2.2 Formulários
+- Criar modelos `Formulario` e `CampoFormulario` com os campos especificados.
+- Definir relações (1:N entre `Formulario` e `CampoFormulario`).
+- Gerar migrations para criação das tabelas `formulario` e `campo_formulario`.
+- Aplicar migrations em ambientes de dev/homolog/produção.
+
+## 3. Permissões e Utilitários
+- Criar/ajustar função `user_can_access_form_builder` (ou similar) verificando: usuário logado + `cargo.atende_ordem_servico`.
+- Garantir verificação tanto no backend (decoradores/rotas) quanto no template (exibição do menu).
+
+## 4. Rotas e Blueprint "Formulários"
+- Criar blueprint `formularios` em `/ordem-servico/formularios`.
+- Rotas básicas:
+  - Listagem (GET `/`)
+  - Criação (GET/POST `/novo`)
+  - Edição (GET/POST `/<id>/editar`)
+  - Salvamento do JSON da estrutura.
+- Aplicar a função de permissão em todas as rotas.
+
+## 5. Interface de Usuário
+### 5.1 Menu Lateral
+- Inserir item "Criador de Formulários" dentro de "Ordem de Serviço", exibindo apenas quando `user_can_access_form_builder` for verdadeiro.
+
+### 5.2 Página de Listagem
+- Tabela/lista dos formulários existentes com botão "Novo Formulário".
+
+### 5.3 Editor
+- Form para nome do formulário.
+- Componentes para adicionar/ordenar campos dinâmicos (tipo, label, obrigatório, ordem, opções, condicional).
+- Pré-visualização dinâmica.
+- Botões de salvar/cancelar.
+
+### 5.4 Preenchimento por Etapas e Manual
+- Implementar wizard que exiba campos conforme respostas (dependências).
+- Adicionar botão "ℹ Manual de Preenchimento" com modal contendo instruções.
+
+## 6. Atualização de `cargos.html`
+- Seção "Permissões Ordem de Serviço" com checkbox "Pode atender OS?" ligado ao novo campo.
+- Exibir nas telas de cadastro e edição de cargos.
+
+## 7. Testes Automatizados
+- Testar migrations (criação dos campos/tabelas).
+- Testes de permissão (acesso ao menu, rotas protegidas).
+- Testes de criação/edição de formulários e de renderização condicional dos campos.
+- Cobrir interface (JS) com testes unitários/funcionais se houver infraestrutura.
+
+## 8. Documentação e Deploy
+- Atualizar docs do projeto com instruções de uso, permissões e processo de criação de formulários.
+- Preparar script/manual de migração para ambientes de produção.
+- Realizar deploy e validar a funcionalidade end-to-end.
+
+**Observação:** Seguindo essa ordem – primeiro banco e modelos, depois permissões, rotas, UI e por fim testes e documentação – evitam-se conflitos de migração e garante-se integração suave entre as camadas do sistema.

--- a/docs/TAREFA_ATUALIZACAO_FORMULARIOS.md
+++ b/docs/TAREFA_ATUALIZACAO_FORMULARIOS.md
@@ -1,0 +1,11 @@
+# Tarefa: Atualização do Criador de Formulários
+
+## Resumo
+- Adicionar flag `atende_ordem_servico` aos cargos para controlar acesso ao construtor de formulários
+- Introduzir modelos `Formulario` e `CampoFormulario` para armazenar formulários dinâmicos
+- Criar blueprint, templates e testes para gerenciar os formulários e suas permissões
+
+## Checklist
+- [ ] Aplicar migrações em todos os ambientes
+- [ ] Validar permissões em produção
+- [ ] Atualizar documentação de deploy

--- a/migrations/versions/1b2c3d4e5f67_add_form_builder_tables.py
+++ b/migrations/versions/1b2c3d4e5f67_add_form_builder_tables.py
@@ -1,0 +1,47 @@
+"""Add form builder tables and cargo flag
+
+Revision ID: 1b2c3d4e5f67
+Revises: 0d1288f8e4f7
+Create Date: 2025-06-02 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '1b2c3d4e5f67'
+down_revision = '0d1288f8e4f7'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    with op.batch_alter_table('cargo', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('atende_ordem_servico', sa.Boolean(), nullable=False, server_default='false'))
+
+    op.create_table(
+        'formulario',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('nome', sa.String(length=200), nullable=False),
+        sa.Column('estrutura', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    )
+
+    op.create_table(
+        'campo_formulario',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('formulario_id', sa.Integer(), sa.ForeignKey('formulario.id'), nullable=False),
+        sa.Column('tipo', sa.String(length=50), nullable=False),
+        sa.Column('label', sa.String(length=200), nullable=False),
+        sa.Column('obrigatorio', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('ordem', sa.Integer(), nullable=False),
+        sa.Column('opcoes', sa.Text(), nullable=True),
+        sa.Column('condicional', sa.Text(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table('campo_formulario')
+    op.drop_table('formulario')
+    with op.batch_alter_table('cargo', schema=None) as batch_op:
+        batch_op.drop_column('atende_ordem_servico')

--- a/models.py
+++ b/models.py
@@ -186,6 +186,7 @@ class Cargo(db.Model):
     descricao = db.Column(db.Text, nullable=True)
     nivel_hierarquico = db.Column(db.Integer, nullable=True) # Para lógica de hierarquia (ex: 1=Alto, 10=Baixo)
     ativo = db.Column(db.Boolean, nullable=False, default=True, server_default='true')
+    atende_ordem_servico = db.Column(db.Boolean, nullable=False, default=False, server_default='false')
 
     # Relacionamentos: Um Cargo pode ter vários Usuários
     usuarios = db.relationship('User', back_populates='cargo', lazy='dynamic')
@@ -472,5 +473,41 @@ class RespostaEtapaOS(db.Model):
 
     def __repr__(self):
         return f"<RespostaEtapaOS {self.ordem_servico_id} campo={self.campo_etapa_id}>"
+
+
+# --- MODELOS DO CRIADOR DE FORMULÁRIOS ---
+
+
+class Formulario(db.Model):
+    __tablename__ = 'formulario'
+
+    id = db.Column(db.Integer, primary_key=True)
+    nome = db.Column(db.String(200), nullable=False)
+    estrutura = db.Column(db.Text, nullable=True)
+    created_at = db.Column(db.DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = db.Column(db.DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    campos = db.relationship('CampoFormulario', back_populates='formulario', cascade='all, delete-orphan')
+
+    def __repr__(self):
+        return f"<Formulario {self.nome}>"
+
+
+class CampoFormulario(db.Model):
+    __tablename__ = 'campo_formulario'
+
+    id = db.Column(db.Integer, primary_key=True)
+    formulario_id = db.Column(db.Integer, db.ForeignKey('formulario.id'), nullable=False)
+    tipo = db.Column(db.String(50), nullable=False)
+    label = db.Column(db.String(200), nullable=False)
+    obrigatorio = db.Column(db.Boolean, nullable=False, default=False, server_default='false')
+    ordem = db.Column(db.Integer, nullable=False)
+    opcoes = db.Column(db.Text, nullable=True)
+    condicional = db.Column(db.Text, nullable=True)
+
+    formulario = db.relationship('Formulario', back_populates='campos')
+
+    def __repr__(self):
+        return f"<CampoFormulario {self.label} ({self.tipo})>"
 
 # --- FIM DOS MODELOS ---

--- a/templates/admin/cargos.html
+++ b/templates/admin/cargos.html
@@ -54,7 +54,7 @@
                                                                             <li class="list-group-item d-flex justify-content-between align-items-center cargo-item {{ 'text-muted' if not cargo.ativo else '' }}" data-cargo="{{ cargo.nome }}" data-setor="{{ setor.obj.nome }}" data-celula="">
                                                                                 <span>
                                                                                     {{ cargo.nome }}
-                                                                                    {% if cargo.permiteAtenderOrdemServico %}
+                                                                                    {% if cargo.atende_ordem_servico %}
                                                                                         <span class="badge bg-success ms-2">Atende OS</span>
                                                                                     {% endif %}
                                                                                 </span>
@@ -89,7 +89,7 @@
                                                                                         <li class="list-group-item d-flex justify-content-between align-items-center cargo-item {{ 'text-muted' if not cargo.ativo else '' }}" data-cargo="{{ cargo.nome }}" data-setor="{{ setor.obj.nome }}" data-celula="{{ cel.obj.nome }}">
                                                                                             <span>
                                                                                                 {{ cargo.nome }}
-                                                                                                {% if cargo.permiteAtenderOrdemServico %}
+                                                                                                {% if cargo.atende_ordem_servico %}
                                                                                                     <span class="badge bg-success ms-2">Atende OS</span>
                                                                                                 {% endif %}
                                                                                             </span>
@@ -190,6 +190,15 @@
                                         </div>
                                     {% endfor %}
                                 {% endfor %}
+                        </div>
+                    </div>
+                    <div class="card mb-3">
+                        <div class="card-header"><h6 class="mb-0">Permissões Ordem de Serviço</h6></div>
+                        <div class="card-body">
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" role="switch" id="atende_ordem_servico" name="atende_ordem_servico" {% if request.form.get('atende_ordem_servico') == 'on' %}checked{% endif %}>
+                                <label class="form-check-label" for="atende_ordem_servico">Pode atender OS?</label>
+                            </div>
                         </div>
                     </div>
                     <div class="card mb-3">
@@ -340,6 +349,15 @@
                                     </div>
                                 {% endif %}
                             {% endfor %}
+                        </div>
+                    </div>
+                    <div class="card mb-3">
+                        <div class="card-header"><h6 class="mb-0">Permissões Ordem de Serviço</h6></div>
+                        <div class="card-body">
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" role="switch" id="edit_atende_ordem_servico" name="atende_ordem_servico" {% if (request.form.get('atende_ordem_servico') == 'on') or (not request.form.get('atende_ordem_servico') and cargo_editar.atende_ordem_servico) %}checked{% endif %}>
+                                <label class="form-check-label" for="edit_atende_ordem_servico">Pode atender OS?</label>
+                            </div>
                         </div>
                     </div>
                     <div class="card mb-3">

--- a/templates/base.html
+++ b/templates/base.html
@@ -305,7 +305,7 @@
                     <hr class="my-2">
 
                     {# Bloco ORDENS DE SERVIÇO #}
-                    {% set os_active = 'os_' in request.endpoint %}
+                    {% set os_active = 'os_' in request.endpoint or 'formularios' in request.endpoint %}
                     <li class="nav-item">
                         <a class="nav-link d-flex justify-content-between align-items-center {{ 'active' if os_active else '' }} {{ 'collapsed' if not os_active }}"
                         data-bs-toggle="collapse" href="#collapseOSGlobal" role="button" aria-expanded="{{ 'true' if os_active else 'false' }}" aria-controls="collapseOSGlobal">
@@ -317,6 +317,9 @@
                                 <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-plus-circle-dotted me-2"></i> Abrir Nova OS</a></li>
                                 <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-binoculars-fill me-2"></i> Consultar OS</a></li>
                                 <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-person-lines-fill me-2"></i> Minhas OS</a></li>
+                                {% if user_can_access_form_builder(current_user) %}
+                                <li class="nav-item"><a class="nav-link {{ 'active' if 'formularios' in request.endpoint else '' }}" href="{{ url_for('listar_formularios') }}"><i class="bi bi-ui-checks-grid me-2"></i> Criador de Formulários</a></li>
+                                {% endif %}
                             </ul>
                         </div>
                     </li>

--- a/templates/formularios/form.html
+++ b/templates/formularios/form.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}{{ 'Editar' if formulario else 'Novo' }} Formulário{% endblock %}
+{% block content %}
+<div class="container mt-3">
+  <h1>{{ 'Editar' if formulario else 'Novo' }} Formulário</h1>
+  <form method="POST">
+    <div class="mb-3">
+      <label for="nome" class="form-label">Nome</label>
+      <input type="text" class="form-control" id="nome" name="nome" value="{{ formulario.nome if formulario else '' }}" required>
+    </div>
+    <div class="mb-3">
+      <label for="estrutura" class="form-label">Estrutura (JSON)</label>
+      <textarea class="form-control" id="estrutura" name="estrutura" rows="6">{{ formulario.estrutura if formulario else '' }}</textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Salvar</button>
+    <a href="{{ url_for('listar_formularios') }}" class="btn btn-secondary">Cancelar</a>
+  </form>
+</div>
+{% endblock %}

--- a/templates/formularios/lista.html
+++ b/templates/formularios/lista.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block title %}Formulários{% endblock %}
+{% block content %}
+<div class="container mt-3">
+  <div class="d-flex justify-content-between mb-3">
+    <h1>Formulários</h1>
+    <a class="btn btn-primary" href="{{ url_for('novo_formulario') }}">Novo Formulário</a>
+  </div>
+  {% if formularios %}
+  <table class="table table-striped">
+    <thead><tr><th>Nome</th><th>Ações</th></tr></thead>
+    <tbody>
+    {% for f in formularios %}
+      <tr>
+        <td>{{ f.nome }}</td>
+        <td><a class="btn btn-sm btn-secondary" href="{{ url_for('editar_formulario', id=f.id) }}">Editar</a></td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="text-muted">Nenhum formulário cadastrado.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/tests/test_form_builder.py
+++ b/tests/test_form_builder.py
@@ -1,0 +1,77 @@
+import pytest
+from app import app, db
+from models import Cargo, Instituicao, Estabelecimento, Setor, Celula, User, Formulario
+from utils import user_can_access_form_builder
+
+def setup_org(prefix):
+    inst = Instituicao(nome=f'Inst_{prefix}')
+    db.session.add(inst)
+    db.session.flush()
+    est = Estabelecimento(codigo=f'E_{prefix}', nome_fantasia='Est', instituicao_id=inst.id)
+    db.session.add(est)
+    db.session.flush()
+    setor = Setor(nome=f'Set_{prefix}', estabelecimento_id=est.id)
+    db.session.add(setor)
+    db.session.flush()
+    cel = Celula(nome=f'Cel_{prefix}', estabelecimento_id=est.id, setor_id=setor.id)
+    db.session.add(cel)
+    db.session.commit()
+    return est.id, setor.id, cel.id
+
+
+def create_user(username, atende=False):
+    est_id, setor_id, cel_id = setup_org(username)
+    cargo = Cargo(nome=f'Cargo_{username}', atende_ordem_servico=atende)
+    db.session.add(cargo)
+    db.session.flush()
+    user = User(username=username, email=f'{username}@test', estabelecimento_id=est_id, setor_id=setor_id, celula_id=cel_id, cargo_id=cargo.id)
+    user.set_password('x')
+    db.session.add(user)
+    db.session.commit()
+    return user.id
+
+
+@pytest.fixture
+def client(app_ctx):
+    with app_ctx.test_client() as client:
+        yield client
+
+
+def login(client, user):
+    with client.session_transaction() as sess:
+        sess['user_id'] = user
+
+
+def test_permission_function(app_ctx):
+    with app_ctx.app_context():
+        user_allowed_id = create_user('u1', True)
+        user_denied_id = create_user('u2', False)
+        user_allowed = User.query.get(user_allowed_id)
+        user_denied = User.query.get(user_denied_id)
+        assert user_can_access_form_builder(user_allowed) is True
+        assert user_can_access_form_builder(user_denied) is False
+
+
+def test_route_permission(client):
+    with app.app_context():
+        user_denied_id = create_user('deny', False)
+    login(client, user_denied_id)
+    resp = client.get('/ordem-servico/formularios/')
+    assert resp.status_code == 302
+
+    with app.app_context():
+        user_allowed_id = create_user('allow', True)
+    login(client, user_allowed_id)
+    resp = client.get('/ordem-servico/formularios/')
+    assert resp.status_code == 200
+
+
+def test_create_formulario(client):
+    with app.app_context():
+        user_allowed_id = create_user('creator', True)
+    login(client, user_allowed_id)
+    resp = client.post('/ordem-servico/formularios/novo', data={'nome': 'Form1', 'estrutura': '{}'}, follow_redirects=True)
+    assert resp.status_code == 200
+    assert b'Form1' in resp.data
+    with app.app_context():
+        assert Formulario.query.filter_by(nome='Form1').first() is not None

--- a/utils.py
+++ b/utils.py
@@ -468,3 +468,8 @@ def eligible_review_notification_users(article):
         u for u in User.query.all()
         if user_can_approve_article(u, article) or user_can_review_article(u, article)
     ]
+
+
+def user_can_access_form_builder(user):
+    """Verifica se o usuário tem acesso ao criador de formulários."""
+    return bool(user and user.cargo and getattr(user.cargo, 'atende_ordem_servico', False))


### PR DESCRIPTION
## Summary
- add cargo flag to control access to form builder and introduce related models
- create blueprint, templates and menu entry for managing custom forms
- ensure cargo pages and tests cover new form builder access
- document follow-up task for deploying the form builder module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68920a86e8ac832e8440d1570dbc46d4