### PR TITLE
Add visual form builder interface

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -170,3 +170,10 @@ body > .container {
   padding: 0 2px;
   border-radius: 3px;
 }
+/* Form builder styles */
+#fieldsContainer .field.card {
+  border: 1px solid #dee2e6;
+}
+#fieldsContainer .field .remove-field {
+  float: right;
+}

--- a/static/js/form_builder.js
+++ b/static/js/form_builder.js
@@ -1,0 +1,105 @@
+// static/js/form_builder.js
+// Simple form builder interface similar to Microsoft Forms
+
+document.addEventListener('DOMContentLoaded', () => {
+  const fieldsContainer = document.getElementById('fieldsContainer');
+  const addFieldBtn = document.getElementById('addField');
+  const estruturaInput = document.getElementById('estrutura');
+  const form = document.getElementById('formBuilderForm');
+
+  function updateJSON() {
+    const fields = [];
+    fieldsContainer.querySelectorAll('.field').forEach((fieldEl, idx) => {
+      const tipo = fieldEl.querySelector('.field-tipo').value;
+      const label = fieldEl.querySelector('.field-label').value.trim();
+      const obrigatorio = fieldEl.querySelector('.field-obrigatorio').checked;
+      const opcoes = fieldEl.querySelector('.field-opcoes').value
+        .split(',')
+        .map(o => o.trim())
+        .filter(o => o);
+      fields.push({ tipo, label, obrigatorio, ordem: idx, opcoes });
+    });
+    estruturaInput.value = JSON.stringify(fields);
+  }
+
+  function addField(data = {}) {
+    const div = document.createElement('div');
+    div.className = 'field card mb-3';
+    div.innerHTML = `
+      <div class="card-body">
+        <div class="mb-2">
+          <label class="form-label">Tipo</label>
+          <select class="form-select field-tipo">
+            <option value="text">Texto</option>
+            <option value="textarea">Parágrafo</option>
+            <option value="select">Escolha</option>
+          </select>
+        </div>
+        <div class="mb-2">
+          <label class="form-label">Label</label>
+          <input type="text" class="form-control field-label">
+        </div>
+        <div class="mb-2 field-opcoes-wrapper d-none">
+          <label class="form-label">Opções (separadas por vírgula)</label>
+          <input type="text" class="form-control field-opcoes">
+        </div>
+        <div class="form-check mb-2">
+          <input class="form-check-input field-obrigatorio" type="checkbox" id="field-obrig-${Date.now()}">
+          <label class="form-check-label" for="field-obrig-${Date.now()}">Obrigatório</label>
+        </div>
+        <button type="button" class="btn btn-sm btn-outline-danger remove-field">Remover</button>
+      </div>`;
+    fieldsContainer.appendChild(div);
+
+    const tipoSelect = div.querySelector('.field-tipo');
+    const opcoesWrapper = div.querySelector('.field-opcoes-wrapper');
+    const opcoesInput = div.querySelector('.field-opcoes');
+
+    tipoSelect.addEventListener('change', () => {
+      if (tipoSelect.value === 'select') {
+        opcoesWrapper.classList.remove('d-none');
+      } else {
+        opcoesWrapper.classList.add('d-none');
+      }
+      updateJSON();
+    });
+
+    div.querySelector('.remove-field').addEventListener('click', () => {
+      div.remove();
+      updateJSON();
+    });
+
+    div.querySelectorAll('input, select').forEach(el => {
+      el.addEventListener('input', updateJSON);
+      el.addEventListener('change', updateJSON);
+    });
+
+    // Prefill data if editing existing structure
+    tipoSelect.value = data.tipo || 'text';
+    div.querySelector('.field-label').value = data.label || '';
+    div.querySelector('.field-obrigatorio').checked = data.obrigatorio || false;
+    if (data.tipo === 'select') {
+      opcoesWrapper.classList.remove('d-none');
+      opcoesInput.value = (data.opcoes || []).join(', ');
+    }
+
+    updateJSON();
+  }
+
+  addFieldBtn.addEventListener('click', () => addField());
+
+  // Load existing structure if present
+  if (estruturaInput.value) {
+    try {
+      const parsed = JSON.parse(estruturaInput.value);
+      parsed.forEach(f => addField(f));
+    } catch (e) {
+      console.error('Erro ao carregar estrutura existente', e);
+    }
+  }
+
+  form.addEventListener('submit', () => {
+    updateJSON();
+  });
+});
+

--- a/templates/formularios/form.html
+++ b/templates/formularios/form.html
@@ -3,17 +3,22 @@
 {% block content %}
 <div class="container mt-3">
   <h1>{{ 'Editar' if formulario else 'Novo' }} Formulário</h1>
-  <form method="POST">
+  <form method="POST" id="formBuilderForm">
     <div class="mb-3">
       <label for="nome" class="form-label">Nome</label>
       <input type="text" class="form-control" id="nome" name="nome" value="{{ formulario.nome if formulario else '' }}" required>
     </div>
-    <div class="mb-3">
-      <label for="estrutura" class="form-label">Estrutura (JSON)</label>
-      <textarea class="form-control" id="estrutura" name="estrutura" rows="6">{{ formulario.estrutura if formulario else '' }}</textarea>
+    <div id="fieldsContainer"></div>
+    <button type="button" class="btn btn-outline-primary mb-3" id="addField">Adicionar Pergunta</button>
+    <input type="hidden" id="estrutura" name="estrutura" value="{{ formulario.estrutura|e if formulario else '' }}">
+    <div class="mt-3">
+      <button type="submit" class="btn btn-primary">Salvar</button>
+      <a href="{{ url_for('formularios_bp.listar_formularios') }}" class="btn btn-secondary">Cancelar</a>
     </div>
-    <button type="submit" class="btn btn-primary">Salvar</button>
-    <a href="{{ url_for('formularios_bp.listar_formularios') }}" class="btn btn-secondary">Cancelar</a>
   </form>
 </div>
+{% endblock %}
+{% block extra_js %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/form_builder.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Implement dynamic form builder with add/remove question capability and JSON serialization
- Replace simple JSON textarea with interactive form builder page
- Add basic styling for builder cards

## Testing
- `pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68923cd1b038832ebf6f3c9ff1bdfaef