### PR TITLE
Add admin screens for subprocesses and OS types

### DIFF
--- a/blueprints/processos.py
+++ b/blueprints/processos.py
@@ -6,9 +6,27 @@ except ImportError:  # pragma: no cover
     from core.database import db
 
 try:
-    from ..core.models import Processo, EtapaProcesso, CampoEtapa, Setor, Celula
+    from ..core.models import (
+        Processo,
+        Subprocesso,
+        CargoProcesso,
+        Cargo,
+        EtapaProcesso,
+        CampoEtapa,
+        Setor,
+        Celula,
+    )
 except ImportError:  # pragma: no cover
-    from core.models import Processo, EtapaProcesso, CampoEtapa, Setor, Celula
+    from core.models import (
+        Processo,
+        Subprocesso,
+        CargoProcesso,
+        Cargo,
+        EtapaProcesso,
+        CampoEtapa,
+        Setor,
+        Celula,
+    )
 
 try:
     from ..core.decorators import admin_required
@@ -213,3 +231,89 @@ def admin_delete_campo(campo_id):
         db.session.rollback()
         flash(f'Erro ao remover campo: {str(e)}', 'danger')
     return redirect(url_for('processos_bp.admin_campos', etapa_id=etapa_id))
+
+
+@processos_bp.route('/admin/subprocessos', methods=['GET', 'POST'])
+@admin_required
+def admin_subprocessos():
+    subprocesso_para_editar = None
+    if request.method == 'GET':
+        edit_id = request.args.get('edit_id', type=int)
+        if edit_id:
+            subprocesso_para_editar = Subprocesso.query.get_or_404(edit_id)
+    if request.method == 'POST':
+        id_para_atualizar = request.form.get('id_para_atualizar', type=int)
+        nome = request.form.get('nome', '').strip()
+        processo_id = request.form.get('processo_id')
+        if not nome or not processo_id:
+            flash('Nome e Processo são obrigatórios.', 'danger')
+        else:
+            if id_para_atualizar:
+                sp = Subprocesso.query.get_or_404(id_para_atualizar)
+                sp.nome = nome
+                sp.processo_id = processo_id
+                action_msg = 'atualizado'
+            else:
+                sp = Subprocesso(nome=nome, processo_id=processo_id)
+                db.session.add(sp)
+                action_msg = 'criado'
+            try:
+                db.session.commit()
+                flash(f'Subprocesso {action_msg} com sucesso!', 'success')
+                return redirect(url_for('processos_bp.admin_subprocessos'))
+            except Exception as e:
+                db.session.rollback()
+                flash(f'Erro ao salvar subprocesso: {str(e)}', 'danger')
+        if id_para_atualizar:
+            subprocesso_para_editar = Subprocesso.query.get(id_para_atualizar)
+    subprocessos = Subprocesso.query.order_by(Subprocesso.nome).all()
+    processos = Processo.query.order_by(Processo.nome).all()
+    return render_template(
+        'admin/subprocessos.html',
+        subprocessos=subprocessos,
+        subprocesso_editar=subprocesso_para_editar,
+        processos=processos,
+    )
+
+
+@processos_bp.route('/admin/cargos_subprocessos', methods=['GET', 'POST'])
+@admin_required
+def admin_cargos_subprocessos():
+    if request.method == 'POST':
+        cargo_id = request.form.get('cargo_id', type=int)
+        subprocesso_id = request.form.get('subprocesso_id', type=int)
+        if cargo_id and subprocesso_id:
+            vinc = CargoProcesso(cargo_id=cargo_id, subprocesso_id=subprocesso_id)
+            db.session.add(vinc)
+            try:
+                db.session.commit()
+                flash('Vínculo criado com sucesso!', 'success')
+            except Exception as e:
+                db.session.rollback()
+                flash(f'Erro ao criar vínculo: {str(e)}', 'danger')
+        else:
+            flash('Cargo e Subprocesso são obrigatórios.', 'danger')
+        return redirect(url_for('processos_bp.admin_cargos_subprocessos'))
+    vinculos = CargoProcesso.query.all()
+    cargos = Cargo.query.order_by(Cargo.nome).all()
+    subprocessos = Subprocesso.query.order_by(Subprocesso.nome).all()
+    return render_template(
+        'admin/cargos_subprocessos.html',
+        vinculos=vinculos,
+        cargos=cargos,
+        subprocessos=subprocessos,
+    )
+
+
+@processos_bp.route('/admin/cargos_subprocessos/delete/<int:id>', methods=['POST'])
+@admin_required
+def admin_cargos_subprocessos_delete(id):
+    vinc = CargoProcesso.query.get_or_404(id)
+    try:
+        db.session.delete(vinc)
+        db.session.commit()
+        flash('Vínculo removido com sucesso!', 'success')
+    except Exception as e:
+        db.session.rollback()
+        flash(f'Erro ao remover vínculo: {str(e)}', 'danger')
+    return redirect(url_for('processos_bp.admin_cargos_subprocessos'))

--- a/templates/admin/cargos_subprocessos.html
+++ b/templates/admin/cargos_subprocessos.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+{% block title %}Vínculos Cargo/Subprocesso{% endblock %}
+{% block content %}
+<div class="container mt-3">
+  <h1>Vínculos Cargo ↔ Subprocesso</h1>
+  <table class="table table-sm">
+    <thead>
+      <tr><th>Cargo</th><th>Subprocesso</th><th>Ações</th></tr>
+    </thead>
+    <tbody>
+      {% for v in vinculos %}
+      <tr>
+        <td>{{ v.cargo.nome }}</td>
+        <td>{{ v.subprocesso.nome }}</td>
+        <td>
+          <form method="POST" action="{{ url_for('processos_bp.admin_cargos_subprocessos_delete', id=v.id) }}" class="d-inline" onsubmit="return confirm('Remover vínculo?');">
+            <button class="btn btn-sm btn-outline-danger">Remover</button>
+          </form>
+        </td>
+      </tr>
+      {% else %}
+      <tr><td colspan="3" class="text-center text-muted">Nenhum vínculo cadastrado.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <hr>
+  <h2 class="h5">Novo Vínculo</h2>
+  <form method="POST" action="{{ url_for('processos_bp.admin_cargos_subprocessos') }}" class="compact-form">
+    <div class="mb-3">
+      <label for="cargo_id" class="form-label">Cargo <span class="text-danger">*</span></label>
+      <select class="form-select form-select-sm" id="cargo_id" name="cargo_id" required>
+        <option value="">--</option>
+        {% for c in cargos %}
+        <option value="{{ c.id }}">{{ c.nome }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="mb-3">
+      <label for="subprocesso_id" class="form-label">Subprocesso <span class="text-danger">*</span></label>
+      <select class="form-select form-select-sm" id="subprocesso_id" name="subprocesso_id" required>
+        <option value="">--</option>
+        {% for sp in subprocessos %}
+        <option value="{{ sp.id }}">{{ sp.nome }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <button type="submit" class="btn btn-sm btn-primary">Adicionar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/admin/subprocessos.html
+++ b/templates/admin/subprocessos.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% block title %}Subprocessos{% endblock %}
+{% block content %}
+<div class="container mt-3">
+  <h1>Subprocessos</h1>
+  <table class="table table-sm">
+    <thead>
+      <tr><th>Nome</th><th>Processo</th><th>Ações</th></tr>
+    </thead>
+    <tbody>
+      {% for sp in subprocessos %}
+      <tr>
+        <td>{{ sp.nome }}</td>
+        <td>{{ sp.processo.nome }}</td>
+        <td>
+          <a href="{{ url_for('processos_bp.admin_subprocessos', edit_id=sp.id) }}" class="btn btn-sm btn-outline-primary">Editar</a>
+        </td>
+      </tr>
+      {% else %}
+      <tr><td colspan="3" class="text-center text-muted">Nenhum subprocesso cadastrado.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <hr>
+  <h2 class="h5">{{ 'Editar Subprocesso' if subprocesso_editar else 'Novo Subprocesso' }}</h2>
+  <form method="POST" action="{{ url_for('processos_bp.admin_subprocessos') }}" class="compact-form">
+    {% if subprocesso_editar %}
+    <input type="hidden" name="id_para_atualizar" value="{{ subprocesso_editar.id }}">
+    {% endif %}
+    <div class="mb-3">
+      <label for="nome" class="form-label">Nome <span class="text-danger">*</span></label>
+      <input type="text" class="form-control form-control-sm" id="nome" name="nome" required value="{{ request.form.get('nome', subprocesso_editar.nome if subprocesso_editar else '') }}">
+    </div>
+    <div class="mb-3">
+      <label for="processo_id" class="form-label">Processo <span class="text-danger">*</span></label>
+      <select class="form-select form-select-sm" id="processo_id" name="processo_id" required>
+        <option value="">--</option>
+        {% for proc in processos %}
+        <option value="{{ proc.id }}" {% if (request.form.get('processo_id', subprocesso_editar.processo_id|string if subprocesso_editar else '') == proc.id|string) %}selected{% endif %}>{{ proc.nome }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <button type="submit" class="btn btn-sm btn-primary">Salvar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/admin/tipos_os.html
+++ b/templates/admin/tipos_os.html
@@ -1,0 +1,78 @@
+{% extends "base.html" %}
+{% block title %}Tipos de OS{% endblock %}
+{% block content %}
+<div class="container mt-3">
+  <h1>Tipos de OS</h1>
+  <table class="table table-sm">
+    <thead>
+      <tr><th>Nome</th><th>Subprocesso</th><th>Equipe</th><th>Formulário</th><th>Obrigatório</th><th>Ações</th></tr>
+    </thead>
+    <tbody>
+      {% for t in tipos %}
+      <tr>
+        <td>{{ t.nome }}</td>
+        <td>{{ t.subprocesso.nome }}</td>
+        <td>{{ t.equipe_responsavel.nome if t.equipe_responsavel else '-' }}</td>
+        <td>{{ formularios_dict.get(t.formulario_vinculado_id).nome if t.formulario_vinculado_id else '-' }}</td>
+        <td>{{ 'Sim' if t.obrigatorio_preenchimento else 'Não' }}</td>
+        <td>
+          <a href="{{ url_for('ordens_servico_bp.admin_tipos_os', edit_id=t.id) }}" class="btn btn-sm btn-outline-primary me-1">Editar</a>
+          <form method="POST" action="{{ url_for('ordens_servico_bp.admin_tipos_os_delete', id=t.id) }}" class="d-inline" onsubmit="return confirm('Excluir tipo de OS?');">
+            <button class="btn btn-sm btn-outline-danger">Excluir</button>
+          </form>
+        </td>
+      </tr>
+      {% else %}
+      <tr><td colspan="6" class="text-center text-muted">Nenhum tipo de OS cadastrado.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <hr>
+  <h2 class="h5">{{ 'Editar Tipo de OS' if tipo_editar else 'Novo Tipo de OS' }}</h2>
+  <form method="POST" action="{{ url_for('ordens_servico_bp.admin_tipos_os') }}" class="compact-form">
+    {% if tipo_editar %}
+    <input type="hidden" name="id_para_atualizar" value="{{ tipo_editar.id }}">
+    {% endif %}
+    <div class="mb-3">
+      <label for="nome" class="form-label">Nome <span class="text-danger">*</span></label>
+      <input type="text" class="form-control form-control-sm" id="nome" name="nome" required value="{{ request.form.get('nome', tipo_editar.nome if tipo_editar else '') }}">
+    </div>
+    <div class="mb-3">
+      <label for="descricao" class="form-label">Descrição</label>
+      <textarea class="form-control form-control-sm" id="descricao" name="descricao" rows="2">{{ request.form.get('descricao', tipo_editar.descricao if tipo_editar else '') }}</textarea>
+    </div>
+    <div class="mb-3">
+      <label for="subprocesso_id" class="form-label">Subprocesso <span class="text-danger">*</span></label>
+      <select class="form-select form-select-sm" id="subprocesso_id" name="subprocesso_id" required>
+        <option value="">--</option>
+        {% for sp in subprocessos %}
+        <option value="{{ sp.id }}" {% if (request.form.get('subprocesso_id', tipo_editar.subprocesso_id|string if tipo_editar else '') == sp.id|string) %}selected{% endif %}>{{ sp.nome }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="mb-3">
+      <label for="equipe_responsavel_id" class="form-label">Equipe Responsável</label>
+      <select class="form-select form-select-sm" id="equipe_responsavel_id" name="equipe_responsavel_id">
+        <option value="">--</option>
+        {% for cel in celulas %}
+        <option value="{{ cel.id }}" {% if (request.form.get('equipe_responsavel_id', tipo_editar.equipe_responsavel_id|string if tipo_editar else '') == cel.id|string) %}selected{% endif %}>{{ cel.nome }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="mb-3">
+      <label for="formulario_vinculado_id" class="form-label">Formulário Vinculado</label>
+      <select class="form-select form-select-sm" id="formulario_vinculado_id" name="formulario_vinculado_id">
+        <option value="">--</option>
+        {% for f in formularios %}
+        <option value="{{ f.id }}" {% if (request.form.get('formulario_vinculado_id', tipo_editar.formulario_vinculado_id|string if tipo_editar else '') == f.id|string) %}selected{% endif %}>{{ f.nome }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="mb-3 form-check">
+      <input class="form-check-input" type="checkbox" id="obrigatorio_preenchimento" name="obrigatorio_preenchimento" {% if request.form.get('obrigatorio_preenchimento', tipo_editar.obrigatorio_preenchimento if tipo_editar else False) %}checked{% endif %}>
+      <label class="form-check-label" for="obrigatorio_preenchimento">Formulário obrigatório?</label>
+    </div>
+    <button type="submit" class="btn btn-sm btn-primary">Salvar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -308,6 +308,8 @@
 
                     {# Link para Processos #}
                     <li class="nav-item"><a class="nav-link {{ 'active' if 'admin_processos' in request.endpoint or 'admin_etapas' in request.endpoint or 'admin_campos' in request.endpoint else '' }}" href="{{ url_for('admin_processos') }}"><i class="bi bi-bezier2 me-2"></i> Processos</a></li>
+                    <li class="nav-item"><a class="nav-link {{ 'active' if 'admin_subprocessos' in request.endpoint else '' }}" href="{{ url_for('processos_bp.admin_subprocessos') }}"><i class="bi bi-diagram-3-fill me-2"></i> Subprocessos</a></li>
+                    <li class="nav-item"><a class="nav-link {{ 'active' if 'admin_cargos_subprocessos' in request.endpoint else '' }}" href="{{ url_for('processos_bp.admin_cargos_subprocessos') }}"><i class="bi bi-link-45deg me-2"></i> Cargos ↔ Subprocessos</a></li>
 
                     <hr class="my-2">
 
@@ -324,6 +326,9 @@
                                 <li class="nav-item"><a class="nav-link {{ 'active' if 'os_nova' in request.endpoint else '' }}" href="{{ url_for('ordens_servico_bp.os_nova') }}"><i class="bi bi-plus-circle-dotted me-2"></i> Abrir Nova OS</a></li>
                                 <li class="nav-item"><a class="nav-link {{ 'active' if 'os_listar' in request.endpoint else '' }}" href="{{ url_for('ordens_servico_bp.os_listar') }}"><i class="bi bi-binoculars-fill me-2"></i> Consultar OS</a></li>
                                 <li class="nav-item"><a class="nav-link {{ 'active' if 'os_minhas' in request.endpoint else '' }}" href="{{ url_for('ordens_servico_bp.os_minhas') }}"><i class="bi bi-person-lines-fill me-2"></i> Minhas OS</a></li>
+                                {% if current_user.is_authenticated and current_user.has_permissao('admin') %}
+                                <li class="nav-item"><a class="nav-link {{ 'active' if 'admin_tipos_os' in request.endpoint else '' }}" href="{{ url_for('ordens_servico_bp.admin_tipos_os') }}"><i class="bi bi-card-text me-2"></i> Tipos de OS</a></li>
+                                {% endif %}
                                 {% if current_user and current_user.pode_atender_os %}
                                 <li class="nav-item"><a class="nav-link {{ 'active' if 'os_atendimento' in request.endpoint else '' }}" href="{{ url_for('ordens_servico_bp.os_atendimento') }}"><i class="bi bi-headset me-2"></i> Atendimento de OS</a></li>
                                 {% endif %}


### PR DESCRIPTION
## Summary
- add CRUD routes and templates for subprocesses
- manage cargo ↔ subprocess links via new admin page
- introduce admin management for OS types and expose navigation links

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68965d1de33c832ea52f4ae9a44e9bb9