### PR TITLE
Adjust editor container height for Etapas screen

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -221,7 +221,7 @@ body > .container {
   display: block;
   /* Ajustado para evitar que o editor invada o layout do formulário */
   min-height: 100px;
-  max-height: 320px;
+  max-height: 100px;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- limit description editor container height to 100px to keep "Adicionar Etapa" button visible

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a545b5440832eb56c46b3893d96d4