### PR TITLE
Keep form search/filter visible when no forms

### DIFF
--- a/templates/formularios/formulario.html
+++ b/templates/formularios/formulario.html
@@ -24,7 +24,6 @@
               <h5 class="mb-0"><i class="bi bi-list-ul me-2"></i>Formulários Cadastrados ({{ formularios|length }})</h5>
             </div>
             <div class="card-body">
-              {% if formularios %}
               <div class="mb-3 row">
                 <div class="col-md-6">
                   <form method="get" class="d-flex">
@@ -42,6 +41,7 @@
                   </div>
                 </div>
               </div>
+              {% if formularios %}
               <table class="table table-striped" id="tabelaFormularios">
                 <thead><tr><th>Nome</th><th>Status</th><th>Ações</th></tr></thead>
                 <tbody>

--- a/tests/test_form_builder.py
+++ b/tests/test_form_builder.py
@@ -125,3 +125,18 @@ def test_toggle_and_filter_formulario(client):
     assert b'FormAtivo' not in resp.data
     resp = client.get('/ordem-servico/formularios/?status=todos')
     assert b'FormAtivo' in resp.data and b'FormInativo' in resp.data
+
+
+def test_filter_and_search_visible_with_no_active_forms(client):
+    with app.app_context():
+        user_allowed_id = create_user('noactive', True)
+    login(client, user_allowed_id)
+    client.post('/ordem-servico/formularios/', data={'nome': 'FormX', 'estrutura': '{}'}, follow_redirects=True)
+    with app.app_context():
+        form = Formulario.query.filter_by(nome='FormX').first()
+        form_id = form.id
+    client.post(f'/ordem-servico/formularios/{form_id}/toggle-ativo', follow_redirects=True)
+    resp = client.get('/ordem-servico/formularios/?status=ativos')
+    assert b'id="formSearch"' in resp.data
+    assert b'name="status"' in resp.data
+    assert b'Nenhum formul' in resp.data


### PR DESCRIPTION
## Summary
- Ensure search and status filter are always displayed on the forms page
- Add regression test to guarantee search/filter visibility when no active forms remain

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68927c9e7d60832e821abe51a220e112