### PR TITLE
feat: add service order CRUD

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,6 +46,7 @@ try:
         Instituicao,
         Funcao,
         user_funcoes,
+        OrdemServico,
     )
 except ImportError:  # pragma: no cover - fallback for direct execution
     from models import (
@@ -63,6 +64,7 @@ except ImportError:  # pragma: no cover - fallback for direct execution
         Instituicao,
         Funcao,
         user_funcoes,
+        OrdemServico,
     )
 
 try:
@@ -173,12 +175,14 @@ try:
     from .blueprints.articles import articles_bp
     from .blueprints.processos import processos_bp
     from .blueprints.formularios import formularios_bp
+    from .blueprints.ordens_servico import ordens_servico_bp
 except ImportError:  # pragma: no cover - fallback for direct execution
     from blueprints.admin import admin_bp
     from blueprints.auth import auth_bp
     from blueprints.articles import articles_bp
     from blueprints.processos import processos_bp
     from blueprints.formularios import formularios_bp
+    from blueprints.ordens_servico import ordens_servico_bp
 
 
 app.register_blueprint(admin_bp)
@@ -186,9 +190,10 @@ app.register_blueprint(auth_bp)
 app.register_blueprint(articles_bp)
 app.register_blueprint(processos_bp)
 app.register_blueprint(formularios_bp)
+app.register_blueprint(ordens_servico_bp)
 
 for rule in list(app.url_map.iter_rules()):
-    if rule.endpoint.startswith('admin_bp.') or rule.endpoint.startswith('auth_bp.') or rule.endpoint.startswith('articles_bp.') or rule.endpoint.startswith('processos_bp.') or rule.endpoint.startswith('formularios_bp.'):
+    if rule.endpoint.startswith('admin_bp.') or rule.endpoint.startswith('auth_bp.') or rule.endpoint.startswith('articles_bp.') or rule.endpoint.startswith('processos_bp.') or rule.endpoint.startswith('formularios_bp.') or rule.endpoint.startswith('ordens_servico_bp.'):
         app.add_url_rule(
             rule.rule,
             endpoint=rule.endpoint.split('.',1)[-1],

--- a/blueprints/ordens_servico.py
+++ b/blueprints/ordens_servico.py
@@ -1,0 +1,85 @@
+from flask import Blueprint, render_template, request, redirect, url_for, flash
+
+try:
+    from ..database import db
+except ImportError:  # pragma: no cover
+    from database import db
+
+try:
+    from ..models import OrdemServico, Processo
+except ImportError:  # pragma: no cover
+    from models import OrdemServico, Processo
+
+try:
+    from ..decorators import admin_required
+except ImportError:  # pragma: no cover
+    from decorators import admin_required
+
+ordens_servico_bp = Blueprint('ordens_servico_bp', __name__)
+
+
+@ordens_servico_bp.route('/admin/ordens_servico', methods=['GET', 'POST'])
+@admin_required
+def admin_ordens_servico():
+    ordem_editar = None
+    if request.method == 'GET':
+        edit_id = request.args.get('edit_id')
+        if edit_id:
+            ordem_editar = OrdemServico.query.get_or_404(edit_id)
+    if request.method == 'POST':
+        id_para_atualizar = request.form.get('id_para_atualizar')
+        titulo = request.form.get('titulo', '').strip()
+        descricao = request.form.get('descricao', '').strip()
+        processo_id = request.form.get('processo_id') or None
+        status = request.form.get('status', 'aberta').strip() or 'aberta'
+        if not titulo:
+            flash('Título da Ordem de Serviço é obrigatório.', 'danger')
+        else:
+            if id_para_atualizar:
+                ordem = OrdemServico.query.get_or_404(id_para_atualizar)
+                ordem.titulo = titulo
+                ordem.descricao = descricao
+                ordem.processo_id = processo_id
+                ordem.status = status
+                action_msg = 'atualizada'
+            else:
+                ordem = OrdemServico(
+                    titulo=titulo,
+                    descricao=descricao,
+                    processo_id=processo_id,
+                    status=status,
+                )
+                db.session.add(ordem)
+                action_msg = 'criada'
+            try:
+                db.session.commit()
+                flash(f'Ordem de Serviço {action_msg} com sucesso!', 'success')
+                return redirect(url_for('ordens_servico_bp.admin_ordens_servico'))
+            except Exception as e:
+                db.session.rollback()
+                flash(f'Erro ao salvar ordem de serviço: {str(e)}', 'danger')
+        if id_para_atualizar:
+            ordem_editar = OrdemServico.query.get(id_para_atualizar)
+    ordens = OrdemServico.query.order_by(OrdemServico.created_at.desc()).all()
+    processos = Processo.query.order_by(Processo.nome).all()
+    return render_template(
+        'admin/ordens_servico.html',
+        ordens=ordens,
+        ordem_editar=ordem_editar,
+        processos=processos,
+    )
+
+
+@ordens_servico_bp.route('/admin/ordens_servico/delete/<ordem_id>', methods=['POST'])
+@admin_required
+def admin_delete_ordem(ordem_id):
+    ordem = OrdemServico.query.get_or_404(ordem_id)
+    try:
+        db.session.delete(ordem)
+        db.session.commit()
+        flash('Ordem de Serviço removida com sucesso!', 'success')
+    except Exception as e:
+        db.session.rollback()
+        flash(f'Erro ao remover ordem de serviço: {str(e)}', 'danger')
+    return redirect(url_for('ordens_servico_bp.admin_ordens_servico'))
+

--- a/migrations/versions/1a2b3c4d5e7f_add_ordem_servico_table.py
+++ b/migrations/versions/1a2b3c4d5e7f_add_ordem_servico_table.py
@@ -1,0 +1,29 @@
+"""add ordem_servico table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '1a2b3c4d5e7f'
+down_revision = '14f1ad31865d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'ordem_servico',
+        sa.Column('id', sa.String(length=36), nullable=False),
+        sa.Column('titulo', sa.String(length=255), nullable=False),
+        sa.Column('descricao', sa.Text(), nullable=True),
+        sa.Column('processo_id', sa.String(length=36), nullable=True),
+        sa.Column('status', sa.String(length=20), nullable=False, server_default='aberta'),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(['processo_id'], ['processo.id']),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade():
+    op.drop_table('ordem_servico')
+

--- a/models.py
+++ b/models.py
@@ -463,6 +463,23 @@ class CampoEtapa(db.Model):
         return f"<CampoEtapa {self.nome} ({self.tipo})>"
 
 
+class OrdemServico(db.Model):
+    __tablename__ = 'ordem_servico'
+
+    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    titulo = db.Column(db.String(255), nullable=False)
+    descricao = db.Column(db.Text, nullable=True)
+    processo_id = db.Column(db.String(36), db.ForeignKey('processo.id'), nullable=True)
+    status = db.Column(db.String(20), nullable=False, default='aberta', server_default='aberta')
+    created_at = db.Column(db.DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = db.Column(db.DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    processo = db.relationship('Processo')
+
+    def __repr__(self):
+        return f"<OrdemServico {self.titulo} ({self.status})>"
+
+
 class RespostaEtapaOS(db.Model):
     __tablename__ = 'resposta_etapa_os'
 

--- a/templates/admin/ordens_servico.html
+++ b/templates/admin/ordens_servico.html
@@ -1,0 +1,63 @@
+{% block content %}
+<div class="container-fluid px-5 mt-3">
+  <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-1 border-bottom">
+    <h1 class="h2">Gerenciar Ordens de Serviço</h1>
+  </div>
+  <div class="row">
+    <div class="col-md-6">
+      <h3>Cadastro</h3>
+      <form method="POST" action="{{ url_for('ordens_servico_bp.admin_ordens_servico') }}" novalidate>
+        {% if ordem_editar %}
+        <input type="hidden" name="id_para_atualizar" value="{{ ordem_editar.id }}">
+        {% endif %}
+        <div class="mb-3">
+          <label for="titulo" class="form-label">Título <span class="text-danger">*</span></label>
+          <input type="text" class="form-control" id="titulo" name="titulo" value="{{ request.form.get('titulo', ordem_editar.titulo if ordem_editar else '') }}" required>
+        </div>
+        <div class="mb-3">
+          <label for="descricao" class="form-label">Descrição</label>
+          <textarea class="form-control" id="descricao" name="descricao" rows="3">{{ request.form.get('descricao', ordem_editar.descricao if ordem_editar else '') }}</textarea>
+        </div>
+        <div class="mb-3">
+          <label for="processo_id" class="form-label">Processo</label>
+          <select class="form-select" id="processo_id" name="processo_id">
+            <option value="">--</option>
+            {% for proc in processos %}
+            <option value="{{ proc.id }}" {% if ordem_editar and ordem_editar.processo_id==proc.id %}selected{% endif %}>{{ proc.nome }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="mb-3">
+          <label for="status" class="form-label">Status</label>
+          <input type="text" class="form-control" id="status" name="status" value="{{ request.form.get('status', ordem_editar.status if ordem_editar else 'aberta') }}">
+        </div>
+        <button type="submit" class="btn btn-primary">Salvar</button>
+      </form>
+    </div>
+    <div class="col-md-6">
+      <h3>Ordens</h3>
+      {% if ordens %}
+      <table class="table table-sm">
+        <thead><tr><th>Título</th><th>Status</th><th>Ações</th></tr></thead>
+        <tbody>
+        {% for os in ordens %}
+        <tr>
+          <td>{{ os.titulo }}</td>
+          <td>{{ os.status }}</td>
+          <td>
+            <a class="btn btn-sm btn-outline-primary" href="{{ url_for('ordens_servico_bp.admin_ordens_servico', edit_id=os.id) }}">Editar</a>
+            <form action="{{ url_for('ordens_servico_bp.admin_delete_ordem', ordem_id=os.id) }}" method="POST" style="display:inline;">
+              <button type="submit" class="btn btn-sm btn-outline-danger">Excluir</button>
+            </form>
+          </td>
+        </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+      <p class="text-muted">Nenhuma ordem cadastrada.</p>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/tests/test_ordem_servico.py
+++ b/tests/test_ordem_servico.py
@@ -1,0 +1,70 @@
+import pytest
+
+from app import app, db
+from models import OrdemServico, Processo, Instituicao, Estabelecimento, Setor, Celula, User, Funcao
+
+
+@pytest.fixture
+def client(app_ctx):
+    with app_ctx.test_client() as client:
+        yield client
+
+
+def login_admin(client):
+    with app.app_context():
+        inst = Instituicao(nome='Inst')
+        est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao=inst)
+        setor = Setor(nome='S1', estabelecimento=est)
+        cel = Celula(nome='C1', estabelecimento=est, setor=setor)
+        func = Funcao(codigo='admin', nome='Admin')
+        db.session.add_all([inst, est, setor, cel, func])
+        user = User(username='admin', email='a@test', estabelecimento=est, setor=setor, celula=cel)
+        user.set_password('x')
+        user.permissoes_personalizadas.append(func)
+        db.session.add(user)
+        db.session.commit()
+        uid = user.id
+    with client.session_transaction() as sess:
+        sess['user_id'] = uid
+
+
+def test_crud_ordem_servico(client):
+    login_admin(client)
+    with app.app_context():
+        proc = Processo(nome='Proc', descricao='d')
+        db.session.add(proc)
+        db.session.commit()
+        proc_id = proc.id
+    # create
+    resp = client.post('/admin/ordens_servico', data={
+        'titulo': 'OS1',
+        'descricao': 'desc',
+        'processo_id': proc_id,
+        'status': 'aberta'
+    }, follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        os_obj = OrdemServico.query.filter_by(titulo='OS1').first()
+        assert os_obj is not None
+        os_id = os_obj.id
+        assert os_obj.processo_id == proc_id
+    # update
+    resp = client.post('/admin/ordens_servico', data={
+        'id_para_atualizar': os_id,
+        'titulo': 'OS1 edit',
+        'descricao': 'd2',
+        'processo_id': '',
+        'status': 'fechada'
+    }, follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        os_obj = OrdemServico.query.get(os_id)
+        assert os_obj.titulo == 'OS1 edit'
+        assert os_obj.processo_id is None
+        assert os_obj.status == 'fechada'
+    # delete
+    resp = client.post(f'/admin/ordens_servico/delete/{os_id}', follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        assert OrdemServico.query.get(os_id) is None
+


### PR DESCRIPTION
## Summary
- add OrdemServico model and migration
- implement admin views and template for service order CRUD
- cover basic service order workflow with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689232e01cfc832e8e95d97a8946884c