### PR TITLE
Ativa Quill globalmente

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -356,6 +356,24 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
     <script src="https://cdn.quilljs.com/2.0.3/quill.min.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('textarea:not(.no-quill)').forEach(function (textarea) {
+          var container = document.createElement('div');
+          container.innerHTML = textarea.value;
+          container.style.minHeight = (textarea.getAttribute('rows') ? textarea.getAttribute('rows') * 24 : 100) + 'px';
+          textarea.style.display = 'none';
+          textarea.parentNode.insertBefore(container, textarea);
+          var quill = new Quill(container, { theme: 'bubble' });
+          var form = textarea.closest('form');
+          if (form) {
+            form.addEventListener('submit', function () {
+              textarea.value = quill.root.innerHTML;
+            });
+          }
+        });
+      });
+    </script>
     {% block extra_js %}{% endblock %}
 </body>
 </html>

--- a/templates/formularios/cadastro_formulario.html
+++ b/templates/formularios/cadastro_formulario.html
@@ -12,7 +12,7 @@
             </div>
             <div class="mb-3">
               <label for="descricao" class="form-label">Descrição</label>
-              <textarea class="form-control" id="descricao" name="descricao">{{ formulario.descricao if formulario else '' }}</textarea>
+              <textarea class="form-control no-quill" id="descricao" name="descricao">{{ formulario.descricao if formulario else '' }}</textarea>
             </div>
           </div>
         </div>

--- a/templates/formularios/preencher_formulario.html
+++ b/templates/formularios/preencher_formulario.html
@@ -30,7 +30,7 @@
             </div>
           </div>
           {% if campo.tipo == 'textarea' %}
-            <textarea class="form-control" {% if campo.obrigatoria %}required{% endif %}></textarea>
+            <textarea class="form-control no-quill" {% if campo.obrigatoria %}required{% endif %}></textarea>
           {% elif campo.tipo == 'select' %}
             <select class="form-select" {% if campo.obrigatoria %}required{% endif %}>
               {% for opcao in campo.opcoes %}


### PR DESCRIPTION
## Resumo
- Reativa carregamento do Quill.js e aplica editor automaticamente em todos os campos de texto
- Exclui formulários customizados do uso automático do Quill

## Testes
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895fc42f214832e835db46a09451e4d