### PR TITLE
Expose OS form builder option via user cargo flag

### DIFF
--- a/models.py
+++ b/models.py
@@ -271,6 +271,11 @@ class User(db.Model):
         """Verifica se o usuário possui uma permissão pelo código."""
         return any(f.codigo == codigo for f in self.get_permissoes())
 
+    @property
+    def atende_ordem_servico(self) -> bool:
+        """Indica se o usuário pode atender ordens de serviço."""
+        return bool(self.cargo and getattr(self.cargo, 'atende_ordem_servico', False))
+
     def __repr__(self):
         return f"<User {self.username}>"
 

--- a/tests/test_form_builder.py
+++ b/tests/test_form_builder.py
@@ -48,6 +48,8 @@ def test_permission_function(app_ctx):
         user_denied_id = create_user('u2', False)
         user_allowed = User.query.get(user_allowed_id)
         user_denied = User.query.get(user_denied_id)
+        assert user_allowed.atende_ordem_servico is True
+        assert user_denied.atende_ordem_servico is False
         assert user_can_access_form_builder(user_allowed) is True
         assert user_can_access_form_builder(user_denied) is False
 

--- a/utils.py
+++ b/utils.py
@@ -472,4 +472,4 @@ def eligible_review_notification_users(article):
 
 def user_can_access_form_builder(user):
     """Verifica se o usuário tem acesso ao criador de formulários."""
-    return bool(user and user.cargo and getattr(user.cargo, 'atende_ordem_servico', False))
+    return bool(user and getattr(user, 'atende_ordem_servico', False))


### PR DESCRIPTION
## Summary
- derive user's OS attendance capability from cargo
- update form builder access utility to use new property
- extend form builder tests for new flag

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68921eb54144832ea2b8beb150c24619