### PR TITLE
Reestrutura status de OS e fluxo de criação

### DIFF
--- a/core/enums.py
+++ b/core/enums.py
@@ -73,11 +73,15 @@ class OSStatus(Enum):
         return obj
 
     RASCUNHO = ("rascunho", "Rascunho")
-    AGUARDANDO = ("aguardando", "Aguardando")
+    AGUARDANDO_ATENDIMENTO = ("aguardando_atendimento", "Aguardando Atendimento")
     EM_ATENDIMENTO = ("em_atendimento", "Em Atendimento")
-    PENDENTE = ("pendente", "Pendente")
+    AGUARDANDO_INFORMACOES_SOLICITANTE = ("aguardando_info_solicitante", "Aguardando Informações do Solicitante")
+    AGUARDANDO_INTERACAO_TERCEIRO = ("aguardando_terceiro", "Aguardando Interação com Terceiro")
+    ENCAMINHADA_PARA_OUTRA_EQUIPE = ("encaminhada_outra_equipe", "Encaminhada para Outra Equipe")
+    PAUSADA = ("pausada", "Pausada")
     CONCLUIDA = ("concluida", "Concluída")
     CANCELADA = ("cancelada", "Cancelada")
+    REJEITADA = ("rejeitada", "Rejeitada")
 
 
 class OSPrioridade(Enum):

--- a/core/models.py
+++ b/core/models.py
@@ -567,7 +567,7 @@ class OrdemServico(db.Model):
         return f"<OrdemServico {self.titulo} ({self.status})>"
 
     def pode_mudar_para_aguardando(self) -> bool:
-        """Valida se a OS pode sair de rascunho para aguardando."""
+        """Valida se a OS pode sair de rascunho para aguardando atendimento."""
         if self.tipo_os and self.tipo_os.obrigatorio_preenchimento:
             return self.formulario_respostas_id is not None
         return True

--- a/templates/admin/ordens_servico.html
+++ b/templates/admin/ordens_servico.html
@@ -68,7 +68,7 @@
         {% for os in ordens %}
         <tr>
           <td>{{ os.titulo }}</td>
-          <td>{{ os.status }}</td>
+          <td>{{ status_choices(os.status).label }}</td>
           <td>
             <a class="btn btn-sm btn-outline-primary" href="{{ url_for('ordens_servico_bp.admin_ordens_servico', edit_id=os.id) }}">Editar</a>
             <form action="{{ url_for('ordens_servico_bp.admin_delete_ordem', ordem_id=os.id) }}" method="POST" style="display:inline;">

--- a/templates/ordens_servico/atendimento_detalhe.html
+++ b/templates/ordens_servico/atendimento_detalhe.html
@@ -7,7 +7,7 @@
       <h3>{{ ordem.titulo }}</h3>
       <p class="text-muted mb-1">Tipo: {{ ordem.tipo_os.nome if ordem.tipo_os else '' }}</p>
       <p class="text-muted mb-1">Prioridade: {{ ordem.prioridade or 'N/A' }}</p>
-      <p class="text-muted">Status atual: {{ ordem.status }}</p>
+      <p class="text-muted">Status atual: {{ status_choices(ordem.status).label }}</p>
       <p>{{ ordem.descricao }}</p>
     </div>
   </div>
@@ -15,7 +15,7 @@
     <form method="post" action="{{ url_for('ordens_servico_bp.os_mudar_status', ordem_id=ordem.id) }}" class="d-flex">
       <select class="form-select form-select-sm" name="status">
         {% for st in status_choices %}
-          <option value="{{ st.value }}" {% if ordem.status==st.value %}selected{% endif %}>{{ st.name }}</option>
+          <option value="{{ st.value }}" {% if ordem.status==st.value %}selected{% endif %}>{{ st.label }}</option>
         {% endfor %}
       </select>
       <button class="btn btn-sm btn-primary ms-2">Alterar</button>

--- a/templates/ordens_servico/atendimento_list.html
+++ b/templates/ordens_servico/atendimento_list.html
@@ -8,7 +8,7 @@
       <select class="form-select form-select-sm" name="status">
         <option value="">Todos os Status</option>
         {% for st in status_choices %}
-          <option value="{{ st.value }}" {% if request.args.get('status') == st.value %}selected{% endif %}>{{ st.name }}</option>
+          <option value="{{ st.value }}" {% if request.args.get('status') == st.value %}selected{% endif %}>{{ st.label }}</option>
         {% endfor %}
       </select>
     </div>
@@ -49,7 +49,7 @@
           <td>{{ os.titulo }}</td>
           <td>{{ os.tipo_os.nome if os.tipo_os else '' }}</td>
           <td>{{ os.prioridade or '' }}</td>
-          <td>{{ os.status }}</td>
+          <td>{{ status_choices(os.status).label }}</td>
           <td>{{ os.criado_por.nome_completo or os.criado_por.username }}</td>
           <td>{{ os.data_criacao.strftime('%d/%m/%Y') if os.data_criacao else '' }}</td>
           <td class="text-end">
@@ -61,8 +61,8 @@
             </form>
             {% else %}
             <form method="post" action="{{ url_for('ordens_servico_bp.os_mudar_status', ordem_id=os.id) }}" style="display:inline-block">
-              <input type="hidden" name="status" value="pendente">
-              <button class="btn btn-sm btn-outline-warning" title="Mover para pendente"><i class="bi bi-hourglass-split"></i></button>
+              <input type="hidden" name="status" value="aguardando_info_solicitante">
+              <button class="btn btn-sm btn-outline-warning" title="Aguardar informações do solicitante"><i class="bi bi-hourglass-split"></i></button>
             </form>
             <form method="post" action="{{ url_for('ordens_servico_bp.os_mudar_status', ordem_id=os.id) }}" style="display:inline-block">
               <input type="hidden" name="status" value="concluida">

--- a/templates/ordens_servico/detalhe_os.html
+++ b/templates/ordens_servico/detalhe_os.html
@@ -7,7 +7,7 @@
       <div class="card shadow-sm">
         <div class="card-body">
           <h3>{{ ordem.titulo }}</h3>
-          <p class="text-muted">Status: {{ ordem.status }}</p>
+          <p class="text-muted">Status: {{ status_enum(ordem.status).label }}</p>
           {% if ordem.processo %}
           <p class="text-muted">Processo: {{ ordem.processo.nome }}</p>
           {% endif %}

--- a/templates/ordens_servico/listar_os.html
+++ b/templates/ordens_servico/listar_os.html
@@ -19,7 +19,7 @@
           {% for os in ordens %}
             <tr>
               <td>{{ os.titulo }}</td>
-              <td>{{ os.status }}</td>
+              <td>{{ status_enum(os.status).label }}</td>
               <td class="text-end">
                 <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.id) }}" class="btn btn-sm btn-outline-primary">Detalhes</a>
               </td>

--- a/templates/ordens_servico/minhas_os.html
+++ b/templates/ordens_servico/minhas_os.html
@@ -5,16 +5,28 @@
   <div class="card shadow-sm">
     <div class="card-body">
       <h3>Minhas Ordens de Serviço</h3>
+      {% if rascunhos %}
+      <h5 class="mt-3">Rascunhos</h5>
+      <div class="list-group mb-3">
+        {% for os in rascunhos %}
+        <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.id) }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+          <span>{{ os.titulo }}</span>
+          <span class="badge bg-warning text-dark">Rascunho</span>
+        </a>
+        {% endfor %}
+      </div>
+      {% endif %}
       {% if ordens %}
+      <h5 class="mt-3">Em andamento</h5>
       <div class="list-group">
         {% for os in ordens %}
         <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.id) }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
           <span>{{ os.titulo }}</span>
-          <span class="badge bg-secondary">{{ os.status }}</span>
+          <span class="badge bg-secondary">{{ status_enum(os.status).label }}</span>
         </a>
         {% endfor %}
       </div>
-      {% else %}
+      {% elif not rascunhos %}
       <p class="text-muted">Nenhuma Ordem de Serviço encontrada.</p>
       {% endif %}
     </div>

--- a/templates/ordens_servico/nova_os.html
+++ b/templates/ordens_servico/nova_os.html
@@ -43,7 +43,10 @@
               <textarea class="form-control" id="observacoes" name="observacoes" rows="3"></textarea>
             </div>
             <div class="mb-3" id="formulario-vinculado"></div>
-            <button type="submit" class="btn btn-primary">Salvar</button>
+            <div class="d-flex gap-2">
+              <button type="submit" name="action" value="rascunho" class="btn btn-secondary">Salvar Rascunho</button>
+              <button type="submit" name="action" value="enviar" class="btn btn-primary">Enviar</button>
+            </div>
           </form>
         </div>
       </div>

--- a/tests/test_ordem_servico.py
+++ b/tests/test_ordem_servico.py
@@ -112,7 +112,7 @@ def test_os_mudar_status_bloqueia_quando_form_obrigatorio(client):
         os_id = os_obj.id
     resp = client.post(
         f'/os/{os_id}/status',
-        data={'status': 'aguardando'},
+        data={'status': 'aguardando_atendimento'},
         follow_redirects=True,
     )
     assert resp.status_code == 200


### PR DESCRIPTION
## Resumo
- Expande enum `OSStatus` com novos estados de atendimento e remove `pendente`
- Ajusta criação de OS com botões **Salvar Rascunho** e **Enviar**, atualizando permissões e listagens
- Exibe rascunhos somente ao solicitante e melhora apresentação dos status

## Testes
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a59e20afc832ea96770ec9893a76e