### PR TITLE
feat: enable field preview menu

### DIFF
--- a/static/js/form_builder.js
+++ b/static/js/form_builder.js
@@ -3,7 +3,6 @@
 
 document.addEventListener('DOMContentLoaded', () => {
   const fieldsContainer = document.getElementById('fieldsContainer');
-  const addFieldBtn = document.getElementById('addField');
   const estruturaInput = document.getElementById('estrutura');
   const form = document.getElementById('formBuilderForm');
 
@@ -22,7 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
     estruturaInput.value = JSON.stringify(fields);
   }
 
-  function addField(data = {}) {
+  function addField(tipo, data = {}) {
     const div = document.createElement('div');
     div.className = 'field card mb-3';
     div.innerHTML = `
@@ -83,7 +82,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // Prefill data if editing existing structure
-    tipoSelect.value = data.tipo || 'text';
+    tipoSelect.value = data.tipo || tipo || 'text';
     div.querySelector('.field-label').value = data.label || '';
     div.querySelector('.field-obrigatorio').checked = data.obrigatorio || false;
     if (['select', 'option', 'likert', 'table'].includes(data.tipo)) {
@@ -94,13 +93,13 @@ document.addEventListener('DOMContentLoaded', () => {
     updateJSON();
   }
 
-  addFieldBtn.addEventListener('click', () => addField());
+  window.addField = addField;
 
   // Load existing structure if present
   if (estruturaInput.value) {
     try {
       const parsed = JSON.parse(estruturaInput.value);
-      parsed.forEach(f => addField(f));
+      parsed.forEach(f => addField(f.tipo, f));
     } catch (e) {
       console.error('Erro ao carregar estrutura existente', e);
     }

--- a/templates/formularios/cadastro_formulario.html
+++ b/templates/formularios/cadastro_formulario.html
@@ -27,8 +27,26 @@
               </div>
 
               <div class="tab-pane fade p-3" id="fields" role="tabpanel" aria-labelledby="fields-tab">
+                <div id="previewContainer" class="mb-3"></div>
                 <div id="fieldsContainer"></div>
-                <button type="button" class="btn btn-outline-primary mb-3" id="addField">Adicionar Pergunta</button>
+                <div class="dropdown mb-3">
+                  <button class="btn btn-outline-primary dropdown-toggle" type="button" id="addField" data-bs-toggle="dropdown" aria-expanded="false">
+                    Adicionar Pergunta
+                  </button>
+                  <ul class="dropdown-menu" aria-labelledby="addField" id="questionTypeMenu">
+                    <li><button class="dropdown-item" type="button" onclick="addField('text')">Texto</button></li>
+                    <li><button class="dropdown-item" type="button" onclick="addField('textarea')">Parágrafo</button></li>
+                    <li><button class="dropdown-item" type="button" onclick="addField('select')">Escolha</button></li>
+                    <li><button class="dropdown-item" type="button" onclick="addField('option')">Opção</button></li>
+                    <li><button class="dropdown-item" type="button" onclick="addField('rating')">Classificação</button></li>
+                    <li><button class="dropdown-item" type="button" onclick="addField('date')">Data</button></li>
+                    <li><button class="dropdown-item" type="button" onclick="addField('likert')">Likert</button></li>
+                    <li><button class="dropdown-item" type="button" onclick="addField('file')">Carregar Arquivo</button></li>
+                    <li><button class="dropdown-item" type="button" onclick="addField('nps')">Net Promoter Score®</button></li>
+                    <li><button class="dropdown-item" type="button" onclick="addField('section')">Seção</button></li>
+                    <li><button class="dropdown-item" type="button" onclick="addField('table')">Tabelas</button></li>
+                  </ul>
+                </div>
                 <input type="hidden" id="estrutura" name="estrutura" value="{{ formulario.estrutura|e if formulario else '' }}">
               </div>
             </div>

--- a/tests/test_form_builder.py
+++ b/tests/test_form_builder.py
@@ -77,3 +77,14 @@ def test_create_formulario(client):
     assert b'Form1' in resp.data
     with app.app_context():
         assert Formulario.query.filter_by(nome='Form1').first() is not None
+
+
+def test_field_added_after_type_selection(client):
+    with app.app_context():
+        user_allowed_id = create_user('builder_menu', True)
+    login(client, user_allowed_id)
+    resp = client.get('/ordem-servico/formularios/')
+    assert resp.status_code == 200
+    html = resp.data.decode('utf-8')
+    assert 'id="previewContainer"' in html
+    assert "onclick=\"addField('text')\"" in html


### PR DESCRIPTION
## Summary
- show question type dropdown and preview container on form builder
- allow addField to take explicit type and expose globally for menu usage
- test that type selection links render immediately

## Testing
- `pytest tests/test_form_builder.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68924ebb6398832eaeb6a52cf9786c0e