### PR TITLE
Expand status length for ordens de serviço

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -547,7 +547,12 @@ class OrdemServico(db.Model):
     titulo = db.Column(db.String(255), nullable=False)
     descricao = db.Column(db.Text, nullable=False)
     tipo_os_id = db.Column(db.Integer, db.ForeignKey('tipo_os.id'), nullable=False)
-    status = db.Column(db.String(20), nullable=False, default=OSStatus.RASCUNHO.value, server_default=OSStatus.RASCUNHO.value)
+    status = db.Column(
+        db.String(50),
+        nullable=False,
+        default=OSStatus.RASCUNHO.value,
+        server_default=OSStatus.RASCUNHO.value,
+    )
     criado_por_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     atribuido_para_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
     equipe_responsavel_id = db.Column(db.Integer, nullable=True)
@@ -581,8 +586,8 @@ class OrdemServicoLog(db.Model):
     data_hora = db.Column(db.DateTime(timezone=True), server_default=func.now(), nullable=False)
     usuario_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     acao = db.Column(db.String(255), nullable=False)
-    origem_status = db.Column(db.String(20), nullable=True)
-    destino_status = db.Column(db.String(20), nullable=True)
+    origem_status = db.Column(db.String(50), nullable=True)
+    destino_status = db.Column(db.String(50), nullable=True)
     observacao = db.Column(db.Text, nullable=True)
 
     os = db.relationship('OrdemServico')

--- a/migrations/versions/abcdef123456_increase_status_length.py
+++ b/migrations/versions/abcdef123456_increase_status_length.py
@@ -1,0 +1,26 @@
+"""increase status column lengths"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'abcdef123456'
+down_revision = 'f1b2c3d4e5f6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('ordem_servico') as batch_op:
+        batch_op.alter_column('status', existing_type=sa.String(length=20), type_=sa.String(length=50))
+    with op.batch_alter_table('ordem_servico_log') as batch_op:
+        batch_op.alter_column('origem_status', existing_type=sa.String(length=20), type_=sa.String(length=50))
+        batch_op.alter_column('destino_status', existing_type=sa.String(length=20), type_=sa.String(length=50))
+
+
+def downgrade():
+    with op.batch_alter_table('ordem_servico') as batch_op:
+        batch_op.alter_column('status', existing_type=sa.String(length=50), type_=sa.String(length=20))
+    with op.batch_alter_table('ordem_servico_log') as batch_op:
+        batch_op.alter_column('origem_status', existing_type=sa.String(length=50), type_=sa.String(length=20))
+        batch_op.alter_column('destino_status', existing_type=sa.String(length=50), type_=sa.String(length=20))


### PR DESCRIPTION
## Summary
- allow status fields to store longer values
- include migration adjusting `ordem_servico` and log tables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b29d912b8832e9ce247a2998031a0