### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -8,6 +8,30 @@ document.addEventListener("DOMContentLoaded", function () {
   const READ_KEY = `readNotifications_${currentUser}`;
   /* ------------------------------------------------------------------ */
 
+  const THEME_KEY = "theme";
+
+  function applyTheme(theme) {
+    if (theme === "dark") {
+      document.documentElement.setAttribute("data-bs-theme", "dark");
+    } else {
+      document.documentElement.removeAttribute("data-bs-theme");
+    }
+  }
+
+  function toggleTheme() {
+    const newTheme = localStorage.getItem(THEME_KEY) === "dark" ? "light" : "dark";
+    localStorage.setItem(THEME_KEY, newTheme);
+    applyTheme(newTheme);
+  }
+
+  document.getElementById("themeToggle")?.addEventListener("click", function (e) {
+    e.preventDefault();
+    toggleTheme();
+  });
+
+  window.toggleTheme = toggleTheme;
+  applyTheme(localStorage.getItem(THEME_KEY));
+
   // 1) Inicializa apenas os tooltips marcados, com offset para centralizar
   Array.from(document.querySelectorAll('[data-bs-toggle="tooltip"]')).forEach((el) =>
     new bootstrap.Tooltip(el, {

--- a/templates/base.html
+++ b/templates/base.html
@@ -164,7 +164,13 @@
                             {% else %}<li><a class="dropdown-item text-muted" href="#">Nenhuma notificação</a></li>{% endif %}
                         </ul>
                     </li>
-                    
+
+                    <li class="nav-item me-2">
+                        <a class="nav-link" href="#" id="themeToggle" title="Alternar tema">
+                            <i class="bi bi-moon-fill"></i>
+                        </a>
+                    </li>
+
                     {# Foto/Nome do Usuário como LINK DIRETO para o Perfil #}
                     <li class="nav-item">
                         <a class="nav-link d-flex align-items-center p-0" href="{{ url_for('perfil') }}" title="Meu Perfil"> {# Link direto para o perfil #}


### PR DESCRIPTION
## Summary
- add navbar button to toggle dark theme
- persist theme preference and apply on page load

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895192dc7a4832ea3b8f70e0d3770c2