### PR TITLE
Add notification animation and adjust etapas editor layout

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -194,8 +194,33 @@ body > .container {
 }
 
 /* Área de notificações com rolagem */
-#notificationMenu {
+#notificationMenu,
+#osNotificationMenu {
   max-height: 300px;
+  overflow-y: auto;
+}
+
+#notificationMenu li.is-new,
+#osNotificationMenu li.is-new {
+  animation: fadeInUp 0.3s ease;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Editor wrapper common rules */
+.editor-container {
+  display: block;
+  min-height: 160px;
+  max-height: 320px;
   overflow-y: auto;
 }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -164,6 +164,12 @@ document.addEventListener("DOMContentLoaded", function () {
           a.className = "dropdown-item notification-link fw-bold";
           a.dataset.id = n.id;
           li.appendChild(a);
+          li.classList.add("is-new");
+          li.addEventListener(
+            "animationend",
+            () => li.classList.remove("is-new"),
+            { once: true }
+          );
           menu.appendChild(li);
         }
         refreshLinks();
@@ -320,6 +326,12 @@ document.addEventListener("DOMContentLoaded", function () {
           a.className = "dropdown-item os-notification-link fw-bold";
           a.dataset.id = n.id;
           li.appendChild(a);
+          li.classList.add("is-new");
+          li.addEventListener(
+            "animationend",
+            () => li.classList.remove("is-new"),
+            { once: true }
+          );
           menu.appendChild(li);
         }
         refreshOsLinks();

--- a/templates/admin/etapas.html
+++ b/templates/admin/etapas.html
@@ -93,7 +93,7 @@
                                 </select>
                             </div>
                         </div>
-                        <div class="row mb-1">
+                        <div class="row" style="margin-bottom: 1.25rem;">
                             <div class="col-md-6">
                                 <label for="descricao" class="form-label">Descrição</label>
                                 <textarea class="form-control form-control-sm" id="descricao" name="descricao">{{ request.form.get('descricao', '') }}</textarea>
@@ -103,8 +103,10 @@
                                 <textarea class="form-control form-control-sm" id="instrucoes" name="instrucoes">{{ request.form.get('instrucoes', '') }}</textarea>
                             </div>
                         </div>
-                        <div class="d-flex pt-2 border-top">
-                            <button type="submit" class="btn btn-primary"><i class="bi bi-check-lg me-1"></i> Adicionar Etapa</button>
+                        <div class="row mt-3">
+                            <div class="col-12 pt-2 border-top">
+                                <button type="submit" class="btn btn-primary"><i class="bi bi-check-lg me-1"></i> Adicionar Etapa</button>
+                            </div>
                         </div>
                     </form>
                 </div>
@@ -152,7 +154,7 @@
                                 </select>
                             </div>
                         </div>
-                        <div class="row mb-1">
+                        <div class="row" style="margin-bottom: 1.25rem;">
                             <div class="col-md-6">
                                 <label for="edit_descricao" class="form-label">Descrição</label>
                                 <textarea class="form-control form-control-sm" id="edit_descricao" name="descricao">{{ request.form.get('descricao', etapa_editar.descricao) }}</textarea>
@@ -162,9 +164,11 @@
                                 <textarea class="form-control form-control-sm" id="edit_instrucoes" name="instrucoes">{{ request.form.get('instrucoes', etapa_editar.instrucoes) }}</textarea>
                             </div>
                         </div>
-                        <div class="d-flex pt-2 border-top">
-                            <button type="submit" class="btn btn-primary"><i class="bi bi-check-lg me-1"></i> Salvar Alterações</button>
-                            <button type="button" class="btn btn-outline-secondary ms-2" data-bs-dismiss="modal"><i class="bi bi-x-lg me-1"></i> Cancelar</button>
+                        <div class="row mt-3">
+                            <div class="col-12 pt-2 border-top">
+                                <button type="submit" class="btn btn-primary"><i class="bi bi-check-lg me-1"></i> Salvar Alterações</button>
+                                <button type="button" class="btn btn-outline-secondary ms-2" data-bs-dismiss="modal"><i class="bi bi-x-lg me-1"></i> Cancelar</button>
+                            </div>
                         </div>
                     </form>
                 </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -379,7 +379,11 @@
         document.querySelectorAll('textarea:not(.no-quill)').forEach(function (textarea) {
           var container = document.createElement('div');
           container.innerHTML = textarea.value;
-          container.style.minHeight = (textarea.getAttribute('rows') ? textarea.getAttribute('rows') * 24 : 100) + 'px';
+          container.classList.add('editor-container');
+          container.style.display = 'block';
+          container.style.minHeight = '160px';
+          container.style.maxHeight = '320px';
+          container.style.overflowY = 'auto';
           textarea.style.display = 'none';
           textarea.parentNode.insertBefore(container, textarea);
           var quill = new Quill(container, { theme: 'snow' });


### PR DESCRIPTION
## Summary
- Animate newly loaded notifications in dropdowns for smoother fade-up effect
- Constrain Quill editor containers and restructure etapa forms to prevent button overlap

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a4a6f34ac832eafbe23aece1aa98c