### PR TITLE
Enable dark Quill styling and adjust icon contrast

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -315,3 +315,24 @@ body > .container {
     min-width: 150px;
   }
 }
+
+/* Dark theme helpers */
+.invert-on-dark {
+  filter: none;
+}
+
+[data-bs-theme="dark"] .invert-on-dark {
+  filter: invert(1);
+}
+
+/* Quill editor dark adjustments */
+[data-bs-theme="dark"] .ql-container,
+[data-bs-theme="dark"] .ql-editor {
+  background-color: var(--bg-default);
+  color: var(--text-default);
+  border-color: var(--border-default);
+}
+
+[data-bs-theme="dark"] .ql-bubble .ql-editor.ql-blank::before {
+  color: var(--text-default);
+}

--- a/templates/artigos/editar_artigo.html
+++ b/templates/artigos/editar_artigo.html
@@ -2,7 +2,7 @@
 {% block title %}Editar Artigo{% endblock %}
 
 {% block extra_css %}
-<link href="https://cdn.quilljs.com/2.0.3/quill.snow.css" rel="stylesheet">
+<link href="https://cdn.quilljs.com/2.0.3/quill.bubble.css" rel="stylesheet">
 {% endblock %}
 
 {% block content %}
@@ -25,7 +25,7 @@
           <div class="mb-3">
             <label class="form-label">Texto</label>
             <!-- Quill Editor -->
-            <div id="quill-editor" class="bg-white border rounded" style="height:300px; overflow:auto;"></div>
+            <div id="quill-editor" class="border rounded bg-body" style="height:300px; overflow:auto;"></div>
           <input type="hidden" name="texto" id="hidden-texto">
         </div>
 
@@ -107,13 +107,12 @@
 </div>
 {% endblock %}
 {% block extra_js %}
-<script src="https://cdn.quilljs.com/2.0.3/quill.min.js"></script>
 <script>
   document.addEventListener("DOMContentLoaded", () => {
     // Inicializa Quill editor e carrega conteúdo existente
     const editorDiv = document.getElementById('quill-editor');
     const quill = new Quill(editorDiv, {
-      theme: 'snow',
+      theme: 'bubble',
       modules: {
         toolbar: [ // Verifique se não há vírgulas sobrando no final de cada array aqui
           [{ header: [1, 2, 3, false] }],

--- a/templates/artigos/novo_artigo.html
+++ b/templates/artigos/novo_artigo.html
@@ -2,7 +2,7 @@
 {% block title %}Novo Artigo{% endblock %}
 
 {% block extra_css %}
-<link href="https://cdn.quilljs.com/2.0.3/quill.snow.css" rel="stylesheet">
+<link href="https://cdn.quilljs.com/2.0.3/quill.bubble.css" rel="stylesheet">
 {% endblock %}
 
 {% block content %}
@@ -25,7 +25,7 @@
 
           <div class="mb-3">
             <label for="quill-editor" class="form-label">Texto</label>
-            <div id="quill-editor" class="bg-white border rounded" style="height:300px; overflow:auto;"></div>
+            <div id="quill-editor" class="border rounded bg-body" style="height:300px; overflow:auto;"></div>
             <input type="hidden" name="texto" id="hidden-texto">
           </div>
 
@@ -73,12 +73,11 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="https://cdn.quilljs.com/2.0.3/quill.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   // Inicializa o Quill editor
   const quill = new Quill('#quill-editor', {
-    theme: 'snow',
+    theme: 'bubble',
     modules: {
       toolbar: [
         [{ header: [1, 2, 3, false] }],

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -10,7 +10,7 @@
   <div class="row justify-content-center">
     <div class="col-md-4">
       <div class="text-center mb-4">
-        <img src="{{ url_for('static', filename='icons/sua_logo.png') }}" class="login-logo mb-2" alt="Logo Orquetask">
+        <img src="{{ url_for('static', filename='icons/sua_logo.png') }}" class="login-logo mb-2 invert-on-dark" alt="Logo Orquetask">
         <h1 class="h4 fw-bold mb-0">Orquetask</h1>
       </div>
       {% with messages = get_flashed_messages(with_categories=true) %}

--- a/templates/auth/reset_password_request.html
+++ b/templates/auth/reset_password_request.html
@@ -4,7 +4,7 @@
 <div class="row justify-content-center">
   <div class="col-md-4">
     <div class="text-center mb-4">
-      <img src="{{ url_for('static', filename='icons/sua_logo.png') }}" class="login-logo mb-2" alt="Logo Orquetask">
+      <img src="{{ url_for('static', filename='icons/sua_logo.png') }}" class="login-logo mb-2 invert-on-dark" alt="Logo Orquetask">
       <h1 class="h4 fw-bold mb-0">Orquetask</h1>
     </div>
     {% with messages = get_flashed_messages(with_categories=true) %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet"> {# Bootstrap Icons atualizado #}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
 
-    <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+    <link href="https://cdn.quilljs.com/2.0.3/quill.bubble.css" rel="stylesheet">
     
     <style>
         /* === ESTILOS GLOBAIS PARA LAYOUT COM NAVBAR FIXA E SIDEBAR FIXA/OFFCANVAS === */
@@ -132,7 +132,7 @@
                 </button>
                 
                 <a class="navbar-brand d-flex align-items-center ms-3" href="{{ url_for('pagina_inicial') }}"> {# Link do brand pode ser o dashboard ou meus_artigos #}
-                    <img src="{{ url_for('static', filename='icons/favicon.png') }}" alt="Logo Orquetask" height="30" class="me-2">
+                    <img src="{{ url_for('static', filename='icons/favicon.png') }}" alt="Logo Orquetask" height="30" class="me-2 invert-on-dark">
                     <span>Orquetask</span>
                 </a>
                 
@@ -354,7 +354,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
-    <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
+    <script src="https://cdn.quilljs.com/2.0.3/quill.min.js"></script>
     {% block extra_js %}{% endblock %}
 </body>
 </html>

--- a/templates/partials/_flash_messages.html
+++ b/templates/partials/_flash_messages.html
@@ -1,24 +1,11 @@
 {% with messages = get_flashed_messages(with_categories=true) %}
   {% if messages %}
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1080;">
-      {% for category, message in messages %}
-        <div class="toast align-items-center text-bg-{{ 'danger' if category in ['error', 'danger'] else category }} border-0 mb-2" role="alert" aria-live="assertive" aria-atomic="true">
-          <div class="d-flex">
-            <div class="toast-body">
-              {{ message }}
-            </div>
-            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
-          </div>
-        </div>
-      {% endfor %}
-    </div>
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        var toastElList = [].slice.call(document.querySelectorAll('.toast'));
-        toastElList.forEach(function(toastEl) {
-          new bootstrap.Toast(toastEl, { delay: 5000 }).show();
-        });
-      });
-    </script>
+    {% for category, message in messages %}
+      <div class="alert alert-{{ 'danger' if category in ['error', 'danger'] else category }} alert-dismissible fade show mb-2" role="alert">
+        {{ message }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+      </div>
+    {% endfor %}
   {% endif %}
 {% endwith %}
+


### PR DESCRIPTION
## Summary
- Switch Quill to the bubble theme and load dark-compatible assets
- Invert logo icons on dark backgrounds and add dark-mode helper CSS
- Replace toast-based flash messages with Bootstrap alerts for better contrast

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68951c5b0694832ea52aac00a0d3329b