### PR TITLE
Add basic Kanban views for service orders

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -336,11 +336,13 @@
                                 <li class="nav-item"><a class="nav-link {{ 'active' if 'os_nova' in request.endpoint else '' }}" href="{{ url_for('ordens_servico_bp.os_nova') }}"><i class="bi bi-plus-circle-dotted me-2"></i> Abrir Nova OS</a></li>
                                 <li class="nav-item"><a class="nav-link {{ 'active' if 'os_listar' in request.endpoint else '' }}" href="{{ url_for('ordens_servico_bp.os_listar') }}"><i class="bi bi-binoculars-fill me-2"></i> Consultar OS</a></li>
                                 <li class="nav-item"><a class="nav-link {{ 'active' if 'os_minhas' in request.endpoint else '' }}" href="{{ url_for('ordens_servico_bp.os_minhas') }}"><i class="bi bi-person-lines-fill me-2"></i> Minhas OS</a></li>
+                                <li class="nav-item"><a class="nav-link {{ 'active' if 'os_kanban' in request.endpoint else '' }}" href="{{ url_for('ordens_servico_bp.os_kanban') }}"><i class="bi bi-kanban me-2"></i> Acompanhar OS (Kanban)</a></li>
                                 {% if current_user.is_authenticated and current_user.has_permissao('admin') %}
                                 <li class="nav-item"><a class="nav-link {{ 'active' if 'admin_tipos_os' in request.endpoint else '' }}" href="{{ url_for('ordens_servico_bp.admin_tipos_os') }}"><i class="bi bi-card-text me-2"></i> Tipos de OS</a></li>
                                 {% endif %}
                                 {% if current_user and current_user.pode_atender_os %}
                                 <li class="nav-item"><a class="nav-link {{ 'active' if 'os_atendimento' in request.endpoint else '' }}" href="{{ url_for('ordens_servico_bp.os_atendimento') }}"><i class="bi bi-headset me-2"></i> Atendimento de OS</a></li>
+                                <li class="nav-item"><a class="nav-link {{ 'active' if 'os_kanban_atendimento' in request.endpoint else '' }}" href="{{ url_for('ordens_servico_bp.os_kanban_atendimento') }}"><i class="bi bi-kanban me-2"></i> Kanban de OS (Atendimento)</a></li>
                                 {% endif %}
                                 {% if user_can_access_form_builder(current_user) %}
                                 <li class="nav-item"><a class="nav-link {{ 'active' if 'formularios' in request.endpoint else '' }}" href="{{ url_for('formularios_bp.formularios') }}"><i class="bi bi-ui-checks-grid me-2"></i> Criador de Formulários</a></li>

--- a/templates/ordens_servico/kanban.html
+++ b/templates/ordens_servico/kanban.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block title %}{{ title }}{% endblock %}
+{% block content %}
+<div class="container-fluid px-5 mt-3">
+  <h3>{{ title }}</h3>
+  <div class="row">
+    {% for key in order %}
+      {% if show_draft or key != 'rascunho' %}
+      <div class="col-md-2">
+        <h5>{{ labels[key] }}</h5>
+        {% if columns[key] %}
+          {% for os in columns[key] %}
+          <div class="card mb-2">
+            <div class="card-body p-2">
+              <div class="fw-bold">{{ os.titulo }}</div>
+              <small>ID {{ os.id }}{% if os.prioridade %} - {{ os.prioridade }}{% endif %}</small>
+            </div>
+          </div>
+          {% endfor %}
+        {% else %}
+          <p class="text-muted small">Sem OS</p>
+        {% endif %}
+      </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement Kanban board views for requesters and attendants
- add sidebar links to access the new Kanban boards
- create shared template for Kanban columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a60657268832ea4e8272ead3c1146