### PR TITLE
Fix OS type foreign key and unify admin layouts

### DIFF
--- a/migrations/versions/6b6b76d9b5e5_fix_ordem_servico_tipo_os_fk.py
+++ b/migrations/versions/6b6b76d9b5e5_fix_ordem_servico_tipo_os_fk.py
@@ -1,0 +1,41 @@
+"""fix ordem_servico.tipo_os foreign key"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '6b6b76d9b5e5'
+down_revision = 'c2d1e3f4a567'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    with op.batch_alter_table('ordem_servico') as batch_op:
+        # Drop old FK pointing to processo
+        batch_op.drop_constraint('ordem_servico_processo_id_fkey', type_='foreignkey')
+        # Alter column type to Integer
+        batch_op.alter_column(
+            'tipo_os_id',
+            existing_type=sa.String(length=36),
+            type_=sa.Integer(),
+            existing_nullable=False,
+            postgresql_using='tipo_os_id::integer'
+        )
+        # Create new FK to tipo_os
+        batch_op.create_foreign_key(
+            'ordem_servico_tipo_os_id_fkey', 'tipo_os', ['tipo_os_id'], ['id']
+        )
+
+def downgrade():
+    with op.batch_alter_table('ordem_servico') as batch_op:
+        batch_op.drop_constraint('ordem_servico_tipo_os_id_fkey', type_='foreignkey')
+        batch_op.alter_column(
+            'tipo_os_id',
+            existing_type=sa.Integer(),
+            type_=sa.String(length=36),
+            existing_nullable=False,
+            postgresql_using='tipo_os_id::text'
+        )
+        batch_op.create_foreign_key(
+            'ordem_servico_processo_id_fkey', 'processo', ['tipo_os_id'], ['id']
+        )

--- a/templates/admin/cargos_subprocessos.html
+++ b/templates/admin/cargos_subprocessos.html
@@ -1,50 +1,68 @@
 {% extends "base.html" %}
 {% block title %}Vínculos Cargo/Subprocesso{% endblock %}
 {% block content %}
-<div class="container mt-3">
-  <h1>Vínculos Cargo ↔ Subprocesso</h1>
-  <table class="table table-sm">
-    <thead>
-      <tr><th>Cargo</th><th>Subprocesso</th><th>Ações</th></tr>
-    </thead>
-    <tbody>
-      {% for v in vinculos %}
-      <tr>
-        <td>{{ v.cargo.nome }}</td>
-        <td>{{ v.subprocesso.nome }}</td>
-        <td>
-          <form method="POST" action="{{ url_for('processos_bp.admin_cargos_subprocessos_delete', id=v.id) }}" class="d-inline" onsubmit="return confirm('Remover vínculo?');">
-            <button class="btn btn-sm btn-outline-danger">Remover</button>
-          </form>
-        </td>
-      </tr>
-      {% else %}
-      <tr><td colspan="3" class="text-center text-muted">Nenhum vínculo cadastrado.</td></tr>
-      {% endfor %}
-    </tbody>
-  </table>
-  <hr>
-  <h2 class="h5">Novo Vínculo</h2>
-  <form method="POST" action="{{ url_for('processos_bp.admin_cargos_subprocessos') }}" class="compact-form">
-    <div class="mb-3">
-      <label for="cargo_id" class="form-label">Cargo <span class="text-danger">*</span></label>
-      <select class="form-select form-select-sm" id="cargo_id" name="cargo_id" required>
-        <option value="">--</option>
-        {% for c in cargos %}
-        <option value="{{ c.id }}">{{ c.nome }}</option>
-        {% endfor %}
-      </select>
+<div class="container-fluid px-5 mt-3">
+  <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-1 border-bottom">
+    <h1 class="h2">Vínculos Cargo ↔ Subprocesso</h1>
+  </div>
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <div class="card shadow-sm mb-4">
+        <div class="card-header">
+          <h5 class="mb-0"><i class="bi bi-list-ul me-2"></i>Vínculos Cadastrados ({{ vinculos|length }})</h5>
+        </div>
+        <div class="card-body">
+          {% if vinculos %}
+          <div class="table-responsive">
+            <table class="table table-hover table-sm align-middle">
+              <thead>
+                <tr><th>Cargo</th><th>Subprocesso</th><th style="width: 120px;" class="text-end">Ações</th></tr>
+              </thead>
+              <tbody>
+                {% for v in vinculos %}
+                <tr>
+                  <td>{{ v.cargo.nome }}</td>
+                  <td>{{ v.subprocesso.nome }}</td>
+                  <td class="text-end">
+                    <form method="POST" action="{{ url_for('processos_bp.admin_cargos_subprocessos_delete', id=v.id) }}" class="d-inline" onsubmit="return confirm('Remover vínculo?');">
+                      <button class="btn btn-sm btn-outline-danger" type="submit"><i class="bi bi-trash-fill"></i></button>
+                    </form>
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% else %}
+          <p class="text-muted">Nenhum vínculo cadastrado.</p>
+          {% endif %}
+        </div>
+      </div>
+      <h5 class="mb-3"><i class="bi bi-plus-circle-fill me-2"></i>Novo Vínculo</h5>
+      <form method="POST" action="{{ url_for('processos_bp.admin_cargos_subprocessos') }}" class="compact-form">
+        <div class="mb-1">
+          <label for="cargo_id" class="form-label">Cargo <span class="text-danger">*</span></label>
+          <select class="form-select form-select-sm" id="cargo_id" name="cargo_id" required>
+            <option value="">--</option>
+            {% for c in cargos %}
+            <option value="{{ c.id }}">{{ c.nome }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="mb-1">
+          <label for="subprocesso_id" class="form-label">Subprocesso <span class="text-danger">*</span></label>
+          <select class="form-select form-select-sm" id="subprocesso_id" name="subprocesso_id" required>
+            <option value="">--</option>
+            {% for sp in subprocessos %}
+            <option value="{{ sp.id }}">{{ sp.nome }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="d-flex pt-2 border-top">
+          <button type="submit" class="btn btn-primary"><i class="bi bi-check-lg me-1"></i> Adicionar</button>
+        </div>
+      </form>
     </div>
-    <div class="mb-3">
-      <label for="subprocesso_id" class="form-label">Subprocesso <span class="text-danger">*</span></label>
-      <select class="form-select form-select-sm" id="subprocesso_id" name="subprocesso_id" required>
-        <option value="">--</option>
-        {% for sp in subprocessos %}
-        <option value="{{ sp.id }}">{{ sp.nome }}</option>
-        {% endfor %}
-      </select>
-    </div>
-    <button type="submit" class="btn btn-sm btn-primary">Adicionar</button>
-  </form>
+  </div>
 </div>
 {% endblock %}

--- a/templates/admin/subprocessos.html
+++ b/templates/admin/subprocessos.html
@@ -1,46 +1,90 @@
 {% extends "base.html" %}
-{% block title %}Subprocessos{% endblock %}
+{% block title %}Admin - Subprocessos{% endblock %}
 {% block content %}
-<div class="container mt-3">
-  <h1>Subprocessos</h1>
-  <table class="table table-sm">
-    <thead>
-      <tr><th>Nome</th><th>Processo</th><th>Ações</th></tr>
-    </thead>
-    <tbody>
-      {% for sp in subprocessos %}
-      <tr>
-        <td>{{ sp.nome }}</td>
-        <td>{{ sp.processo.nome }}</td>
-        <td>
-          <a href="{{ url_for('processos_bp.admin_subprocessos', edit_id=sp.id) }}" class="btn btn-sm btn-outline-primary">Editar</a>
-        </td>
-      </tr>
-      {% else %}
-      <tr><td colspan="3" class="text-center text-muted">Nenhum subprocesso cadastrado.</td></tr>
-      {% endfor %}
-    </tbody>
-  </table>
-  <hr>
-  <h2 class="h5">{{ 'Editar Subprocesso' if subprocesso_editar else 'Novo Subprocesso' }}</h2>
-  <form method="POST" action="{{ url_for('processos_bp.admin_subprocessos') }}" class="compact-form">
-    {% if subprocesso_editar %}
-    <input type="hidden" name="id_para_atualizar" value="{{ subprocesso_editar.id }}">
-    {% endif %}
-    <div class="mb-3">
-      <label for="nome" class="form-label">Nome <span class="text-danger">*</span></label>
-      <input type="text" class="form-control form-control-sm" id="nome" name="nome" required value="{{ request.form.get('nome', subprocesso_editar.nome if subprocesso_editar else '') }}">
+<div class="container-fluid px-5 mt-3">
+  <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-1 border-bottom">
+    <h1 class="h2">Subprocessos</h1>
+  </div>
+  <ul class="nav nav-tabs" id="tabSubproc" role="tablist">
+    <li class="nav-item">
+      <button class="nav-link active" id="consulta-tab" data-bs-toggle="tab" data-bs-target="#consulta" type="button" role="tab">Consulta</button>
+    </li>
+    <li class="nav-item">
+      <button class="nav-link" id="cadastro-tab" data-bs-toggle="tab" data-bs-target="#cadastro" type="button" role="tab">Cadastro</button>
+    </li>
+  </ul>
+  <div class="card shadow-sm">
+    <div class="card-body p-0">
+      <div class="tab-content" id="tabSubprocContent">
+        <div class="tab-pane fade show active p-3" id="consulta" role="tabpanel" aria-labelledby="consulta-tab">
+          <div class="card shadow-sm mb-4">
+            <div class="card-header">
+              <h5 class="mb-0"><i class="bi bi-list-ul me-2"></i>Subprocessos Cadastrados ({{ subprocessos|length }})</h5>
+            </div>
+            <div class="card-body">
+              {% if subprocessos %}
+                <div class="table-responsive">
+                  <table class="table table-hover table-sm align-middle">
+                    <thead>
+                      <tr>
+                        <th>Nome</th>
+                        <th>Processo</th>
+                        <th style="width: 120px;" class="text-end">Ações</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {% for sp in subprocessos %}
+                      <tr class="clickable-row" data-href="{{ url_for('processos_bp.admin_subprocessos', edit_id=sp.id) }}">
+                        <td>{{ sp.nome }}</td>
+                        <td>{{ sp.processo.nome }}</td>
+                        <td class="text-end">
+                          <a href="{{ url_for('processos_bp.admin_subprocessos', edit_id=sp.id) }}" class="btn btn-sm btn-outline-primary" title="Editar"><i class="bi bi-pencil-fill"></i></a>
+                        </td>
+                      </tr>
+                      {% endfor %}
+                    </tbody>
+                  </table>
+                </div>
+              {% else %}
+                <p class="text-muted">Nenhum subprocesso cadastrado.</p>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+        <div class="tab-pane fade p-3" id="cadastro" role="tabpanel" aria-labelledby="cadastro-tab">
+          <h5 class="mb-3"><i class="bi bi-plus-circle-fill me-2"></i>{{ 'Editar Subprocesso' if subprocesso_editar else 'Adicionar Subprocesso' }}</h5>
+          <form method="POST" action="{{ url_for('processos_bp.admin_subprocessos') }}" class="compact-form" novalidate>
+            {% if subprocesso_editar %}
+            <input type="hidden" name="id_para_atualizar" value="{{ subprocesso_editar.id }}">
+            {% endif %}
+            <div class="mb-1">
+              <label for="nome" class="form-label">Nome <span class="text-danger">*</span></label>
+              <input type="text" class="form-control form-control-sm" id="nome" name="nome" required value="{{ request.form.get('nome', subprocesso_editar.nome if subprocesso_editar else '') }}">
+            </div>
+            <div class="mb-1">
+              <label for="processo_id" class="form-label">Processo <span class="text-danger">*</span></label>
+              <select class="form-select form-select-sm" id="processo_id" name="processo_id" required>
+                <option value="">--</option>
+                {% for proc in processos %}
+                <option value="{{ proc.id }}" {% if (request.form.get('processo_id', subprocesso_editar.processo_id|string if subprocesso_editar else '') == proc.id|string) %}selected{% endif %}>{{ proc.nome }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="d-flex pt-2 border-top">
+              <button type="submit" class="btn btn-primary"><i class="bi bi-check-lg me-1"></i> Salvar</button>
+            </div>
+          </form>
+        </div>
+      </div>
     </div>
-    <div class="mb-3">
-      <label for="processo_id" class="form-label">Processo <span class="text-danger">*</span></label>
-      <select class="form-select form-select-sm" id="processo_id" name="processo_id" required>
-        <option value="">--</option>
-        {% for proc in processos %}
-        <option value="{{ proc.id }}" {% if (request.form.get('processo_id', subprocesso_editar.processo_id|string if subprocesso_editar else '') == proc.id|string) %}selected{% endif %}>{{ proc.nome }}</option>
-        {% endfor %}
-      </select>
-    </div>
-    <button type="submit" class="btn btn-sm btn-primary">Salvar</button>
-  </form>
+  </div>
 </div>
+{% if subprocesso_editar %}
+<script>
+  document.addEventListener('DOMContentLoaded', function(){
+    var tab = new bootstrap.Tab(document.getElementById('cadastro-tab'));
+    tab.show();
+  });
+</script>
+{% endif %}
 {% endblock %}

--- a/templates/admin/tipos_os.html
+++ b/templates/admin/tipos_os.html
@@ -1,78 +1,114 @@
 {% extends "base.html" %}
 {% block title %}Tipos de OS{% endblock %}
 {% block content %}
-<div class="container mt-3">
-  <h1>Tipos de OS</h1>
-  <table class="table table-sm">
-    <thead>
-      <tr><th>Nome</th><th>Subprocesso</th><th>Equipe</th><th>Formulário</th><th>Obrigatório</th><th>Ações</th></tr>
-    </thead>
-    <tbody>
-      {% for t in tipos %}
-      <tr>
-        <td>{{ t.nome }}</td>
-        <td>{{ t.subprocesso.nome }}</td>
-        <td>{{ t.equipe_responsavel.nome if t.equipe_responsavel else '-' }}</td>
-        <td>{{ formularios_dict.get(t.formulario_vinculado_id).nome if t.formulario_vinculado_id else '-' }}</td>
-        <td>{{ 'Sim' if t.obrigatorio_preenchimento else 'Não' }}</td>
-        <td>
-          <a href="{{ url_for('ordens_servico_bp.admin_tipos_os', edit_id=t.id) }}" class="btn btn-sm btn-outline-primary me-1">Editar</a>
-          <form method="POST" action="{{ url_for('ordens_servico_bp.admin_tipos_os_delete', id=t.id) }}" class="d-inline" onsubmit="return confirm('Excluir tipo de OS?');">
-            <button class="btn btn-sm btn-outline-danger">Excluir</button>
+<div class="container-fluid px-5 mt-3">
+  <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-1 border-bottom">
+    <h1 class="h2">Tipos de OS</h1>
+  </div>
+  <ul class="nav nav-tabs" id="tabTipoOS" role="tablist">
+    <li class="nav-item"><button class="nav-link active" id="consulta-tab" data-bs-toggle="tab" data-bs-target="#consulta" type="button" role="tab">Consulta</button></li>
+    <li class="nav-item"><button class="nav-link" id="cadastro-tab" data-bs-toggle="tab" data-bs-target="#cadastro" type="button" role="tab">Cadastro</button></li>
+  </ul>
+  <div class="card shadow-sm">
+    <div class="card-body p-0">
+      <div class="tab-content" id="tabTipoOSContent">
+        <div class="tab-pane fade show active p-3" id="consulta" role="tabpanel" aria-labelledby="consulta-tab">
+          <div class="card shadow-sm mb-4">
+            <div class="card-header">
+              <h5 class="mb-0"><i class="bi bi-list-ul me-2"></i>Tipos de OS Cadastrados ({{ tipos|length }})</h5>
+            </div>
+            <div class="card-body">
+              {% if tipos %}
+              <div class="table-responsive">
+                <table class="table table-hover table-sm align-middle">
+                  <thead>
+                    <tr><th>Nome</th><th>Subprocesso</th><th>Equipe</th><th>Formulário</th><th>Obrigatório</th><th style="width: 120px;" class="text-end">Ações</th></tr>
+                  </thead>
+                  <tbody>
+                    {% for t in tipos %}
+                    <tr class="clickable-row" data-href="{{ url_for('ordens_servico_bp.admin_tipos_os', edit_id=t.id) }}">
+                      <td>{{ t.nome }}</td>
+                      <td>{{ t.subprocesso.nome }}</td>
+                      <td>{{ t.equipe_responsavel.nome if t.equipe_responsavel else '-' }}</td>
+                      <td>{{ formularios_dict.get(t.formulario_vinculado_id).nome if t.formulario_vinculado_id else '-' }}</td>
+                      <td>{{ 'Sim' if t.obrigatorio_preenchimento else 'Não' }}</td>
+                      <td class="text-end">
+                        <a href="{{ url_for('ordens_servico_bp.admin_tipos_os', edit_id=t.id) }}" class="btn btn-sm btn-outline-primary" title="Editar"><i class="bi bi-pencil-fill"></i></a>
+                        <form method="POST" action="{{ url_for('ordens_servico_bp.admin_tipos_os_delete', id=t.id) }}" class="d-inline" onsubmit="return confirm('Excluir tipo de OS?');">
+                          <button class="btn btn-sm btn-outline-danger" type="submit"><i class="bi bi-trash-fill"></i></button>
+                        </form>
+                      </td>
+                    </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+              {% else %}
+              <p class="text-muted">Nenhum tipo de OS cadastrado.</p>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+        <div class="tab-pane fade p-3" id="cadastro" role="tabpanel" aria-labelledby="cadastro-tab">
+          <h5 class="mb-3"><i class="bi bi-plus-circle-fill me-2"></i>{{ 'Editar Tipo de OS' if tipo_editar else 'Adicionar Tipo de OS' }}</h5>
+          <form method="POST" action="{{ url_for('ordens_servico_bp.admin_tipos_os') }}" class="compact-form" novalidate>
+            {% if tipo_editar %}
+            <input type="hidden" name="id_para_atualizar" value="{{ tipo_editar.id }}">
+            {% endif %}
+            <div class="mb-1">
+              <label for="nome" class="form-label">Nome <span class="text-danger">*</span></label>
+              <input type="text" class="form-control form-control-sm" id="nome" name="nome" required value="{{ request.form.get('nome', tipo_editar.nome if tipo_editar else '') }}">
+            </div>
+            <div class="mb-1">
+              <label for="descricao" class="form-label">Descrição</label>
+              <textarea class="form-control form-control-sm" id="descricao" name="descricao" rows="2">{{ request.form.get('descricao', tipo_editar.descricao if tipo_editar else '') }}</textarea>
+            </div>
+            <div class="mb-1">
+              <label for="subprocesso_id" class="form-label">Subprocesso <span class="text-danger">*</span></label>
+              <select class="form-select form-select-sm" id="subprocesso_id" name="subprocesso_id" required>
+                <option value="">--</option>
+                {% for sp in subprocessos %}
+                <option value="{{ sp.id }}" {% if (request.form.get('subprocesso_id', tipo_editar.subprocesso_id|string if tipo_editar else '') == sp.id|string) %}selected{% endif %}>{{ sp.nome }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="mb-1">
+              <label for="equipe_responsavel_id" class="form-label">Equipe Responsável</label>
+              <select class="form-select form-select-sm" id="equipe_responsavel_id" name="equipe_responsavel_id">
+                <option value="">--</option>
+                {% for cel in celulas %}
+                <option value="{{ cel.id }}" {% if (request.form.get('equipe_responsavel_id', tipo_editar.equipe_responsavel_id|string if tipo_editar else '') == cel.id|string) %}selected{% endif %}>{{ cel.nome }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="mb-1">
+              <label for="formulario_vinculado_id" class="form-label">Formulário Vinculado</label>
+              <select class="form-select form-select-sm" id="formulario_vinculado_id" name="formulario_vinculado_id">
+                <option value="">--</option>
+                {% for f in formularios %}
+                <option value="{{ f.id }}" {% if (request.form.get('formulario_vinculado_id', tipo_editar.formulario_vinculado_id|string if tipo_editar else '') == f.id|string) %}selected{% endif %}>{{ f.nome }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="mb-1 form-check">
+              <input class="form-check-input" type="checkbox" id="obrigatorio_preenchimento" name="obrigatorio_preenchimento" {% if request.form.get('obrigatorio_preenchimento', tipo_editar.obrigatorio_preenchimento if tipo_editar else False) %}checked{% endif %}>
+              <label class="form-check-label" for="obrigatorio_preenchimento">Formulário obrigatório?</label>
+            </div>
+            <div class="d-flex pt-2 border-top">
+              <button type="submit" class="btn btn-primary"><i class="bi bi-check-lg me-1"></i> Salvar</button>
+            </div>
           </form>
-        </td>
-      </tr>
-      {% else %}
-      <tr><td colspan="6" class="text-center text-muted">Nenhum tipo de OS cadastrado.</td></tr>
-      {% endfor %}
-    </tbody>
-  </table>
-  <hr>
-  <h2 class="h5">{{ 'Editar Tipo de OS' if tipo_editar else 'Novo Tipo de OS' }}</h2>
-  <form method="POST" action="{{ url_for('ordens_servico_bp.admin_tipos_os') }}" class="compact-form">
-    {% if tipo_editar %}
-    <input type="hidden" name="id_para_atualizar" value="{{ tipo_editar.id }}">
-    {% endif %}
-    <div class="mb-3">
-      <label for="nome" class="form-label">Nome <span class="text-danger">*</span></label>
-      <input type="text" class="form-control form-control-sm" id="nome" name="nome" required value="{{ request.form.get('nome', tipo_editar.nome if tipo_editar else '') }}">
+        </div>
+      </div>
     </div>
-    <div class="mb-3">
-      <label for="descricao" class="form-label">Descrição</label>
-      <textarea class="form-control form-control-sm" id="descricao" name="descricao" rows="2">{{ request.form.get('descricao', tipo_editar.descricao if tipo_editar else '') }}</textarea>
-    </div>
-    <div class="mb-3">
-      <label for="subprocesso_id" class="form-label">Subprocesso <span class="text-danger">*</span></label>
-      <select class="form-select form-select-sm" id="subprocesso_id" name="subprocesso_id" required>
-        <option value="">--</option>
-        {% for sp in subprocessos %}
-        <option value="{{ sp.id }}" {% if (request.form.get('subprocesso_id', tipo_editar.subprocesso_id|string if tipo_editar else '') == sp.id|string) %}selected{% endif %}>{{ sp.nome }}</option>
-        {% endfor %}
-      </select>
-    </div>
-    <div class="mb-3">
-      <label for="equipe_responsavel_id" class="form-label">Equipe Responsável</label>
-      <select class="form-select form-select-sm" id="equipe_responsavel_id" name="equipe_responsavel_id">
-        <option value="">--</option>
-        {% for cel in celulas %}
-        <option value="{{ cel.id }}" {% if (request.form.get('equipe_responsavel_id', tipo_editar.equipe_responsavel_id|string if tipo_editar else '') == cel.id|string) %}selected{% endif %}>{{ cel.nome }}</option>
-        {% endfor %}
-      </select>
-    </div>
-    <div class="mb-3">
-      <label for="formulario_vinculado_id" class="form-label">Formulário Vinculado</label>
-      <select class="form-select form-select-sm" id="formulario_vinculado_id" name="formulario_vinculado_id">
-        <option value="">--</option>
-        {% for f in formularios %}
-        <option value="{{ f.id }}" {% if (request.form.get('formulario_vinculado_id', tipo_editar.formulario_vinculado_id|string if tipo_editar else '') == f.id|string) %}selected{% endif %}>{{ f.nome }}</option>
-        {% endfor %}
-      </select>
-    </div>
-    <div class="mb-3 form-check">
-      <input class="form-check-input" type="checkbox" id="obrigatorio_preenchimento" name="obrigatorio_preenchimento" {% if request.form.get('obrigatorio_preenchimento', tipo_editar.obrigatorio_preenchimento if tipo_editar else False) %}checked{% endif %}>
-      <label class="form-check-label" for="obrigatorio_preenchimento">Formulário obrigatório?</label>
-    </div>
-    <button type="submit" class="btn btn-sm btn-primary">Salvar</button>
-  </form>
+  </div>
 </div>
+{% if tipo_editar %}
+<script>
+  document.addEventListener('DOMContentLoaded', function(){
+    var tab = new bootstrap.Tab(document.getElementById('cadastro-tab'));
+    tab.show();
+  });
+</script>
+{% endif %}
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -234,6 +234,22 @@
                                             </ul>
                                         </div>
                                     </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link d-flex justify-content-between align-items-center {{ 'active' if ('admin_processos' in request.endpoint) or ('admin_subprocessos' in request.endpoint) or ('admin_cargos_subprocessos' in request.endpoint) or ('admin_etapas' in request.endpoint) or ('admin_campos' in request.endpoint) else '' }} {{ 'collapsed' if not ('admin_processos' in request.endpoint or 'admin_subprocessos' in request.endpoint or 'admin_cargos_subprocessos' in request.endpoint or 'admin_etapas' in request.endpoint or 'admin_campos' in request.endpoint) }}"
+                                        data-bs-toggle="collapse" href="#collapseProcessosSub" role="button"
+                                        aria-expanded="{{ 'true' if ('admin_processos' in request.endpoint) or ('admin_subprocessos' in request.endpoint) or ('admin_cargos_subprocessos' in request.endpoint) or ('admin_etapas' in request.endpoint) or ('admin_campos' in request.endpoint) else 'false' }}"
+                                        aria-controls="collapseProcessosSub">
+                                            <i class="bi bi-diagram-3-fill me-2"></i> Processos
+                                            <i class="bi bi-chevron-down small ms-auto"></i>
+                                        </a>
+                                        <div class="collapse {{ 'show' if ('admin_processos' in request.endpoint) or ('admin_subprocessos' in request.endpoint) or ('admin_cargos_subprocessos' in request.endpoint) or ('admin_etapas' in request.endpoint) or ('admin_campos' in request.endpoint) else '' }}" id="collapseProcessosSub">
+                                            <ul class="nav flex-column ps-3">
+                                                <li class="nav-item"><a class="nav-link {{ 'active' if 'admin_processos' in request.endpoint or 'admin_etapas' in request.endpoint or 'admin_campos' in request.endpoint else '' }}" href="{{ url_for('admin_processos') }}"><i class="bi bi-bezier2 me-2"></i> Processos</a></li>
+                                                <li class="nav-item"><a class="nav-link {{ 'active' if 'admin_subprocessos' in request.endpoint else '' }}" href="{{ url_for('admin_subprocessos') }}"><i class="bi bi-diagram-3-fill me-2"></i> Subprocessos</a></li>
+                                                <li class="nav-item"><a class="nav-link {{ 'active' if 'admin_cargos_subprocessos' in request.endpoint else '' }}" href="{{ url_for('admin_cargos_subprocessos') }}"><i class="bi bi-link-45deg me-2"></i> Cargos ↔ Subprocessos</a></li>
+                                            </ul>
+                                        </div>
+                                    </li>
                                     <li class="nav-item"><a class="nav-link {{ 'active' if 'admin_dashboard' in request.endpoint else '' }}" href="{{ url_for('admin_dashboard') }}"><i class="bi bi-speedometer2 me-2"></i> Dashboard Admin</a></li>
                                     <li class="nav-item">
                                         <a class="nav-link d-flex justify-content-between align-items-center {{ 'active' if 'admin_usuarios' in request.endpoint else '' }} {{ 'collapsed' if 'admin_usuarios' not in request.endpoint }}"
@@ -303,13 +319,6 @@
                             </ul>
                         </div>
                     </li>
-
-                    <hr class="my-2">
-
-                    {# Link para Processos #}
-                    <li class="nav-item"><a class="nav-link {{ 'active' if 'admin_processos' in request.endpoint or 'admin_etapas' in request.endpoint or 'admin_campos' in request.endpoint else '' }}" href="{{ url_for('admin_processos') }}"><i class="bi bi-bezier2 me-2"></i> Processos</a></li>
-                    <li class="nav-item"><a class="nav-link {{ 'active' if 'admin_subprocessos' in request.endpoint else '' }}" href="{{ url_for('processos_bp.admin_subprocessos') }}"><i class="bi bi-diagram-3-fill me-2"></i> Subprocessos</a></li>
-                    <li class="nav-item"><a class="nav-link {{ 'active' if 'admin_cargos_subprocessos' in request.endpoint else '' }}" href="{{ url_for('processos_bp.admin_cargos_subprocessos') }}"><i class="bi bi-link-45deg me-2"></i> Cargos ↔ Subprocessos</a></li>
 
                     <hr class="my-2">
 


### PR DESCRIPTION
## Summary
- Group process-related links under Administration and fix Cargos ↔ Subprocessos menu
- Standardize admin pages for subprocessos, cargos/subprocessos and tipos de OS
- Add migration fixing ordem_servico.tipo_os_id foreign key

## Testing
- `SECRET_KEY=testing DATABASE_URI=sqlite:///test.db pytest`


------
https://chatgpt.com/codex/tasks/task_e_689664b2b484832ea12d60029cd98024