### PR TITLE
test: check for single alembic head

### DIFF
--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,33 @@
+import glob
+
+def _get_heads():
+    revisions = set()
+    downs = set()
+    for path in glob.glob("migrations/versions/*.py"):
+        revision = None
+        down_values = []
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("revision ="):
+                    revision = line.split("=", 1)[1].strip().strip("'\"")
+                elif line.startswith("down_revision"):
+                    raw = line.split("=", 1)[1].strip()
+                    if raw.startswith("("):
+                        down_values = [
+                            part.strip().strip("'\"")
+                            for part in raw.strip("()").split(",")
+                            if part.strip()
+                        ]
+                    elif raw in {"None", "NULL"}:
+                        down_values = []
+                    else:
+                        down_values = [raw.strip("'\"")]
+        if revision:
+            revisions.add(revision)
+        downs.update(down_values)
+    return revisions - downs
+
+def test_single_alembic_head():
+    heads = _get_heads()
+    assert len(heads) == 1, f"multiple migration heads detected: {heads}"


### PR DESCRIPTION
## Summary
- add test ensuring there's only one Alembic head revision to avoid migration conflicts

## Testing
- `pytest tests/test_migrations.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689215affc64832ebedd7f3f8250da03