### PR TITLE
Fix service order detail link

### DIFF
--- a/templates/ordens_servico/listar_os.html
+++ b/templates/ordens_servico/listar_os.html
@@ -21,7 +21,7 @@
               <td>{{ os.titulo }}</td>
               <td>{{ os.status }}</td>
               <td class="text-end">
-                <a href="{{ url_for('ordens_servico_bp.detalhar_os', ordem_id=os.id) }}" class="btn btn-sm btn-outline-primary">Detalhes</a>
+                <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.id) }}" class="btn btn-sm btn-outline-primary">Detalhes</a>
               </td>
             </tr>
           {% endfor %}

--- a/templates/ordens_servico/minhas_os.html
+++ b/templates/ordens_servico/minhas_os.html
@@ -8,7 +8,7 @@
       {% if ordens %}
       <div class="list-group">
         {% for os in ordens %}
-        <a href="{{ url_for('ordens_servico_bp.detalhar_os', ordem_id=os.id) }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+        <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.id) }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
           <span>{{ os.titulo }}</span>
           <span class="badge bg-secondary">{{ os.status }}</span>
         </a>


### PR DESCRIPTION
## Summary
- fix `url_for` endpoint for service order details in listing and personal pages

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68923968ed5c832e9512fe05e6ce2d9d