### PR TITLE
Mostrar campo "Especifique" somente ao selecionar "Outra"

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -415,4 +415,30 @@ document.addEventListener("DOMContentLoaded", function () {
   // Expose helper for inline scripts
   window.setCargoFuncoesDisabled = setCargoFuncoesDisabled;
 
+  // Mostra o campo de especificar apenas quando a opção "Outra" estiver selecionada
+  document.querySelectorAll('select[data-outra-select]').forEach((select) => {
+    const especificar = select.parentElement.querySelector('.outra-especifique');
+    if (!especificar) return;
+    const toggle = () => {
+      especificar.classList.toggle('d-none', select.value !== 'outra');
+    };
+    toggle();
+    select.addEventListener('change', toggle);
+  });
+
+  document.querySelectorAll('.outra-option').forEach((outra) => {
+    const container = outra.closest('.mb-3');
+    if (!container || container.dataset.outraBound) return;
+    container.dataset.outraBound = 'true';
+    const inputs = container.querySelectorAll('input[type="radio"], input[type="checkbox"]');
+    const especificar = container.querySelector('.outra-especifique');
+    if (!especificar) return;
+    const toggle = () => {
+      const show = Array.from(inputs).some((inp) => inp.value === 'outra' && inp.checked);
+      especificar.classList.toggle('d-none', !show);
+    };
+    toggle();
+    inputs.forEach((inp) => inp.addEventListener('change', toggle));
+  });
+
 });

--- a/templates/formularios/preencher_formulario.html
+++ b/templates/formularios/preencher_formulario.html
@@ -29,7 +29,7 @@
             </select>
           {% elif campo.tipo == 'option' %}
             {% if campo.usarMenuSuspenso %}
-              <select class="form-select" {% if campo.permiteMultiplaEscolha %}multiple{% endif %} {% if campo.obrigatoria %}required{% endif %}>
+              <select class="form-select" {% if campo.permiteMultiplaEscolha %}multiple{% endif %} {% if campo.obrigatoria %}required{% endif %} {% if campo.temOpcaoOutra %}data-outra-select{% endif %}>
                 {% for opcao in campo.opcoes %}
                   <option value="{{ opcao }}">{{ opcao }}</option>
                 {% endfor %}
@@ -37,7 +37,7 @@
                   <option value="outra">Outra</option>
                 {% endif %}
               </select>
-              {% if campo.temOpcaoOutra %}<input type="text" class="form-control mt-2" placeholder="Especifique">{% endif %}
+              {% if campo.temOpcaoOutra %}<input type="text" class="form-control mt-2 d-none outra-especifique" placeholder="Especifique">{% endif %}
             {% else %}
               {% set input_type = 'checkbox' if campo.permiteMultiplaEscolha else 'radio' %}
               {% for opcao in campo.opcoes %}
@@ -48,10 +48,10 @@
               {% endfor %}
               {% if campo.temOpcaoOutra %}
                 <div class="form-check mt-2">
-                  <input class="form-check-input" type="{{ input_type }}" name="campo{{ idx }}{% if campo.permiteMultiplaEscolha %}[]{% endif %}" value="outra">
+                  <input class="form-check-input outra-option" type="{{ input_type }}" name="campo{{ idx }}{% if campo.permiteMultiplaEscolha %}[]{% endif %}" value="outra">
                   <label class="form-check-label">Outra</label>
                 </div>
-                <input type="text" class="form-control mt-2" placeholder="Especifique">
+                <input type="text" class="form-control mt-2 d-none outra-especifique" placeholder="Especifique">
               {% endif %}
             {% endif %}
           {% elif campo.tipo == 'rating' %}


### PR DESCRIPTION
## Summary
- mostrar campo "Especifique" apenas quando a opção "Outra" é selecionada nos campos de opção
- adicionar lógica JS para alternar visibilidade do campo de especificação

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68938f8beb40832ebaf82e2451c75d4e