### PR TITLE
Use Quill.js v1.3.6 snow theme

### DIFF
--- a/templates/artigos/editar_artigo.html
+++ b/templates/artigos/editar_artigo.html
@@ -2,7 +2,7 @@
 {% block title %}Editar Artigo{% endblock %}
 
 {% block extra_css %}
-<link href="https://cdn.quilljs.com/2.0.3/quill.bubble.css" rel="stylesheet">
+<link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
 {% endblock %}
 
 {% block content %}
@@ -112,7 +112,7 @@
     // Inicializa Quill editor e carrega conteúdo existente
     const editorDiv = document.getElementById('quill-editor');
     const quill = new Quill(editorDiv, {
-      theme: 'bubble',
+      theme: 'snow',
       modules: {
         toolbar: [ // Verifique se não há vírgulas sobrando no final de cada array aqui
           [{ header: [1, 2, 3, false] }],

--- a/templates/artigos/novo_artigo.html
+++ b/templates/artigos/novo_artigo.html
@@ -2,7 +2,7 @@
 {% block title %}Novo Artigo{% endblock %}
 
 {% block extra_css %}
-<link href="https://cdn.quilljs.com/2.0.3/quill.bubble.css" rel="stylesheet">
+<link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
 {% endblock %}
 
 {% block content %}
@@ -77,7 +77,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   // Inicializa o Quill editor
   const quill = new Quill('#quill-editor', {
-    theme: 'bubble',
+    theme: 'snow',
     modules: {
       toolbar: [
         [{ header: [1, 2, 3, false] }],

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet"> {# Bootstrap Icons atualizado #}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
 
-    <link href="https://cdn.quilljs.com/2.0.3/quill.bubble.css" rel="stylesheet">
+    <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
     
     <style>
         /* === ESTILOS GLOBAIS PARA LAYOUT COM NAVBAR FIXA E SIDEBAR FIXA/OFFCANVAS === */
@@ -355,7 +355,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
-    <script src="https://cdn.quilljs.com/2.0.3/quill.min.js"></script>
+    <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
     <script>
       document.addEventListener('DOMContentLoaded', function () {
         document.querySelectorAll('textarea:not(.no-quill)').forEach(function (textarea) {
@@ -364,7 +364,7 @@
           container.style.minHeight = (textarea.getAttribute('rows') ? textarea.getAttribute('rows') * 24 : 100) + 'px';
           textarea.style.display = 'none';
           textarea.parentNode.insertBefore(container, textarea);
-          var quill = new Quill(container, { theme: 'bubble' });
+          var quill = new Quill(container, { theme: 'snow' });
           var form = textarea.closest('form');
           if (form) {
             form.addEventListener('submit', function () {


### PR DESCRIPTION
## Summary
- Revert Quill CSS and JS assets to version 1.3.6 with the snow theme.
- Update article templates to load the snow theme and initialize editors accordingly.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895ff8cc8d8832ebe11ba45c5a286ea