### PR TITLE
feat: add autosave to key forms

### DIFF
--- a/static/js/form_builder.js
+++ b/static/js/form_builder.js
@@ -5,6 +5,39 @@ document.addEventListener('DOMContentLoaded', () => {
   const fieldsContainer = document.getElementById('fieldsContainer');
   const estruturaInput = document.getElementById('estrutura');
   const form = document.getElementById('formBuilderForm');
+  const nomeInput = document.getElementById('nome');
+  const descInput = document.getElementById('descricao');
+  const STORAGE_KEY = 'formBuilderDraft_' + (form?.dataset.formId || 'novo');
+
+  function saveDraft() {
+    if (!nomeInput || !descInput) return;
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        nome: nomeInput.value,
+        descricao: descInput.value,
+        estrutura: estruturaInput.value
+      })
+    );
+  }
+
+  function loadDraft() {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    try {
+      const data = JSON.parse(raw);
+      if (data.nome && nomeInput) nomeInput.value = data.nome;
+      if (data.descricao && descInput) descInput.value = data.descricao;
+      if (data.estrutura) estruturaInput.value = data.estrutura;
+    } catch (e) {
+      console.warn('Falha ao carregar rascunho do formulário', e);
+    }
+  }
+
+  loadDraft();
+  if (nomeInput) nomeInput.addEventListener('input', saveDraft);
+  if (descInput) descInput.addEventListener('input', saveDraft);
+  form?.addEventListener('submit', () => localStorage.removeItem(STORAGE_KEY));
 
   async function uploadImage(file) {
     const fd = new FormData();
@@ -153,6 +186,7 @@ document.addEventListener('DOMContentLoaded', () => {
       ordem += 1;
     });
     estruturaInput.value = JSON.stringify(fields);
+    saveDraft();
   }
 
   function initQuestionsSortable(container) {

--- a/templates/admin/ordens_servico.html
+++ b/templates/admin/ordens_servico.html
@@ -57,7 +57,35 @@
       {% else %}
       <p class="text-muted">Nenhuma ordem cadastrada.</p>
       {% endif %}
-    </div>
   </div>
 </div>
+</div>
+{% endblock %}
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('form');
+  const inputs = form.querySelectorAll('input, textarea, select');
+  const idField = form.querySelector('input[name="id_para_atualizar"]');
+  const STORAGE_KEY = 'draft_admin_os_' + (idField ? idField.value || 'novo' : 'novo');
+  function save() {
+    const data = {};
+    inputs.forEach(i => data[i.id] = i.value);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  }
+  function load() {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    try {
+      const data = JSON.parse(raw);
+      inputs.forEach(i => { if (data[i.id]) i.value = data[i.id]; });
+    } catch (e) {
+      console.warn('Falha ao carregar rascunho da OS', e);
+    }
+  }
+  load();
+  inputs.forEach(i => i.addEventListener('input', save));
+  form.addEventListener('submit', () => localStorage.removeItem(STORAGE_KEY));
+});
+</script>
 {% endblock %}

--- a/templates/artigos/editar_artigo.html
+++ b/templates/artigos/editar_artigo.html
@@ -138,6 +138,34 @@
   const visChecks = document.querySelectorAll('.vis-check');
   const visInput = document.getElementById('visibilityInput');
   const visDisplay = document.getElementById('visibilityDisplay');
+  const STORAGE_KEY = 'draft_editar_artigo_{{ artigo.id }}';
+  function saveDraft() {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        titulo: document.querySelector('input[name="titulo"]').value,
+        texto: quill.root.innerHTML,
+        visibility: visInput.value
+      })
+    );
+  }
+  function loadDraft() {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    try {
+      const data = JSON.parse(raw);
+      if (data.titulo) document.querySelector('input[name="titulo"]').value = data.titulo;
+      if (data.texto) quill.root.innerHTML = data.texto;
+      if (data.visibility) {
+        visInput.value = data.visibility;
+        const parts = data.visibility.split(',');
+        visChecks.forEach(cb => cb.checked = parts.includes(cb.value));
+        updateVisibility();
+      }
+    } catch (e) {
+      console.warn('Falha ao carregar rascunho do artigo', e);
+    }
+  }
   function updateVisibility() {
     const opts = Array.from(visChecks).filter(c => c.checked);
     visInput.value = opts.map(o => o.value).join(',');
@@ -145,6 +173,10 @@
   }
   visChecks.forEach(cb => cb.addEventListener('change', updateVisibility));
   updateVisibility();
+  loadDraft();
+  document.querySelector('input[name="titulo"]').addEventListener('input', saveDraft);
+  quill.on('text-change', saveDraft);
+  visChecks.forEach(cb => cb.addEventListener('change', saveDraft));
 
   // Sincroniza conteúdo no hidden antes de submeter
   const form = document.querySelector('form');
@@ -154,6 +186,7 @@
       if (hiddenTexto) {
         hiddenTexto.value = quill.root.innerHTML;
       }
+      localStorage.removeItem(STORAGE_KEY);
     });
   }
 

--- a/templates/artigos/novo_artigo.html
+++ b/templates/artigos/novo_artigo.html
@@ -97,6 +97,34 @@ document.addEventListener('DOMContentLoaded', () => {
   const visChecks = document.querySelectorAll('.vis-check');
   const visInput = document.getElementById('visibilityInput');
   const visDisplay = document.getElementById('visibilityDisplay');
+  const STORAGE_KEY = 'draft_novo_artigo';
+  function saveDraft() {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        titulo: document.getElementById('titulo').value,
+        texto: quill.root.innerHTML,
+        visibility: visInput.value
+      })
+    );
+  }
+  function loadDraft() {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    try {
+      const data = JSON.parse(raw);
+      if (data.titulo) document.getElementById('titulo').value = data.titulo;
+      if (data.texto) quill.root.innerHTML = data.texto;
+      if (data.visibility) {
+        visInput.value = data.visibility;
+        const parts = data.visibility.split(',');
+        visChecks.forEach(cb => cb.checked = parts.includes(cb.value));
+        updateVisibility();
+      }
+    } catch (e) {
+      console.warn('Falha ao carregar rascunho do artigo', e);
+    }
+  }
   function updateVisibility() {
     const opts = Array.from(visChecks).filter(c => c.checked);
     visInput.value = opts.map(o => o.value).join(',');
@@ -104,12 +132,17 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   visChecks.forEach(cb => cb.addEventListener('change', updateVisibility));
   updateVisibility();
+  loadDraft();
+  document.getElementById('titulo').addEventListener('input', saveDraft);
+  quill.on('text-change', saveDraft);
+  visChecks.forEach(cb => cb.addEventListener('change', saveDraft));
 
   // Sincroniza conteúdo Quill no campo hidden antes de submeter
   const form = document.querySelector('form');
   form.addEventListener('submit', () => {
     document.getElementById('hidden-texto').value = quill.root.innerHTML;
     overlay.style.display = 'flex';
+    localStorage.removeItem(STORAGE_KEY);
   });
 
   // Preview de anexos

--- a/templates/formularios/cadastro_formulario.html
+++ b/templates/formularios/cadastro_formulario.html
@@ -3,7 +3,7 @@
     <div class="col-md-10 mt-4">
       <h3 class="mb-3">{{ 'Editar' if formulario else 'Novo' }} Formulário</h3>
       <div class="form-container">
-      <form method="POST" id="formBuilderForm" action="{{ action_url }}">
+      <form method="POST" id="formBuilderForm" action="{{ action_url }}" data-form-id="{{ formulario.id if formulario else '' }}">
         <div class="card shadow-sm mb-3">
           <div class="card-body">
             <div class="mb-3">

--- a/templates/ordens_servico/nova_os.html
+++ b/templates/ordens_servico/nova_os.html
@@ -29,7 +29,34 @@
           </form>
         </div>
       </div>
-    </div>
-  </div>
 </div>
+</div>
+</div>
+{% endblock %}
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('form');
+  const inputs = form.querySelectorAll('input, textarea, select');
+  const STORAGE_KEY = 'draft_nova_os';
+  function save() {
+    const data = {};
+    inputs.forEach(i => data[i.id] = i.value);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  }
+  function load() {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    try {
+      const data = JSON.parse(raw);
+      inputs.forEach(i => { if (data[i.id]) i.value = data[i.id]; });
+    } catch (e) {
+      console.warn('Falha ao carregar rascunho da OS', e);
+    }
+  }
+  load();
+  inputs.forEach(i => i.addEventListener('input', save));
+  form.addEventListener('submit', () => localStorage.removeItem(STORAGE_KEY));
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add localStorage autosave for creating and editing articles
- persist form builder drafts in localStorage
- autosave Ordem de Serviço forms for users and admins

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894e539b4dc832eb23682fe090a0876