### PR TITLE
feat: add more form field types

### DIFF
--- a/static/js/form_builder.js
+++ b/static/js/form_builder.js
@@ -33,6 +33,14 @@ document.addEventListener('DOMContentLoaded', () => {
             <option value="text">Texto</option>
             <option value="textarea">Parágrafo</option>
             <option value="select">Escolha</option>
+            <option value="option">Opção</option>
+            <option value="rating">Classificação</option>
+            <option value="date">Data</option>
+            <option value="likert">Likert</option>
+            <option value="file">Carregar Arquivo</option>
+            <option value="nps">Net Promoter Score®</option>
+            <option value="section">Seção</option>
+            <option value="table">Tabelas</option>
           </select>
         </div>
         <div class="mb-2">
@@ -56,7 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const opcoesInput = div.querySelector('.field-opcoes');
 
     tipoSelect.addEventListener('change', () => {
-      if (tipoSelect.value === 'select') {
+      if (['select', 'option', 'likert', 'table'].includes(tipoSelect.value)) {
         opcoesWrapper.classList.remove('d-none');
       } else {
         opcoesWrapper.classList.add('d-none');
@@ -78,7 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
     tipoSelect.value = data.tipo || 'text';
     div.querySelector('.field-label').value = data.label || '';
     div.querySelector('.field-obrigatorio').checked = data.obrigatorio || false;
-    if (data.tipo === 'select') {
+    if (['select', 'option', 'likert', 'table'].includes(data.tipo)) {
       opcoesWrapper.classList.remove('d-none');
       opcoesInput.value = (data.opcoes || []).join(', ');
     }

--- a/templates/formularios/preencher_formulario.html
+++ b/templates/formularios/preencher_formulario.html
@@ -7,18 +7,83 @@
       <h3 class="mb-3">Preencher Formulário: {{ formulario.nome }}</h3>
       <form>
         {% for campo in estrutura %}
+          {% set idx = loop.index0 %}
           <div class="mb-3">
-            <label class="form-label">{{ campo.label }}{% if campo.obrigatorio %} *{% endif %}</label>
-            {% if campo.tipo == 'textarea' %}
-              <textarea class="form-control" {% if campo.obrigatorio %}required{% endif %}></textarea>
-            {% elif campo.tipo == 'select' %}
-              <select class="form-select" {% if campo.obrigatorio %}required{% endif %}>
-                {% for opcao in campo.opcoes %}
-                  <option value="{{ opcao }}">{{ opcao }}</option>
-                {% endfor %}
-              </select>
+            {% if campo.tipo == 'section' %}
+              <h4 class="mt-4">{{ campo.label }}</h4>
             {% else %}
-              <input type="text" class="form-control" {% if campo.obrigatorio %}required{% endif %}>
+              <label class="form-label">{{ campo.label }}{% if campo.obrigatorio %} *{% endif %}</label>
+              {% if campo.tipo == 'textarea' %}
+                <textarea class="form-control" {% if campo.obrigatorio %}required{% endif %}></textarea>
+              {% elif campo.tipo == 'select' %}
+                <select class="form-select" {% if campo.obrigatorio %}required{% endif %}>
+                  {% for opcao in campo.opcoes %}
+                    <option value="{{ opcao }}">{{ opcao }}</option>
+                  {% endfor %}
+                </select>
+              {% elif campo.tipo == 'option' %}
+                {% for opcao in campo.opcoes %}
+                  <div class="form-check">
+                    <input class="form-check-input" type="radio" name="campo{{ idx }}" value="{{ opcao }}" {% if campo.obrigatorio %}required{% endif %}>
+                    <label class="form-check-label">{{ opcao }}</label>
+                  </div>
+                {% endfor %}
+              {% elif campo.tipo == 'rating' %}
+                {% set opcoes = campo.opcoes if campo.opcoes else ['1','2','3','4','5'] %}
+                <select class="form-select" {% if campo.obrigatorio %}required{% endif %}>
+                  {% for opcao in opcoes %}
+                    <option value="{{ opcao }}">{{ opcao }}</option>
+                  {% endfor %}
+                </select>
+              {% elif campo.tipo == 'date' %}
+                <input type="date" class="form-control" {% if campo.obrigatorio %}required{% endif %}>
+              {% elif campo.tipo == 'likert' %}
+                {% set opcoes = campo.opcoes if campo.opcoes else ['Discordo totalmente','Discordo','Neutro','Concordo','Concordo totalmente'] %}
+                <div>
+                  {% for opcao in opcoes %}
+                    <div class="form-check form-check-inline">
+                      <input class="form-check-input" type="radio" name="campo{{ idx }}" value="{{ opcao }}" {% if campo.obrigatorio %}required{% endif %}>
+                      <label class="form-check-label">{{ opcao }}</label>
+                    </div>
+                  {% endfor %}
+                </div>
+              {% elif campo.tipo == 'file' %}
+                <input type="file" class="form-control" {% if campo.obrigatorio %}required{% endif %}>
+              {% elif campo.tipo == 'nps' %}
+                <div class="d-flex flex-wrap">
+                  {% for i in range(11) %}
+                    <div class="form-check form-check-inline">
+                      <input class="form-check-input" type="radio" name="campo{{ idx }}" value="{{ i }}" {% if campo.obrigatorio %}required{% endif %}>
+                      <label class="form-check-label">{{ i }}</label>
+                    </div>
+                  {% endfor %}
+                </div>
+              {% elif campo.tipo == 'table' %}
+                <div class="table-responsive">
+                  <table class="table table-bordered">
+                    {% if campo.opcoes %}
+                      <thead>
+                        <tr>
+                          {% for cab in campo.opcoes %}
+                            <th>{{ cab }}</th>
+                          {% endfor %}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          {% for cab in campo.opcoes %}
+                            <td><input type="text" class="form-control"></td>
+                          {% endfor %}
+                        </tr>
+                      </tbody>
+                    {% else %}
+                      <tbody><tr><td>Sem dados</td></tr></tbody>
+                    {% endif %}
+                  </table>
+                </div>
+              {% else %}
+                <input type="text" class="form-control" {% if campo.obrigatorio %}required{% endif %}>
+              {% endif %}
             {% endif %}
           </div>
         {% endfor %}


### PR DESCRIPTION
## Summary
- extend form builder options for Option, Rating, Date, Likert, File upload, Net Promoter Score, Section and Table types
- support rendering of new field types when filling forms

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68924ad8d0d0832e8c1d1b4b4a95d8e8