### PR TITLE
Improve dark mode contrast and spacing

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,5 +1,7 @@
 /* CSS Variables */
 :root {
+  --page-bg: #f0f2f5;
+  --content-bg: #ffffff;
   --bg-default: #fff;
   --bg-muted: #f8f9fa;
   --bg-hover: rgba(0,0,0,0.03);
@@ -20,6 +22,8 @@
 }
 
 [data-bs-theme="dark"] {
+  --page-bg: #1e1e1e;
+  --content-bg: #2c2c2c;
   --bg-default: #1e1e1e;
   --bg-muted: #2c2c2c;
   --bg-hover: rgba(255,255,255,0.05);
@@ -162,7 +166,7 @@ body > .container {
 
 /* espaçamento e responsividade dos botões de navegação do formulário */
 #navButtons {
-  gap: 0.5rem;
+  gap: 1rem;
 }
 
 /* Logo da página de login */
@@ -335,4 +339,52 @@ body > .container {
 
 [data-bs-theme="dark"] .ql-bubble .ql-editor.ql-blank::before {
   color: var(--text-default);
+}
+
+/* Dark mode card and typography adjustments */
+[data-bs-theme="dark"] .card {
+  background-color: var(--content-bg);
+  color: #f5f5f5;
+  border: 1px solid #444;
+}
+
+[data-bs-theme="dark"] h1,
+[data-bs-theme="dark"] h2,
+[data-bs-theme="dark"] h3,
+[data-bs-theme="dark"] h4,
+[data-bs-theme="dark"] h5,
+[data-bs-theme="dark"] h6,
+[data-bs-theme="dark"] .h1,
+[data-bs-theme="dark"] .h2,
+[data-bs-theme="dark"] .h3,
+[data-bs-theme="dark"] .h4,
+[data-bs-theme="dark"] .h5,
+[data-bs-theme="dark"] .h6 {
+  color: #f5f5f5;
+}
+
+/* Navbar and sidebar colors */
+[data-bs-theme="dark"] .navbar.bg-dark,
+[data-bs-theme="dark"] #globalSidebarOffcanvas {
+  background-color: #1a1a1a !important;
+}
+
+[data-bs-theme="dark"] .navbar-dark .navbar-nav .nav-link,
+[data-bs-theme="dark"] #globalSidebarOffcanvas .nav-link {
+  color: #ccc;
+}
+
+[data-bs-theme="dark"] .navbar-dark .navbar-nav .nav-link:hover,
+[data-bs-theme="dark"] .navbar-dark .navbar-nav .nav-link:focus,
+[data-bs-theme="dark"] #globalSidebarOffcanvas .nav-link:hover {
+  color: #fff;
+}
+
+/* Progress bar tone for dark mode */
+[data-bs-theme="dark"] .progress {
+  background-color: #444;
+}
+
+[data-bs-theme="dark"] .progress-bar {
+  background-color: #4d90fe;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,7 +15,7 @@
         /* === ESTILOS GLOBAIS PARA LAYOUT COM NAVBAR FIXA E SIDEBAR FIXA/OFFCANVAS === */
         body {
             margin: 0;
-            background-color: #f0f2f5; /* Um cinza de fundo bem suave */
+            background-color: var(--page-bg); /* Ajuste conforme tema */
         }
 
         /* Classe aplicada ao HTML ou BODY para layout com navbar e sidebar */
@@ -105,7 +105,8 @@
         }
         .main-page-content {
             padding: 1.5rem; /* Espaçamento interno do conteúdo */
-            background-color: #ffffff; 
+            background-color: var(--content-bg);
+            color: var(--text-default);
             /* Para garantir que o conteúdo não seja muito baixo em páginas curtas */
             min-height: calc(100vh - 56px - 3rem); /* Altura da viewport - navbar - (padding-top+bottom do .main-page-content) */
         }


### PR DESCRIPTION
## Summary
- Add CSS variables to unify page and content backgrounds and adjust dark theme colors
- Style dark mode cards, navbars, headings and progress bars for higher contrast
- Increase form navigation button spacing for better layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689520ad4440832eb1a1a8a1c0a38014