### PR TITLE
Add section management to form builder

### DIFF
--- a/migrations/versions/2f1a2b3c4d5e_add_secao_table.py
+++ b/migrations/versions/2f1a2b3c4d5e_add_secao_table.py
@@ -1,0 +1,32 @@
+"""add secao table and campo_formulario.secao_id
+
+Revision ID: 2f1a2b3c4d5e
+Revises: 1a2b3c4d5e7f
+Create Date: 2025-06-02 00:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '2f1a2b3c4d5e'
+down_revision = '1a2b3c4d5e7f'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'secao',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('formulario_id', sa.Integer(), sa.ForeignKey('formulario.id'), nullable=False),
+        sa.Column('titulo', sa.String(length=200), nullable=True),
+        sa.Column('subtitulo', sa.String(length=200), nullable=True),
+        sa.Column('imagem_url', sa.String(length=255), nullable=True),
+        sa.Column('video_url', sa.String(length=255), nullable=True),
+        sa.Column('ordem', sa.Integer(), nullable=False)
+    )
+    op.add_column('campo_formulario', sa.Column('secao_id', sa.Integer(), nullable=True))
+    op.create_foreign_key('campo_formulario_secao_id_fkey', 'campo_formulario', 'secao', ['secao_id'], ['id'])
+
+def downgrade():
+    op.drop_constraint('campo_formulario_secao_id_fkey', 'campo_formulario', type_='foreignkey')
+    op.drop_column('campo_formulario', 'secao_id')
+    op.drop_table('secao')

--- a/models.py
+++ b/models.py
@@ -510,6 +510,12 @@ class Formulario(db.Model):
     updated_at = db.Column(db.DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 
     campos = db.relationship('CampoFormulario', back_populates='formulario', cascade='all, delete-orphan')
+    secoes = db.relationship(
+        'Secao',
+        back_populates='formulario',
+        cascade='all, delete-orphan',
+        order_by='Secao.ordem'
+    )
 
     def __repr__(self):
         return f"<Formulario {self.nome}>"
@@ -520,6 +526,7 @@ class CampoFormulario(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     formulario_id = db.Column(db.Integer, db.ForeignKey('formulario.id'), nullable=False)
+    secao_id = db.Column(db.Integer, db.ForeignKey('secao.id'), nullable=True)
     tipo = db.Column(db.String(50), nullable=False)
     label = db.Column(db.String(200), nullable=False)
     obrigatorio = db.Column(db.Boolean, nullable=False, default=False, server_default='false')
@@ -528,8 +535,27 @@ class CampoFormulario(db.Model):
     condicional = db.Column(db.Text, nullable=True)
 
     formulario = db.relationship('Formulario', back_populates='campos')
+    secao = db.relationship('Secao', back_populates='campos')
 
     def __repr__(self):
         return f"<CampoFormulario {self.label} ({self.tipo})>"
+
+
+class Secao(db.Model):
+    __tablename__ = 'secao'
+
+    id = db.Column(db.Integer, primary_key=True)
+    formulario_id = db.Column(db.Integer, db.ForeignKey('formulario.id'), nullable=False)
+    titulo = db.Column(db.String(200), nullable=True)
+    subtitulo = db.Column(db.String(200), nullable=True)
+    imagem_url = db.Column(db.String(255), nullable=True)
+    video_url = db.Column(db.String(255), nullable=True)
+    ordem = db.Column(db.Integer, nullable=False)
+
+    formulario = db.relationship('Formulario', back_populates='secoes')
+    campos = db.relationship('CampoFormulario', back_populates='secao', cascade='all, delete-orphan')
+
+    def __repr__(self):
+        return f"<Secao {self.titulo}>"
 
 # --- FIM DOS MODELOS ---

--- a/static/js/form_builder.js
+++ b/static/js/form_builder.js
@@ -7,25 +7,50 @@ document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('formBuilderForm');
 
   function updateNumbers() {
-    fieldsContainer.querySelectorAll('.field').forEach((el, idx) => {
+    let pergunta = 0;
+    let secao = 0;
+    fieldsContainer.querySelectorAll('.field').forEach(el => {
       const numero = el.querySelector('.question-number');
-      if (numero) numero.textContent = `Pergunta ${idx + 1}`;
+      const tipoEl = el.querySelector('.field-tipo');
+      if (tipoEl && tipoEl.value === 'section') {
+        secao += 1;
+        if (numero) numero.textContent = `Seção ${secao}`;
+      } else {
+        pergunta += 1;
+        if (numero) numero.textContent = `Pergunta ${pergunta}`;
+      }
     });
   }
 
   function updateQuestionTitle(fieldEl) {
     const titulo = fieldEl.querySelector('.field-label').value.trim();
+    const tipo = fieldEl.querySelector('.field-tipo').value;
     const titleSpan = fieldEl.querySelector('.question-title');
-    if (titleSpan) titleSpan.textContent = titulo || 'Pergunta';
+    if (!titleSpan) return;
+    if (tipo === 'section') {
+      titleSpan.textContent = titulo || 'Seção';
+    } else {
+      titleSpan.textContent = titulo || 'Pergunta';
+    }
   }
 
   function updateJSON() {
     const fields = [];
     fieldsContainer.querySelectorAll('.field').forEach((fieldEl, idx) => {
       const tipo = fieldEl.querySelector('.field-tipo').value;
+      const id = fieldEl.dataset.id;
+
+      if (tipo === 'section') {
+        const titulo = fieldEl.querySelector('.field-label').value.trim();
+        const subtitulo = fieldEl.querySelector('.field-subtitulo')?.value.trim() || '';
+        const imagem = fieldEl.querySelector('.field-imagem')?.value.trim() || '';
+        const video = fieldEl.querySelector('.field-video')?.value.trim() || '';
+        fields.push({ id, tipo, titulo, subtitulo, imagem_url: imagem, video_url: video, ordem: idx });
+        return;
+      }
+
       const label = fieldEl.querySelector('.field-label').value.trim();
       const obrigatorio = fieldEl.querySelector('.field-obrigatorio').checked;
-      const id = fieldEl.dataset.id;
       const fieldData = { id, tipo, label, obrigatorio, ordem: idx };
 
       if (tipo === 'likert') {
@@ -95,6 +120,16 @@ document.addEventListener('DOMContentLoaded', () => {
           <label class="form-label">Título</label>
           <input type="text" class="form-control field-label" placeholder="Título da Pergunta">
         </div>
+        <div class="mb-2 field-section-subtitulo-wrapper d-none">
+          <label class="form-label">Subtítulo</label>
+          <input type="text" class="form-control field-subtitulo" placeholder="Insira um subtítulo">
+        </div>
+        <div class="mb-2 field-section-media-wrapper d-none">
+          <label class="form-label">Imagem (URL)</label>
+          <input type="text" class="form-control field-imagem" placeholder="URL da imagem">
+          <label class="form-label mt-2">Vídeo (URL)</label>
+          <input type="text" class="form-control field-video" placeholder="URL do vídeo">
+        </div>
         <div class="mb-2 field-opcoes-wrapper d-none">
           <label class="form-label">Opções (separadas por vírgula)</label>
           <input type="text" class="form-control field-opcoes">
@@ -111,7 +146,7 @@ document.addEventListener('DOMContentLoaded', () => {
           <label class="form-label mt-2">Cabeçalhos (separados por vírgula)</label>
           <input type="text" class="form-control field-table-cabecalhos">
         </div>
-        <div class="form-check mb-2">
+        <div class="form-check mb-2 field-obrigatorio-wrapper">
           <input class="form-check-input field-obrigatorio" type="checkbox" id="field-obrig-${Date.now()}">
           <label class="form-check-label" for="field-obrig-${Date.now()}">Obrigatório</label>
         </div>
@@ -124,25 +159,55 @@ document.addEventListener('DOMContentLoaded', () => {
     const opcoesWrapper = div.querySelector('.field-opcoes-wrapper');
     const likertWrapper = div.querySelector('.field-likert-wrapper');
     const tableWrapper = div.querySelector('.field-table-wrapper');
+    const obrigatorioWrapper = div.querySelector('.field-obrigatorio-wrapper');
+    const sectionSubtitleWrapper = div.querySelector('.field-section-subtitulo-wrapper');
+    const sectionMediaWrapper = div.querySelector('.field-section-media-wrapper');
+    const labelInput = div.querySelector('.field-label');
 
     tipoSelect.addEventListener('change', () => {
       if (['select', 'option'].includes(tipoSelect.value)) {
         opcoesWrapper.classList.remove('d-none');
         likertWrapper.classList.add('d-none');
         tableWrapper.classList.add('d-none');
+        sectionSubtitleWrapper.classList.add('d-none');
+        sectionMediaWrapper.classList.add('d-none');
+        obrigatorioWrapper.classList.remove('d-none');
+        labelInput.placeholder = 'Título da Pergunta';
       } else if (tipoSelect.value === 'likert') {
         opcoesWrapper.classList.add('d-none');
         likertWrapper.classList.remove('d-none');
         tableWrapper.classList.add('d-none');
+        sectionSubtitleWrapper.classList.add('d-none');
+        sectionMediaWrapper.classList.add('d-none');
+        obrigatorioWrapper.classList.remove('d-none');
+        labelInput.placeholder = 'Título da Pergunta';
       } else if (tipoSelect.value === 'table') {
         opcoesWrapper.classList.add('d-none');
         likertWrapper.classList.add('d-none');
         tableWrapper.classList.remove('d-none');
+        sectionSubtitleWrapper.classList.add('d-none');
+        sectionMediaWrapper.classList.add('d-none');
+        obrigatorioWrapper.classList.remove('d-none');
+        labelInput.placeholder = 'Título da Pergunta';
+      } else if (tipoSelect.value === 'section') {
+        opcoesWrapper.classList.add('d-none');
+        likertWrapper.classList.add('d-none');
+        tableWrapper.classList.add('d-none');
+        obrigatorioWrapper.classList.add('d-none');
+        sectionSubtitleWrapper.classList.remove('d-none');
+        sectionMediaWrapper.classList.remove('d-none');
+        labelInput.placeholder = 'Insira o seu título aqui';
       } else {
         opcoesWrapper.classList.add('d-none');
         likertWrapper.classList.add('d-none');
         tableWrapper.classList.add('d-none');
+        sectionSubtitleWrapper.classList.add('d-none');
+        sectionMediaWrapper.classList.add('d-none');
+        obrigatorioWrapper.classList.remove('d-none');
+        labelInput.placeholder = 'Título da Pergunta';
       }
+      updateNumbers();
+      updateQuestionTitle(div);
       updateJSON();
     });
 
@@ -162,19 +227,27 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Prefill data if editing existing structure
     tipoSelect.value = data.tipo || tipo || 'text';
-    div.querySelector('.field-label').value = data.label || '';
+    labelInput.value = data.label || data.titulo || '';
     div.querySelector('.field-obrigatorio').checked = data.obrigatorio || false;
-    if (['select', 'option'].includes(data.tipo)) {
+    if (['select', 'option'].includes(tipoSelect.value)) {
       opcoesWrapper.classList.remove('d-none');
       div.querySelector('.field-opcoes').value = (data.opcoes || []).join(', ');
-    } else if (data.tipo === 'likert') {
+    } else if (tipoSelect.value === 'likert') {
       likertWrapper.classList.remove('d-none');
       div.querySelector('.field-likert-linhas').value = (data.linhas || []).join(', ');
       div.querySelector('.field-likert-colunas').value = (data.colunas || []).join(', ');
-    } else if (data.tipo === 'table') {
+    } else if (tipoSelect.value === 'table') {
       tableWrapper.classList.remove('d-none');
       div.querySelector('.field-table-rows').value = data.linhas || 1;
       div.querySelector('.field-table-cabecalhos').value = (data.opcoes || []).join(', ');
+    } else if (tipoSelect.value === 'section') {
+      obrigatorioWrapper.classList.add('d-none');
+      sectionSubtitleWrapper.classList.remove('d-none');
+      sectionMediaWrapper.classList.remove('d-none');
+      labelInput.placeholder = 'Insira o seu título aqui';
+      div.querySelector('.field-subtitulo').value = data.subtitulo || '';
+      div.querySelector('.field-imagem').value = data.imagem_url || '';
+      div.querySelector('.field-video').value = data.video_url || '';
     }
 
     updateQuestionTitle(div);

--- a/templates/formularios/preencher_formulario.html
+++ b/templates/formularios/preencher_formulario.html
@@ -10,7 +10,16 @@
           {% set idx = loop.index0 %}
           <div class="mb-3">
             {% if campo.tipo == 'section' %}
-              <h4 class="mt-4">{{ campo.label }}</h4>
+              <div class="p-3 bg-light border rounded">
+                <h4 class="mb-1">{{ campo.titulo or campo.label }}</h4>
+                {% if campo.subtitulo %}<p class="text-muted mb-2">{{ campo.subtitulo }}</p>{% endif %}
+                {% if campo.imagem_url %}
+                  <img src="{{ campo.imagem_url }}" alt="" class="img-fluid mb-2" style="max-width: 200px;">
+                {% endif %}
+                {% if campo.video_url %}
+                  <div class="ratio ratio-16x9 mb-2"><iframe src="{{ campo.video_url }}" allowfullscreen></iframe></div>
+                {% endif %}
+              </div>
             {% else %}
               <label class="form-label">{{ campo.label }}{% if campo.obrigatorio %} *{% endif %}</label>
               {% if campo.tipo == 'textarea' %}

--- a/tests/test_form_builder.py
+++ b/tests/test_form_builder.py
@@ -1,6 +1,6 @@
 import pytest
 from app import app, db
-from models import Cargo, Instituicao, Estabelecimento, Setor, Celula, User, Formulario
+from models import Cargo, Instituicao, Estabelecimento, Setor, Celula, User, Formulario, Secao, CampoFormulario
 from utils import user_can_access_form_builder
 
 def setup_org(prefix):
@@ -88,3 +88,20 @@ def test_field_added_after_type_selection(client):
     html = resp.data.decode('utf-8')
     assert 'id="previewContainer"' in html
     assert "onclick=\"addField('text')\"" in html
+
+
+def test_section_model_relationship(app_ctx):
+    with app_ctx.app_context():
+        f = Formulario(nome='F', estrutura='[]')
+        db.session.add(f)
+        db.session.flush()
+        s = Secao(formulario_id=f.id, titulo='Sec', ordem=0)
+        db.session.add(s)
+        db.session.flush()
+        c = CampoFormulario(formulario_id=f.id, secao_id=s.id, tipo='text', label='Perg', obrigatorio=False, ordem=0)
+        db.session.add(c)
+        db.session.commit()
+        sec = Secao.query.filter_by(formulario_id=f.id).first()
+        assert sec.titulo == 'Sec'
+        assert sec.campos[0].label == 'Perg'
+        assert sec.campos[0].secao_id == sec.id


### PR DESCRIPTION
## Summary
- add `Secao` model and link questions to their sections
- support sections with title, subtitle and media in JS form builder and preview template
- test section persistence and provide migration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689265939a44832e8674dd0fbb729553