### PR TITLE
Fix autosave reset on form builder

### DIFF
--- a/static/js/form_builder.js
+++ b/static/js/form_builder.js
@@ -881,9 +881,12 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  form.addEventListener('submit', () => {
-    updateJSON();
-  });
+  // 'submit' event is already handled above, where we update the JSON
+  // structure, validate the form, and clear any saved draft. Adding another
+  // listener here would trigger another `updateJSON()` call which in turn
+  // saves the draft again, re-populating localStorage right after it was
+  // cleared. Therefore, we avoid attaching a duplicate submit handler that
+  // would interfere with the autosave reset logic.
 
   function showToast(message) {
     const container = document.createElement('div');


### PR DESCRIPTION
## Summary
- prevent form builder from re-saving draft after submission

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68960ca3a924832eaa18aaaef67e5b6f