### PR TITLE
Ensure subprocesso table exists before related migrations

### DIFF
--- a/migrations/versions/ea3b24d8f6c7_add_tipo_os_and_cargo_processo_tables.py
+++ b/migrations/versions/ea3b24d8f6c7_add_tipo_os_and_cargo_processo_tables.py
@@ -16,6 +16,14 @@ def upgrade():
     op.rename_table('etapa_processo', 'processo_etapa')
     op.create_foreign_key('campo_etapa_etapa_id_fkey', 'campo_etapa', 'processo_etapa', ['etapa_id'], ['id'])
 
+    # Create subprocesso table
+    op.create_table(
+        'subprocesso',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('nome', sa.String(length=255), nullable=False),
+        sa.Column('processo_id', sa.String(length=36), sa.ForeignKey('processo.id'), nullable=False),
+    )
+
     # Create cargo_processo table
     op.create_table(
         'cargo_processo',
@@ -41,6 +49,7 @@ def downgrade():
     # Drop newly created tables
     op.drop_table('tipo_os')
     op.drop_table('cargo_processo')
+    op.drop_table('subprocesso')
 
     # Rename processo_etapa back to etapa_processo and restore FK
     op.drop_constraint('campo_etapa_etapa_id_fkey', 'campo_etapa', type_='foreignkey')


### PR DESCRIPTION
## Summary
- Create `subprocesso` table in migration so `cargo_processo` and `tipo_os` can reference it
- Drop `subprocesso` in downgrade to keep schema reversible

## Testing
- `pytest`
- `flask db upgrade` *(fails: sqlite3.OperationalError: near "TYPE": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_689656edfd44832ea7ba23cdf3c3b510