### PR TITLE
feat: reestruturar ordens de serviço

### DIFF
--- a/core/enums.py
+++ b/core/enums.py
@@ -61,3 +61,35 @@ class Permissao(Enum):
     ARTIGO_ASSUMIR_REVISAO_ESTABELECIMENTO = "artigo_assumir_revisao_estabelecimento"
     ARTIGO_ASSUMIR_REVISAO_INSTITUICAO = "artigo_assumir_revisao_instituicao"
     ARTIGO_ASSUMIR_REVISAO_TODAS = "artigo_assumir_revisao_todas"
+
+
+class OSStatus(Enum):
+    """Status possíveis de uma Ordem de Serviço."""
+
+    def __new__(cls, value: str, label: str):
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.label = label
+        return obj
+
+    RASCUNHO = ("rascunho", "Rascunho")
+    AGUARDANDO = ("aguardando", "Aguardando")
+    EM_ATENDIMENTO = ("em_atendimento", "Em Atendimento")
+    PENDENTE = ("pendente", "Pendente")
+    CONCLUIDA = ("concluida", "Concluída")
+    CANCELADA = ("cancelada", "Cancelada")
+
+
+class OSPrioridade(Enum):
+    """Prioridade de atendimento para a Ordem de Serviço."""
+
+    def __new__(cls, value: str, label: str):
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.label = label
+        return obj
+
+    BAIXA = ("baixa", "Baixa")
+    MEDIA = ("media", "Média")
+    ALTA = ("alta", "Alta")
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -143,8 +143,9 @@ seed. Cada etapa pode estar vinculada a um cargo e setor para controle de
 responsáveis. Uma Ordem de Serviço pode selecionar um `processo_id` e avançar
 entre as etapas conforme as permissões do usuário.
 
-Os processos se integram aos módulos de OS, Artigos e permissões por meio das
-notificações e da atribuição de cargos responsáveis.
+Os processos se integram ao módulo de Ordem de Serviço, que está em constante
+construção, além de Artigos e permissões por meio das notificações e da
+atribuição de cargos responsáveis.
 
 ## Tema, Modo Escuro e Acessibilidade
 

--- a/migrations/versions/ab12cd34ef56_restructure_ordem_servico.py
+++ b/migrations/versions/ab12cd34ef56_restructure_ordem_servico.py
@@ -1,0 +1,80 @@
+"""restructure ordem servico
+
+Revision ID: ab12cd34ef56
+Revises: fa23b0c1c9d0
+Create Date: 2025-07-09 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'ab12cd34ef56'
+down_revision = ('fa23b0c1c9d0', '7c8d9e0f1a2b')
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.alter_column('ordem_servico', 'descricao', existing_type=sa.Text(), nullable=False)
+    op.alter_column('ordem_servico', 'processo_id', new_column_name='tipo_os_id')
+    op.alter_column('ordem_servico', 'tipo_os_id', existing_type=sa.String(length=36), nullable=False)
+    op.alter_column('ordem_servico', 'status', existing_type=sa.String(length=20), nullable=False, server_default='rascunho')
+    op.add_column('ordem_servico', sa.Column('criado_por_id', sa.Integer(), nullable=False))
+    op.add_column('ordem_servico', sa.Column('atribuido_para_id', sa.Integer(), nullable=True))
+    op.add_column('ordem_servico', sa.Column('equipe_responsavel_id', sa.Integer(), nullable=True))
+    op.add_column('ordem_servico', sa.Column('data_criacao', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False))
+    op.add_column('ordem_servico', sa.Column('data_conclusao', sa.DateTime(timezone=True), nullable=True))
+    op.add_column('ordem_servico', sa.Column('formulario_respostas_id', sa.Integer(), nullable=True))
+    op.add_column('ordem_servico', sa.Column('prioridade', sa.String(length=10), nullable=True))
+    op.add_column('ordem_servico', sa.Column('origem', sa.String(length=255), nullable=True))
+    op.add_column('ordem_servico', sa.Column('observacoes', sa.Text(), nullable=True))
+    op.drop_column('ordem_servico', 'created_at')
+    op.drop_column('ordem_servico', 'updated_at')
+
+    op.create_table(
+        'ordem_servico_participante',
+        sa.Column('ordem_servico_id', sa.String(length=36), sa.ForeignKey('ordem_servico.id'), primary_key=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('user.id'), primary_key=True)
+    )
+
+    op.create_table(
+        'ordem_servico_log',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('os_id', sa.String(length=36), sa.ForeignKey('ordem_servico.id'), nullable=False),
+        sa.Column('data_hora', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('usuario_id', sa.Integer(), sa.ForeignKey('user.id'), nullable=False),
+        sa.Column('acao', sa.String(length=255), nullable=False),
+        sa.Column('origem_status', sa.String(length=20)),
+        sa.Column('destino_status', sa.String(length=20)),
+        sa.Column('observacao', sa.Text())
+    )
+
+    op.create_table(
+        'ordem_servico_comentario',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('os_id', sa.String(length=36), sa.ForeignKey('ordem_servico.id'), nullable=False),
+        sa.Column('usuario_id', sa.Integer(), sa.ForeignKey('user.id'), nullable=False),
+        sa.Column('data_hora', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('mensagem', sa.Text(), nullable=False),
+        sa.Column('anexo', sa.String(length=255))
+    )
+
+
+def downgrade():
+    op.drop_table('ordem_servico_comentario')
+    op.drop_table('ordem_servico_log')
+    op.drop_table('ordem_servico_participante')
+    op.add_column('ordem_servico', sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False))
+    op.add_column('ordem_servico', sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False))
+    op.drop_column('ordem_servico', 'observacoes')
+    op.drop_column('ordem_servico', 'origem')
+    op.drop_column('ordem_servico', 'prioridade')
+    op.drop_column('ordem_servico', 'formulario_respostas_id')
+    op.drop_column('ordem_servico', 'data_conclusao')
+    op.drop_column('ordem_servico', 'data_criacao')
+    op.drop_column('ordem_servico', 'equipe_responsavel_id')
+    op.drop_column('ordem_servico', 'atribuido_para_id')
+    op.drop_column('ordem_servico', 'criado_por_id')
+    op.alter_column('ordem_servico', 'status', existing_type=sa.String(length=20), nullable=False, server_default='aberta')
+    op.alter_column('ordem_servico', 'tipo_os_id', new_column_name='processo_id', existing_type=sa.String(length=36), nullable=True)
+    op.alter_column('ordem_servico', 'descricao', existing_type=sa.Text(), nullable=True)

--- a/templates/admin/ordens_servico.html
+++ b/templates/admin/ordens_servico.html
@@ -19,17 +19,42 @@
           <textarea class="form-control" id="descricao" name="descricao" rows="3">{{ request.form.get('descricao', ordem_editar.descricao if ordem_editar else '') }}</textarea>
         </div>
         <div class="mb-3">
-          <label for="processo_id" class="form-label">Processo</label>
-          <select class="form-select" id="processo_id" name="processo_id">
+          <label for="tipo_os_id" class="form-label">Tipo</label>
+          <select class="form-select" id="tipo_os_id" name="tipo_os_id" required>
             <option value="">--</option>
             {% for proc in processos %}
-            <option value="{{ proc.id }}" {% if ordem_editar and ordem_editar.processo_id==proc.id %}selected{% endif %}>{{ proc.nome }}</option>
+            <option value="{{ proc.id }}" {% if ordem_editar and ordem_editar.tipo_os_id==proc.id %}selected{% endif %}>{{ proc.nome }}</option>
             {% endfor %}
           </select>
         </div>
         <div class="mb-3">
+          <label for="atribuido_para_id" class="form-label">Atribuído para</label>
+          <input type="text" class="form-control" id="atribuido_para_id" name="atribuido_para_id" value="{{ request.form.get('atribuido_para_id', ordem_editar.atribuido_para_id if ordem_editar else '') }}">
+        </div>
+        <div class="mb-3">
+          <label for="prioridade" class="form-label">Prioridade</label>
+          <select class="form-select" id="prioridade" name="prioridade">
+            <option value="">--</option>
+            {% for p in prioridades %}
+            <option value="{{ p.value }}" {% if ordem_editar and ordem_editar.prioridade==p.value %}selected{% endif %}>{{ p.label }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="mb-3">
+          <label for="origem" class="form-label">Origem</label>
+          <input type="text" class="form-control" id="origem" name="origem" value="{{ request.form.get('origem', ordem_editar.origem if ordem_editar else '') }}">
+        </div>
+        <div class="mb-3">
+          <label for="observacoes" class="form-label">Observações</label>
+          <textarea class="form-control" id="observacoes" name="observacoes" rows="3">{{ request.form.get('observacoes', ordem_editar.observacoes if ordem_editar else '') }}</textarea>
+        </div>
+        <div class="mb-3">
           <label for="status" class="form-label">Status</label>
-          <input type="text" class="form-control" id="status" name="status" value="{{ request.form.get('status', ordem_editar.status if ordem_editar else 'aberta') }}">
+          <select class="form-select" id="status" name="status">
+            {% for st in status_choices %}
+            <option value="{{ st.value }}" {% if ordem_editar and ordem_editar.status==st.value %}selected{% elif not ordem_editar and st.value=='rascunho' %}selected{% endif %}>{{ st.label }}</option>
+            {% endfor %}
+          </select>
         </div>
         <button type="submit" class="btn btn-primary">Salvar</button>
       </form>

--- a/templates/ordens_servico/nova_os.html
+++ b/templates/ordens_servico/nova_os.html
@@ -17,20 +17,37 @@
               <textarea class="form-control" id="descricao" name="descricao" rows="4"></textarea>
             </div>
             <div class="mb-3">
-              <label for="processo_id" class="form-label">Processo</label>
-              <select class="form-select" id="processo_id" name="processo_id">
+              <label for="tipo_os_id" class="form-label">Tipo</label>
+              <select class="form-select" id="tipo_os_id" name="tipo_os_id">
                 <option value="">--</option>
                 {% for proc in processos %}
                 <option value="{{ proc.id }}">{{ proc.nome }}</option>
                 {% endfor %}
               </select>
             </div>
+            <div class="mb-3">
+              <label for="prioridade" class="form-label">Prioridade</label>
+              <select class="form-select" id="prioridade" name="prioridade">
+                <option value="">--</option>
+                {% for p in prioridades %}
+                <option value="{{ p.value }}">{{ p.label }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="mb-3">
+              <label for="origem" class="form-label">Origem</label>
+              <input type="text" class="form-control" id="origem" name="origem">
+            </div>
+            <div class="mb-3">
+              <label for="observacoes" class="form-label">Observações</label>
+              <textarea class="form-control" id="observacoes" name="observacoes" rows="3"></textarea>
+            </div>
             <button type="submit" class="btn btn-primary">Salvar</button>
           </form>
         </div>
       </div>
-</div>
-</div>
+    </div>
+  </div>
 </div>
 {% endblock %}
 {% block extra_js %}

--- a/tests/test_ordem_servico.py
+++ b/tests/test_ordem_servico.py
@@ -39,29 +39,30 @@ def test_crud_ordem_servico(client):
     resp = client.post('/admin/ordens_servico', data={
         'titulo': 'OS1',
         'descricao': 'desc',
-        'processo_id': proc_id,
-        'status': 'aberta'
+        'tipo_os_id': proc_id,
+        'status': 'rascunho',
+        'prioridade': 'baixa'
     }, follow_redirects=True)
     assert resp.status_code == 200
     with app.app_context():
         os_obj = OrdemServico.query.filter_by(titulo='OS1').first()
         assert os_obj is not None
         os_id = os_obj.id
-        assert os_obj.processo_id == proc_id
+        assert os_obj.tipo_os_id == proc_id
     # update
     resp = client.post('/admin/ordens_servico', data={
         'id_para_atualizar': os_id,
         'titulo': 'OS1 edit',
         'descricao': 'd2',
-        'processo_id': '',
-        'status': 'fechada'
+        'tipo_os_id': proc_id,
+        'status': 'cancelada'
     }, follow_redirects=True)
     assert resp.status_code == 200
     with app.app_context():
         os_obj = OrdemServico.query.get(os_id)
         assert os_obj.titulo == 'OS1 edit'
-        assert os_obj.processo_id is None
-        assert os_obj.status == 'fechada'
+        assert os_obj.tipo_os_id == proc_id
+        assert os_obj.status == 'cancelada'
     # delete
     resp = client.post(f'/admin/ordens_servico/delete/{os_id}', follow_redirects=True)
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- expandir enums para status e prioridade de OS
- reestruturar modelo de ordem de serviço com histórico e comentários
- atualizar formulários e rotas para novos campos e validações

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68962fc1029c832e9733f7f9e0326c30