### PR TITLE
Carrega formulário vinculado via AJAX

### DIFF
--- a/templates/ordens_servico/_formulario_vinculado.html
+++ b/templates/ordens_servico/_formulario_vinculado.html
@@ -1,0 +1,151 @@
+{% macro render_campo(campo, idx) %}
+<div class="mb-3 question-block" data-id="{{ campo.id }}" data-ramificacoes='{{ (campo.ramificacoes or [])|tojson }}'>
+  <div class="d-flex justify-content-between">
+    <div class="flex-grow-1 me-3">
+      <label class="form-label">{{ campo.label }}{% if campo.obrigatoria %} *{% endif %}</label>
+      {% if campo.subtitulo %}<div class="form-text mb-2">{{ campo.subtitulo }}</div>{% endif %}
+    </div>
+    <div class="text-end">
+      {% if campo.midia_url %}
+        <img src="{{ campo.midia_url }}" class="img-fluid mb-2" style="max-width: 200px;" alt="">
+      {% endif %}
+      {% if campo.video_url %}
+        <div class="video-holder">
+          <iframe width="250" height="140" src="{{ campo.video_url }}" allowfullscreen></iframe>
+          <button type="button" class="btn btn-link p-0 mt-1 expand-video" data-video="{{ campo.video_url }}">Expandir</button>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+  {% if campo.tipo == 'textarea' %}
+    <textarea class="form-control no-quill" {% if campo.obrigatoria %}required{% endif %}></textarea>
+  {% elif campo.tipo == 'select' %}
+    <select class="form-select" {% if campo.obrigatoria %}required{% endif %}>
+      {% for opcao in campo.opcoes %}
+        <option value="{{ opcao }}">{{ opcao }}</option>
+      {% endfor %}
+    </select>
+  {% elif campo.tipo == 'option' %}
+    {% if campo.usarMenuSuspenso %}
+      <select class="form-select" {% if campo.permiteMultiplaEscolha %}multiple{% endif %} {% if campo.obrigatoria %}required{% endif %} {% if campo.temOpcaoOutra %}data-outra-select{% endif %}>
+        {% for opcao in campo.opcoes %}
+          <option value="{{ opcao }}">{{ opcao }}</option>
+        {% endfor %}
+        {% if campo.temOpcaoOutra %}
+          <option value="outra">Outra</option>
+        {% endif %}
+      </select>
+      {% if campo.temOpcaoOutra %}<input type="text" class="form-control mt-2 d-none outra-especifique" placeholder="Especifique">{% endif %}
+    {% else %}
+      {% set input_type = 'checkbox' if campo.permiteMultiplaEscolha else 'radio' %}
+      {% for opcao in campo.opcoes %}
+        <div class="form-check">
+          <input class="form-check-input" type="{{ input_type }}" name="campo{{ idx }}{% if campo.permiteMultiplaEscolha %}[]{% endif %}" value="{{ opcao }}" {% if campo.obrigatoria %}required{% endif %}>
+          <label class="form-check-label">{{ opcao }}</label>
+        </div>
+      {% endfor %}
+      {% if campo.temOpcaoOutra %}
+        <div class="form-check mt-2">
+          <input class="form-check-input outra-option" type="{{ input_type }}" name="campo{{ idx }}{% if campo.permiteMultiplaEscolha %}[]{% endif %}" value="outra">
+          <label class="form-check-label">Outra</label>
+        </div>
+        <input type="text" class="form-control mt-2 d-none outra-especifique" placeholder="Especifique">
+      {% endif %}
+    {% endif %}
+  {% elif campo.tipo == 'rating' %}
+    {% set opcoes = campo.opcoes if campo.opcoes else ['1','2','3','4','5'] %}
+    <select class="form-select" {% if campo.obrigatoria %}required{% endif %}>
+      {% for opcao in opcoes %}
+        <option value="{{ opcao }}">{{ opcao }}</option>
+      {% endfor %}
+    </select>
+  {% elif campo.tipo == 'date' %}
+    <input type="date" class="form-control date-field" placeholder="dd/mm/aaaa" {% if campo.obrigatoria %}required{% endif %}>
+  {% elif campo.tipo == 'likert' %}
+    {% set linhas = campo.linhas if campo.linhas else ['Item 1'] %}
+    {% set colunas = campo.colunas if campo.colunas else ['Discordo totalmente','Discordo','Neutro','Concordo','Concordo totalmente'] %}
+    <div class="table-responsive">
+      <table class="table table-bordered">
+        <thead>
+          <tr>
+            <th></th>
+            {% for col in colunas %}
+              <th class="text-center">{{ col }}</th>
+            {% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for linha in linhas %}
+            {% set row_index = loop.index0 %}
+            <tr>
+              <th>{{ linha }}</th>
+              {% for col in colunas %}
+                <td class="text-center">
+                  <input class="form-check-input" type="radio" name="campo{{ idx }}_{{ row_index }}" value="{{ col }}" {% if campo.obrigatoria %}required{% endif %}>
+                </td>
+              {% endfor %}
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% elif campo.tipo == 'file' %}
+    <input type="file" class="form-control" {% if campo.obrigatoria %}required{% endif %}>
+  {% elif campo.tipo == 'nps' %}
+    <div class="d-flex flex-wrap">
+      {% for i in range(11) %}
+        <div class="form-check form-check-inline">
+          <input class="form-check-input" type="radio" name="campo{{ idx }}" value="{{ i }}" {% if campo.obrigatoria %}required{% endif %}>
+          <label class="form-check-label">{{ i }}</label>
+        </div>
+      {% endfor %}
+    </div>
+  {% elif campo.tipo == 'table' %}
+    <div class="table-responsive">
+      <table class="table table-bordered">
+        {% set cabecalhos = campo.opcoes if campo.opcoes else [] %}
+        {% if cabecalhos %}
+          <thead>
+            <tr>
+              {% for cab in cabecalhos %}
+                <th>{{ cab }}</th>
+              {% endfor %}
+            </tr>
+          </thead>
+        {% endif %}
+        <tbody>
+          {% set total_linhas = campo.linhas if campo.linhas else 1 %}
+          {% for r in range(total_linhas) %}
+            <tr>
+              {% if cabecalhos %}
+                {% for cab in cabecalhos %}
+                  <td><input type="text" class="form-control"></td>
+                {% endfor %}
+              {% else %}
+                <td>Sem colunas definidas</td>
+              {% endif %}
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    <input type="text" class="form-control" {% if campo.obrigatoria %}required{% endif %}>
+  {% endif %}
+</div>
+{% endmacro %}
+
+{% set q_idx = namespace(value=0) %}
+{% for bloco in estrutura %}
+  {% if bloco.tipo == 'section' %}
+    <div class="section-block mb-4" data-section-index="{{ loop.index0 }}">
+      {% for campo in bloco.campos %}
+        {{ render_campo(campo, q_idx.value) }}
+        {% set q_idx.value = q_idx.value + 1 %}
+      {% endfor %}
+    </div>
+  {% else %}
+    {{ render_campo(bloco, q_idx.value) }}
+    {% set q_idx.value = q_idx.value + 1 %}
+  {% endif %}
+{% endfor %}

--- a/templates/ordens_servico/nova_os.html
+++ b/templates/ordens_servico/nova_os.html
@@ -42,6 +42,7 @@
               <label for="observacoes" class="form-label">Observações</label>
               <textarea class="form-control" id="observacoes" name="observacoes" rows="3"></textarea>
             </div>
+            <div class="mb-3" id="formulario-vinculado"></div>
             <button type="submit" class="btn btn-primary">Salvar</button>
           </form>
         </div>
@@ -54,7 +55,7 @@
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.querySelector('form');
-  const inputs = form.querySelectorAll('input, textarea, select');
+  let inputs = form.querySelectorAll('input, textarea, select');
   const STORAGE_KEY = 'draft_nova_os';
   function save() {
     const data = {};
@@ -73,7 +74,48 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   load();
   inputs.forEach(i => i.addEventListener('input', save));
-  form.addEventListener('submit', () => localStorage.removeItem(STORAGE_KEY));
+  const tipoSelect = document.getElementById('tipo_os_id');
+  const formContainer = document.getElementById('formulario-vinculado');
+  let formularioObrigatorio = false;
+
+  tipoSelect.addEventListener('change', () => {
+    const tipoId = tipoSelect.value;
+    if (!tipoId) {
+      formContainer.innerHTML = '';
+      formularioObrigatorio = false;
+      inputs = form.querySelectorAll('input, textarea, select');
+      inputs.forEach(i => i.addEventListener('input', save));
+      return;
+    }
+    fetch(`/os/tipo/${tipoId}/formulario`)
+      .then(r => r.json())
+      .then(data => {
+        formContainer.innerHTML = data.html || '';
+        formularioObrigatorio = data.obrigatorio;
+        inputs = form.querySelectorAll('input, textarea, select');
+        inputs.forEach(i => i.addEventListener('input', save));
+      })
+      .catch(() => {
+        formContainer.innerHTML = '';
+        formularioObrigatorio = false;
+      });
+  });
+
+  form.addEventListener('submit', (e) => {
+    if (formularioObrigatorio) {
+      const campos = formContainer.querySelectorAll('input, textarea, select');
+      const algumPreenchido = Array.from(campos).some(c => {
+        if (c.type === 'checkbox' || c.type === 'radio') return c.checked;
+        return c.value && c.value.trim() !== '';
+      });
+      if (!algumPreenchido) {
+        e.preventDefault();
+        alert('Preenchimento do formulário vinculado é obrigatório.');
+        return;
+      }
+    }
+    localStorage.removeItem(STORAGE_KEY);
+  });
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Load linked form when selecting TipoOS via AJAX and mark required fields
- Block submission when required form is empty
- Add endpoint and test for retrieving linked form

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896472562b8832eaf3451b76086044a