### PR TITLE
Validação de fluxos de ramificação no construtor de formulários

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -80,6 +80,12 @@
 .novo-artigo-preview .card {
   max-width: 120px;
 }
+
+/* Destaca perguntas já utilizadas como destino em ramificações */
+.branch-select option[data-used="1"] {
+  color: #0d6efd;
+  font-weight: 600;
+}
 .novo-artigo-preview .card-img-top {
   object-fit: cover;
   width: 100%;


### PR DESCRIPTION
## Summary
- validar ramificações no backend para evitar ciclos ou destinos inativos
- agrupar perguntas por seção no dropdown de destino e destacar perguntas já utilizadas
- adicionar validação de fluxo no frontend com mensagens claras de erro

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894f0fdaf54832e90dc84ad1e48226c