### PR TITLE
Permite ativar ou inativar formulários e filtrar por status

### DIFF
--- a/blueprints/formularios.py
+++ b/blueprints/formularios.py
@@ -44,8 +44,14 @@ def formularios():
             db.session.commit()
             flash('Formulário criado com sucesso!', 'success')
             return redirect(url_for('formularios_bp.formularios'))
-    formularios = Formulario.query.order_by(Formulario.created_at.desc()).all()
-    return render_template('formularios/formulario.html', formularios=formularios, aba_ativa=aba_ativa)
+    status = request.args.get('status', 'ativos')
+    query = Formulario.query
+    if status == 'ativos':
+        query = query.filter_by(ativo=True)
+    elif status == 'inativos':
+        query = query.filter_by(ativo=False)
+    formularios = query.order_by(Formulario.created_at.desc()).all()
+    return render_template('formularios/formulario.html', formularios=formularios, aba_ativa=aba_ativa, status=status)
 
 
 @formularios_bp.route('/<int:id>/editar', methods=['GET', 'POST'])
@@ -66,6 +72,17 @@ def editar_formulario(id):
             flash('Formulário atualizado!', 'success')
             return redirect(url_for('formularios_bp.formularios'))
     return render_template('formularios/editar_formulario.html', formulario=formulario)
+
+
+@formularios_bp.route('/<int:id>/toggle-ativo', methods=['POST'])
+@form_builder_required
+def toggle_ativo_formulario(id):
+    formulario = Formulario.query.get_or_404(id)
+    formulario.ativo = not formulario.ativo
+    db.session.commit()
+    status_texto = 'ativado' if formulario.ativo else 'inativado'
+    flash(f'Formulário {status_texto} com sucesso!', 'success')
+    return redirect(url_for('formularios_bp.formularios'))
 
 
 @formularios_bp.route('/upload-imagem', methods=['POST'])

--- a/migrations/versions/7c8d9e0f1a2b_add_ativo_to_formulario.py
+++ b/migrations/versions/7c8d9e0f1a2b_add_ativo_to_formulario.py
@@ -1,0 +1,25 @@
+"""add ativo column to formulario
+
+Revision ID: 7c8d9e0f1a2b
+Revises: 123456789abc
+Create Date: 2025-07-05 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '7c8d9e0f1a2b'
+down_revision = '123456789abc'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('formulario', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('ativo', sa.Boolean(), nullable=False, server_default='true'))
+
+
+def downgrade():
+    with op.batch_alter_table('formulario', schema=None) as batch_op:
+        batch_op.drop_column('ativo')

--- a/models.py
+++ b/models.py
@@ -509,6 +509,7 @@ class Formulario(db.Model):
     estrutura = db.Column(db.Text, nullable=True)
     created_at = db.Column(db.DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = db.Column(db.DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    ativo = db.Column(db.Boolean, nullable=False, default=True, server_default='true')
 
     campos = db.relationship('CampoFormulario', back_populates='formulario', cascade='all, delete-orphan')
     secoes = db.relationship(

--- a/templates/formularios/formulario.html
+++ b/templates/formularios/formulario.html
@@ -25,21 +25,40 @@
             </div>
             <div class="card-body">
               {% if formularios %}
-              <div class="mb-3">
-                <div class="input-group">
-                  <span class="input-group-text"><i class="bi bi-search"></i></span>
-                  <input type="text" id="formSearch" class="form-control" placeholder="Buscar por formulário">
+              <div class="mb-3 row">
+                <div class="col-md-6">
+                  <form method="get" class="d-flex">
+                    <select class="form-select me-2" name="status" onchange="this.form.submit()">
+                      <option value="ativos" {% if status == 'ativos' %}selected{% endif %}>Ativos</option>
+                      <option value="inativos" {% if status == 'inativos' %}selected{% endif %}>Inativos</option>
+                      <option value="todos" {% if status == 'todos' %}selected{% endif %}>Todos</option>
+                    </select>
+                  </form>
+                </div>
+                <div class="col-md-6">
+                  <div class="input-group">
+                    <span class="input-group-text"><i class="bi bi-search"></i></span>
+                    <input type="text" id="formSearch" class="form-control" placeholder="Buscar por formulário">
+                  </div>
                 </div>
               </div>
               <table class="table table-striped" id="tabelaFormularios">
-                <thead><tr><th>Nome</th><th>Ações</th></tr></thead>
+                <thead><tr><th>Nome</th><th>Status</th><th>Ações</th></tr></thead>
                 <tbody>
                 {% for f in formularios %}
-                  <tr data-nome="{{ f.nome }}">
+                  <tr data-nome="{{ f.nome }}" class="{{ 'table-light text-muted' if not f.ativo else '' }}">
                     <td>{{ f.nome }}</td>
+                    <td>{% if f.ativo %}<span class="badge bg-success">Ativo</span>{% else %}<span class="badge bg-secondary">Inativo</span>{% endif %}</td>
                     <td>
                       <a class="btn btn-sm btn-primary" href="{{ url_for('formularios_bp.preencher_formulario', id=f.id) }}">Preencher</a>
                       <a class="btn btn-sm btn-secondary ms-1" href="{{ url_for('formularios_bp.editar_formulario', id=f.id) }}">Editar</a>
+                      <form action="{{ url_for('formularios_bp.toggle_ativo_formulario', id=f.id) }}" method="post" class="d-inline">
+                        {% if f.ativo %}
+                        <button type="submit" class="btn btn-sm btn-outline-warning ms-1">Desativar</button>
+                        {% else %}
+                        <button type="submit" class="btn btn-sm btn-outline-success ms-1">Ativar</button>
+                        {% endif %}
+                      </form>
                     </td>
                   </tr>
                 {% endfor %}


### PR DESCRIPTION
## Summary
- Permite ativar ou inativar formulários e adiciona coluna `ativo`
- Inclui filtro por status na listagem de formulários
- Adiciona migration para o novo campo

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892797ed5ec832e9208fde5266464b1