### PR TITLE
Add basic service order pages and navigation

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -314,9 +314,9 @@
                         </a>
                         <div class="collapse {{ 'show' if os_active }}" id="collapseOSGlobal">
                             <ul class="nav flex-column ps-3">
-                                <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-plus-circle-dotted me-2"></i> Abrir Nova OS</a></li>
-                                <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-binoculars-fill me-2"></i> Consultar OS</a></li>
-                                <li class="nav-item"><a class="nav-link" href="#"><i class="bi bi-person-lines-fill me-2"></i> Minhas OS</a></li>
+                                <li class="nav-item"><a class="nav-link {{ 'active' if 'os_nova' in request.endpoint else '' }}" href="{{ url_for('ordens_servico_bp.os_nova') }}"><i class="bi bi-plus-circle-dotted me-2"></i> Abrir Nova OS</a></li>
+                                <li class="nav-item"><a class="nav-link {{ 'active' if 'os_listar' in request.endpoint else '' }}" href="{{ url_for('ordens_servico_bp.os_listar') }}"><i class="bi bi-binoculars-fill me-2"></i> Consultar OS</a></li>
+                                <li class="nav-item"><a class="nav-link {{ 'active' if 'os_minhas' in request.endpoint else '' }}" href="{{ url_for('ordens_servico_bp.os_minhas') }}"><i class="bi bi-person-lines-fill me-2"></i> Minhas OS</a></li>
                                 {% if user_can_access_form_builder(current_user) %}
                                 <li class="nav-item"><a class="nav-link {{ 'active' if 'formularios' in request.endpoint else '' }}" href="{{ url_for('formularios_bp.listar_formularios') }}"><i class="bi bi-ui-checks-grid me-2"></i> Criador de Formulários</a></li>
                                 {% endif %}

--- a/templates/ordens_servico/detalhe_os.html
+++ b/templates/ordens_servico/detalhe_os.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}{{ ordem.titulo }}{% endblock %}
+{% block content %}
+<div class="container-fluid px-5 mt-3">
+  <div class="row">
+    <div class="col-md-8 mx-auto">
+      <div class="card shadow-sm">
+        <div class="card-body">
+          <h3>{{ ordem.titulo }}</h3>
+          <p class="text-muted">Status: {{ ordem.status }}</p>
+          {% if ordem.processo %}
+          <p class="text-muted">Processo: {{ ordem.processo.nome }}</p>
+          {% endif %}
+          <p>{{ ordem.descricao }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/ordens_servico/listar_os.html
+++ b/templates/ordens_servico/listar_os.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block title %}Ordens de Serviço{% endblock %}
+{% block content %}
+<div class="container-fluid px-5 mt-3">
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <h3>Ordens de Serviço</h3>
+      {% if ordens %}
+      <div class="table-responsive">
+        <table class="table table-hover table-sm align-middle">
+          <thead>
+            <tr>
+              <th>Título</th>
+              <th>Status</th>
+              <th class="text-end">Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+          {% for os in ordens %}
+            <tr>
+              <td>{{ os.titulo }}</td>
+              <td>{{ os.status }}</td>
+              <td class="text-end">
+                <a href="{{ url_for('ordens_servico_bp.detalhar_os', ordem_id=os.id) }}" class="btn btn-sm btn-outline-primary">Detalhes</a>
+              </td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% else %}
+      <p class="text-muted">Nenhuma Ordem de Serviço encontrada.</p>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/ordens_servico/minhas_os.html
+++ b/templates/ordens_servico/minhas_os.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block title %}Minhas Ordens de Serviço{% endblock %}
+{% block content %}
+<div class="container-fluid px-5 mt-3">
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <h3>Minhas Ordens de Serviço</h3>
+      {% if ordens %}
+      <div class="list-group">
+        {% for os in ordens %}
+        <a href="{{ url_for('ordens_servico_bp.detalhar_os', ordem_id=os.id) }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+          <span>{{ os.titulo }}</span>
+          <span class="badge bg-secondary">{{ os.status }}</span>
+        </a>
+        {% endfor %}
+      </div>
+      {% else %}
+      <p class="text-muted">Nenhuma Ordem de Serviço encontrada.</p>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/ordens_servico/nova_os.html
+++ b/templates/ordens_servico/nova_os.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% block title %}Nova Ordem de Serviço{% endblock %}
+{% block content %}
+<div class="container-fluid px-5 mt-3">
+  <div class="row">
+    <div class="col-md-8 mx-auto">
+      <div class="card shadow-sm">
+        <div class="card-body">
+          <h3>Abrir Nova Ordem de Serviço</h3>
+          <form method="POST">
+            <div class="mb-3">
+              <label for="titulo" class="form-label">Título <span class="text-danger">*</span></label>
+              <input type="text" class="form-control" id="titulo" name="titulo" required>
+            </div>
+            <div class="mb-3">
+              <label for="descricao" class="form-label">Descrição</label>
+              <textarea class="form-control" id="descricao" name="descricao" rows="4"></textarea>
+            </div>
+            <div class="mb-3">
+              <label for="processo_id" class="form-label">Processo</label>
+              <select class="form-select" id="processo_id" name="processo_id">
+                <option value="">--</option>
+                {% for proc in processos %}
+                <option value="{{ proc.id }}">{{ proc.nome }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <button type="submit" class="btn btn-primary">Salvar</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add user-facing service order routes and templates
- wire new service order links into sidebar navigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689236e14390832e8f22472b4c311073