### PR TITLE
Ajusta rotas de formulários na ordem de serviço

### DIFF
--- a/blueprints/formularios.py
+++ b/blueprints/formularios.py
@@ -40,7 +40,7 @@ def novo_formulario():
             db.session.add(f)
             db.session.commit()
             flash('Formulário criado com sucesso!', 'success')
-            return redirect(url_for('listar_formularios'))
+            return redirect(url_for('formularios_bp.listar_formularios'))
     return render_template('formularios/form.html', formulario=None)
 
 
@@ -58,5 +58,5 @@ def editar_formulario(id):
             formulario.estrutura = estrutura
             db.session.commit()
             flash('Formulário atualizado!', 'success')
-            return redirect(url_for('listar_formularios'))
+            return redirect(url_for('formularios_bp.listar_formularios'))
     return render_template('formularios/form.html', formulario=formulario)

--- a/templates/base.html
+++ b/templates/base.html
@@ -318,7 +318,7 @@
                                 <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-binoculars-fill me-2"></i> Consultar OS</a></li>
                                 <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-person-lines-fill me-2"></i> Minhas OS</a></li>
                                 {% if user_can_access_form_builder(current_user) %}
-                                <li class="nav-item"><a class="nav-link {{ 'active' if 'formularios' in request.endpoint else '' }}" href="{{ url_for('listar_formularios') }}"><i class="bi bi-ui-checks-grid me-2"></i> Criador de Formulários</a></li>
+                                <li class="nav-item"><a class="nav-link {{ 'active' if 'formularios' in request.endpoint else '' }}" href="{{ url_for('formularios_bp.listar_formularios') }}"><i class="bi bi-ui-checks-grid me-2"></i> Criador de Formulários</a></li>
                                 {% endif %}
                             </ul>
                         </div>

--- a/templates/formularios/form.html
+++ b/templates/formularios/form.html
@@ -13,7 +13,7 @@
       <textarea class="form-control" id="estrutura" name="estrutura" rows="6">{{ formulario.estrutura if formulario else '' }}</textarea>
     </div>
     <button type="submit" class="btn btn-primary">Salvar</button>
-    <a href="{{ url_for('listar_formularios') }}" class="btn btn-secondary">Cancelar</a>
+    <a href="{{ url_for('formularios_bp.listar_formularios') }}" class="btn btn-secondary">Cancelar</a>
   </form>
 </div>
 {% endblock %}

--- a/templates/formularios/lista.html
+++ b/templates/formularios/lista.html
@@ -4,7 +4,7 @@
 <div class="container mt-3">
   <div class="d-flex justify-content-between mb-3">
     <h1>Formulários</h1>
-    <a class="btn btn-primary" href="{{ url_for('novo_formulario') }}">Novo Formulário</a>
+    <a class="btn btn-primary" href="{{ url_for('formularios_bp.novo_formulario') }}">Novo Formulário</a>
   </div>
   {% if formularios %}
   <table class="table table-striped">
@@ -13,7 +13,7 @@
     {% for f in formularios %}
       <tr>
         <td>{{ f.nome }}</td>
-        <td><a class="btn btn-sm btn-secondary" href="{{ url_for('editar_formulario', id=f.id) }}">Editar</a></td>
+        <td><a class="btn btn-sm btn-secondary" href="{{ url_for('formularios_bp.editar_formulario', id=f.id) }}">Editar</a></td>
       </tr>
     {% endfor %}
     </tbody>


### PR DESCRIPTION
## Resumo
- Corrige redirecionamentos no blueprint de formulários usando endpoints do próprio blueprint
- Atualiza menu "Ordens de Serviço" para apontar corretamente para o Criador de Formulários
- Ajusta templates de formulários para usarem rotas nomeadas do blueprint

## Testes
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68922fe112d4832eb69175568f2b011a