### PR TITLE
Align description and instructions fields in Etapas form

### DIFF
--- a/templates/admin/etapas.html
+++ b/templates/admin/etapas.html
@@ -94,17 +94,17 @@
                             </div>
                         </div>
                         <div class="row mb-3">
-                            <div class="col-md-6">
+                            <div class="col-md-6 d-flex flex-column">
                                 <label for="descricao" class="form-label">Descrição</label>
-                                <textarea class="form-control form-control-sm" id="descricao" name="descricao">{{ request.form.get('descricao', '') }}</textarea>
+                                <textarea class="form-control form-control-sm flex-grow-1" id="descricao" name="descricao">{{ request.form.get('descricao', '') }}</textarea>
                             </div>
-                            <div class="col-md-6">
+                            <div class="col-md-6 d-flex flex-column">
                                 <label for="instrucoes" class="form-label">Instruções</label>
-                                <textarea class="form-control form-control-sm" id="instrucoes" name="instrucoes">{{ request.form.get('instrucoes', '') }}</textarea>
+                                <textarea class="form-control form-control-sm flex-grow-1" id="instrucoes" name="instrucoes">{{ request.form.get('instrucoes', '') }}</textarea>
+                                <div class="text-end border-top pt-2 mt-3">
+                                    <button type="submit" class="btn btn-primary"><i class="bi bi-check-lg me-1"></i> Adicionar Etapa</button>
+                                </div>
                             </div>
-                        </div>
-                        <div class="text-end border-top pt-2 mt-3">
-                            <button type="submit" class="btn btn-primary"><i class="bi bi-check-lg me-1"></i> Adicionar Etapa</button>
                         </div>
                     </form>
                 </div>
@@ -153,18 +153,18 @@
                             </div>
                         </div>
                         <div class="row mb-3">
-                            <div class="col-md-6">
+                            <div class="col-md-6 d-flex flex-column">
                                 <label for="edit_descricao" class="form-label">Descrição</label>
-                                <textarea class="form-control form-control-sm" id="edit_descricao" name="descricao">{{ request.form.get('descricao', etapa_editar.descricao) }}</textarea>
+                                <textarea class="form-control form-control-sm flex-grow-1" id="edit_descricao" name="descricao">{{ request.form.get('descricao', etapa_editar.descricao) }}</textarea>
                             </div>
-                            <div class="col-md-6">
+                            <div class="col-md-6 d-flex flex-column">
                                 <label for="edit_instrucoes" class="form-label">Instruções</label>
-                                <textarea class="form-control form-control-sm" id="edit_instrucoes" name="instrucoes">{{ request.form.get('instrucoes', etapa_editar.instrucoes) }}</textarea>
+                                <textarea class="form-control form-control-sm flex-grow-1" id="edit_instrucoes" name="instrucoes">{{ request.form.get('instrucoes', etapa_editar.instrucoes) }}</textarea>
+                                <div class="text-end border-top pt-2 mt-3">
+                                    <button type="submit" class="btn btn-primary"><i class="bi bi-check-lg me-1"></i> Salvar Alterações</button>
+                                    <button type="button" class="btn btn-outline-secondary ms-2" data-bs-dismiss="modal"><i class="bi bi-x-lg me-1"></i> Cancelar</button>
+                                </div>
                             </div>
-                        </div>
-                        <div class="text-end border-top pt-2 mt-3">
-                            <button type="submit" class="btn btn-primary"><i class="bi bi-check-lg me-1"></i> Salvar Alterações</button>
-                            <button type="button" class="btn btn-outline-secondary ms-2" data-bs-dismiss="modal"><i class="bi bi-x-lg me-1"></i> Cancelar</button>
                         </div>
                     </form>
                 </div>


### PR DESCRIPTION
## Summary
- Place "Adicionar Etapa" button beside instructions text area in Cadastro tab
- Align edit modal buttons with instructions field
- Stretch description field to match instructions height for balanced layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a5dbaf04c832e8babd3b6d2dd4f2a