### PR TITLE
Enable drag and drop reordering for form fields

### DIFF
--- a/static/js/form_builder.js
+++ b/static/js/form_builder.js
@@ -6,6 +6,49 @@ document.addEventListener('DOMContentLoaded', () => {
   const estruturaInput = document.getElementById('estrutura');
   const form = document.getElementById('formBuilderForm');
 
+  let draggedField = null;
+
+  function addDragAndDropHandlers(field) {
+    field.draggable = true;
+    field.style.cursor = 'move';
+    field.addEventListener('dragstart', () => {
+      draggedField = field;
+      field.classList.add('dragging');
+    });
+    field.addEventListener('dragend', () => {
+      field.classList.remove('dragging');
+      draggedField = null;
+      updateJSON();
+    });
+  }
+
+  function getDragAfterElement(container, y) {
+    const elements = [...container.querySelectorAll('.field:not(.dragging)')];
+    return elements.reduce(
+      (closest, child) => {
+        const box = child.getBoundingClientRect();
+        const offset = y - box.top - box.height / 2;
+        if (offset < 0 && offset > closest.offset) {
+          return { offset, element: child };
+        } else {
+          return closest;
+        }
+      },
+      { offset: Number.NEGATIVE_INFINITY }
+    ).element;
+  }
+
+  fieldsContainer.addEventListener('dragover', e => {
+    if (!draggedField) return;
+    e.preventDefault();
+    const afterElement = getDragAfterElement(fieldsContainer, e.clientY);
+    if (afterElement == null) {
+      fieldsContainer.appendChild(draggedField);
+    } else if (afterElement !== draggedField) {
+      fieldsContainer.insertBefore(draggedField, afterElement);
+    }
+  });
+
   function updateJSON() {
     const fields = [];
     fieldsContainer.querySelectorAll('.field').forEach((fieldEl, idx) => {
@@ -98,6 +141,7 @@ document.addEventListener('DOMContentLoaded', () => {
         <button type="button" class="btn btn-sm btn-outline-danger remove-field">Remover</button>
       </div>`;
     fieldsContainer.appendChild(div);
+    addDragAndDropHandlers(div);
 
     const tipoSelect = div.querySelector('.field-tipo');
     const opcoesWrapper = div.querySelector('.field-opcoes-wrapper');

--- a/templates/formularios/cadastro_formulario.html
+++ b/templates/formularios/cadastro_formulario.html
@@ -28,7 +28,8 @@
 
               <div class="tab-pane fade p-3" id="fields" role="tabpanel" aria-labelledby="fields-tab">
                 <div id="previewContainer" class="mb-3"></div>
-                <div id="fieldsContainer"></div>
+                <div id="fieldsContainer" class="mb-2"></div>
+                <div class="form-text mb-3">Arraste os campos para reorganizá-los.</div>
                 <div class="dropdown mb-3">
                   <button class="btn btn-outline-primary dropdown-toggle" type="button" id="addFieldBtn" data-bs-toggle="dropdown" aria-expanded="false">
                     Adicionar Pergunta


### PR DESCRIPTION
## Summary
- allow dragging form fields to reorder them in builder
- inform users that fields can be rearranged by dragging

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892554bbfb8832ebf4618dedef252da