### PR TITLE
feat(form-builder): reorder questions via drag and drop

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,6 +47,8 @@ try:
         Funcao,
         user_funcoes,
         OrdemServico,
+        Formulario,
+        CampoFormulario,
     )
 except ImportError:  # pragma: no cover - fallback for direct execution
     from models import (
@@ -65,6 +67,8 @@ except ImportError:  # pragma: no cover - fallback for direct execution
         Funcao,
         user_funcoes,
         OrdemServico,
+        Formulario,
+        CampoFormulario,
     )
 
 try:
@@ -99,6 +103,10 @@ except ImportError:  # pragma: no cover - fallback for direct execution
         eligible_review_notification_users,
         user_can_access_form_builder,
     )
+try:
+    from .decorators import form_builder_required
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from decorators import form_builder_required
 from mimetypes import guess_type # Se for usar, descomente
 from werkzeug.utils import secure_filename # Útil para uploads, como na sua foto de perfil
 
@@ -337,6 +345,19 @@ def inject_notificacoes():
         'os_notificacoes': 0,
         'os_notificacoes_list': [],
     }
+
+
+@app.route("/formulario/reordenar_perguntas", methods=["POST"])
+@form_builder_required
+def reordenar_perguntas():
+    data = request.get_json(silent=True) or {}
+    ids = data.get("ids", [])
+    for ordem, campo_id in enumerate(ids):
+        campo = CampoFormulario.query.get(campo_id)
+        if campo:
+            campo.ordem = ordem
+    db.session.commit()
+    return jsonify({"status": "ok"})
 
 @app.context_processor
 def inject_enums():

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -177,3 +177,18 @@ body > .container {
 #fieldsContainer .field .remove-field {
   float: right;
 }
+
+/* Ordenação de perguntas no construtor */
+#fieldsContainer.sorting .field .card-body {
+  display: none;
+}
+#fieldsContainer .drag-handle {
+  cursor: grab;
+}
+.sortable-chosen {
+  box-shadow: 0 0 10px rgba(0,0,0,0.2);
+}
+.sortable-ghost {
+  border: 2px dashed #0d6efd;
+  background: #f8f9fa;
+}

--- a/templates/formularios/editar_formulario.html
+++ b/templates/formularios/editar_formulario.html
@@ -6,5 +6,6 @@
 {% endblock %}
 {% block extra_js %}
 {{ super() }}
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
 <script src="{{ url_for('static', filename='js/form_builder.js') }}"></script>
 {% endblock %}

--- a/templates/formularios/formulario.html
+++ b/templates/formularios/formulario.html
@@ -64,6 +64,7 @@
 {% endblock %}
 {% block extra_js %}
 {{ super() }}
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
 <script src="{{ url_for('static', filename='js/form_builder.js') }}"></script>
 <script>
 const busca = document.getElementById('formSearch');


### PR DESCRIPTION
## Summary
- enable drag-and-drop ordering for form questions with SortableJS
- update question numbers and persist order through new backend route
- rename "Label" to "Título" in the form builder UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892594d4c20832e81d89e1bc32058b7