### PR TITLE
Implement process workflow and OS type structure

### DIFF
--- a/templates/admin/ordens_servico.html
+++ b/templates/admin/ordens_servico.html
@@ -22,8 +22,8 @@
           <label for="tipo_os_id" class="form-label">Tipo</label>
           <select class="form-select" id="tipo_os_id" name="tipo_os_id" required>
             <option value="">--</option>
-            {% for proc in processos %}
-            <option value="{{ proc.id }}" {% if ordem_editar and ordem_editar.tipo_os_id==proc.id %}selected{% endif %}>{{ proc.nome }}</option>
+            {% for t in tipos_os %}
+            <option value="{{ t.id }}" {% if ordem_editar and ordem_editar.tipo_os_id==t.id %}selected{% endif %}>{{ t.nome }}</option>
             {% endfor %}
           </select>
         </div>

--- a/templates/ordens_servico/atendimento_list.html
+++ b/templates/ordens_servico/atendimento_list.html
@@ -15,8 +15,8 @@
     <div class="col-md-3">
       <select class="form-select form-select-sm" name="tipo">
         <option value="">Todos os Tipos</option>
-        {% for p in processos %}
-          <option value="{{ p.id }}" {% if request.args.get('tipo') == p.id|string %}selected{% endif %}>{{ p.nome }}</option>
+        {% for t in tipos_os %}
+          <option value="{{ t.id }}" {% if request.args.get('tipo') == t.id|string %}selected{% endif %}>{{ t.nome }}</option>
         {% endfor %}
       </select>
     </div>

--- a/templates/ordens_servico/nova_os.html
+++ b/templates/ordens_servico/nova_os.html
@@ -20,8 +20,8 @@
               <label for="tipo_os_id" class="form-label">Tipo</label>
               <select class="form-select" id="tipo_os_id" name="tipo_os_id">
                 <option value="">--</option>
-                {% for proc in processos %}
-                <option value="{{ proc.id }}">{{ proc.nome }}</option>
+                {% for t in tipos_os %}
+                <option value="{{ t.id }}">{{ t.nome }}</option>
                 {% endfor %}
               </select>
             </div>

--- a/tests/test_ordem_servico.py
+++ b/tests/test_ordem_servico.py
@@ -1,7 +1,7 @@
 import pytest
 
 from app import app, db
-from core.models import OrdemServico, Processo, Instituicao, Estabelecimento, Setor, Celula, User, Funcao
+from core.models import OrdemServico, Processo, Subprocesso, TipoOS, Instituicao, Estabelecimento, Setor, Celula, User, Funcao
 
 
 @pytest.fixture
@@ -31,10 +31,13 @@ def login_admin(client):
 def test_crud_ordem_servico(client):
     login_admin(client)
     with app.app_context():
-        proc = Processo(nome='Proc', descricao='d')
-        db.session.add(proc)
+        proc = Processo(nome='Proc')
+        sub = Subprocesso(nome='Sub', processo=proc)
+        cel = Celula.query.first()
+        tipo = TipoOS(nome='Tipo', descricao='d', subprocesso=sub, equipe_responsavel_id=cel.id)
+        db.session.add_all([proc, sub, tipo])
         db.session.commit()
-        proc_id = proc.id
+        proc_id = tipo.id
     # create
     resp = client.post('/admin/ordens_servico', data={
         'titulo': 'OS1',


### PR DESCRIPTION
## Summary
- add subprocess, OS type and cargo link models to support workflow automation
- tie OrdemServico to TipoOS and enforce required form completion
- filter OS type options by user's cargo and prefill responsible team

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68963c5d3f08832eb5554dd49d3eb626