### PR TITLE
Add codigo field to Instituicao model

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -124,29 +124,36 @@ def admin_instituicoes():
 
     if request.method == 'POST':
         id_para_atualizar = request.form.get('id_para_atualizar')
+        codigo = request.form.get('codigo', '').strip().upper()
         nome = request.form.get('nome', '').strip()
         descricao = request.form.get('descricao', '').strip()
         ativo = request.form.get('ativo_check') == 'on'
 
-        if not nome:
-            flash('Nome da instituição é obrigatório.', 'danger')
+        if not codigo or not nome:
+            flash('Código e nome da instituição são obrigatórios.', 'danger')
         else:
+            query_codigo_existente = Instituicao.query.filter_by(codigo=codigo)
             query_nome_existente = Instituicao.query.filter_by(nome=nome)
             if id_para_atualizar:
+                query_codigo_existente = query_codigo_existente.filter(Instituicao.id != int(id_para_atualizar))
                 query_nome_existente = query_nome_existente.filter(Instituicao.id != int(id_para_atualizar))
+            codigo_ja_existe = query_codigo_existente.first()
             nome_ja_existe = query_nome_existente.first()
 
-            if nome_ja_existe:
+            if codigo_ja_existe:
+                flash(f'O código "{codigo}" já está em uso.', 'danger')
+            elif nome_ja_existe:
                 flash(f'O nome "{nome}" já está em uso.', 'danger')
             else:
                 if id_para_atualizar:
                     inst = Instituicao.query.get_or_404(id_para_atualizar)
+                    inst.codigo = codigo
                     inst.nome = nome
                     inst.descricao = descricao
                     inst.ativo = ativo
                     action_msg = 'atualizada'
                 else:
-                    inst = Instituicao(nome=nome, descricao=descricao, ativo=ativo)
+                    inst = Instituicao(codigo=codigo, nome=nome, descricao=descricao, ativo=ativo)
                     db.session.add(inst)
                     action_msg = 'criada'
 

--- a/core/models.py
+++ b/core/models.py
@@ -108,6 +108,7 @@ class Instituicao(db.Model):
     __tablename__ = 'instituicao'
 
     id = db.Column(db.Integer, primary_key=True)
+    codigo = db.Column(db.String(7), unique=True, nullable=False)
     nome = db.Column(db.String(200), unique=True, nullable=False)
     descricao = db.Column(db.Text, nullable=True)
     ativo = db.Column(db.Boolean, nullable=False, default=True, server_default='true')

--- a/migrations/versions/e8b4b622ad3f_add_codigo_to_instituicao.py
+++ b/migrations/versions/e8b4b622ad3f_add_codigo_to_instituicao.py
@@ -1,0 +1,26 @@
+"""add codigo to instituicao
+
+Revision ID: e8b4b622ad3f
+Revises: abcdef123456
+Create Date: 2025-08-05 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'e8b4b622ad3f'
+down_revision = 'abcdef123456'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    with op.batch_alter_table('instituicao', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('codigo', sa.String(length=7), nullable=False))
+        batch_op.create_unique_constraint(None, ['codigo'])
+
+
+def downgrade():
+    with op.batch_alter_table('instituicao', schema=None) as batch_op:
+        batch_op.drop_constraint(None, type_='unique')
+        batch_op.drop_column('codigo')

--- a/seeds/seed_demonstration.py
+++ b/seeds/seed_demonstration.py
@@ -104,8 +104,8 @@ def run():
     with app.app_context():
         print("Populando dados de exemplo...")
 
-        inst1 = get_or_create(Instituicao, nome="Instituição 1", descricao="Inst 1")
-        inst2 = get_or_create(Instituicao, nome="Instituição 2", descricao="Inst 2")
+        inst1 = get_or_create(Instituicao, codigo="INST001", nome="Instituição 1", descricao="Inst 1")
+        inst2 = get_or_create(Instituicao, codigo="INST002", nome="Instituição 2", descricao="Inst 2")
 
         est1 = get_or_create(Estabelecimento, codigo="EST1", nome_fantasia="Estabelecimento 1", instituicao=inst1)
         est2 = get_or_create(Estabelecimento, codigo="EST2", nome_fantasia="Estabelecimento 2", instituicao=inst2)

--- a/seeds/seed_organizacao.py
+++ b/seeds/seed_organizacao.py
@@ -15,7 +15,7 @@ def run():
 
         inst = Instituicao.query.filter_by(nome="Instituição Exemplo").first()
         if not inst:
-            inst = Instituicao(nome="Instituição Exemplo", descricao="Instituição para testes")
+            inst = Instituicao(codigo="INST001", nome="Instituição Exemplo", descricao="Instituição para testes")
             db.session.add(inst)
             print("Instituição criada.")
         else:

--- a/templates/admin/instituicoes.html
+++ b/templates/admin/instituicoes.html
@@ -31,6 +31,7 @@
                                     <table class="table table-hover table-sm align-middle">
                                         <thead>
                                             <tr>
+                                                <th>Código</th>
                                                 <th>Nome</th>
                                                 <th>Status</th>
                                                 <th style="width: 200px;" class="text-end">Ações</th>
@@ -39,6 +40,7 @@
                                         <tbody>
                                             {% for inst in instituicoes %}
                                             <tr class="{{ 'table-light text-muted' if not inst.ativo else '' }} clickable-row" data-href="{{ url_for('admin_instituicoes', edit_id=inst.id) }}">
+                                                <td>{{ inst.codigo }}</td>
                                                 <td>{{ inst.nome }}</td>
                                                 <td>
                                                     {% if inst.ativo %}
@@ -83,7 +85,11 @@
 
                     <form method="POST" action="{{ url_for('admin_instituicoes') }}" novalidate class="compact-form">
                         <div class="row">
-                            <div class="col-md-8 mb-1">
+                            <div class="col-md-4 mb-1">
+                                <label for="codigo" class="form-label">Código <span class="text-danger">*</span></label>
+                                <input type="text" class="form-control form-control-sm" id="codigo" name="codigo" value="{{ request.form.get('codigo', '') }}" required maxlength="7">
+                            </div>
+                            <div class="col-md-4 mb-1">
                                 <label for="nome" class="form-label">Nome <span class="text-danger">*</span></label>
                                 <input type="text" class="form-control form-control-sm" id="nome" name="nome" value="{{ request.form.get('nome', '') }}" required maxlength="200">
                             </div>
@@ -120,6 +126,10 @@
             <div class="modal-body">
                 <form method="POST" action="{{ url_for('admin_instituicoes') }}" novalidate class="compact-form">
                     <input type="hidden" name="id_para_atualizar" value="{{ inst_editar.id }}">
+                    <div class="mb-1">
+                        <label for="edit_codigo" class="form-label">Código <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control form-control-sm" id="edit_codigo" name="codigo" value="{{ request.form.get('codigo', inst_editar.codigo) }}" required maxlength="7">
+                    </div>
                     <div class="mb-1">
                         <label for="edit_nome" class="form-label">Nome <span class="text-danger">*</span></label>
                         <input type="text" class="form-control form-control-sm" id="edit_nome" name="nome" value="{{ request.form.get('nome', inst_editar.nome) }}" required maxlength="200">

--- a/tests/test_admin_dashboard.py
+++ b/tests/test_admin_dashboard.py
@@ -7,7 +7,7 @@ from core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, Use
 @pytest.fixture
 def client(app_ctx):
     with app.app_context():
-        inst = Instituicao(nome='Inst')
+        inst = Instituicao(codigo='INST001', nome='Inst')
         db.session.add(inst)
         db.session.flush()
         est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao_id=inst.id)

--- a/tests/test_admin_usuarios.py
+++ b/tests/test_admin_usuarios.py
@@ -7,7 +7,7 @@ from core.utils import DEFAULT_NEW_USER_PASSWORD
 @pytest.fixture
 def client(app_ctx):
     with app.app_context():
-        inst = Instituicao(nome='Inst')
+        inst = Instituicao(codigo='INST001', nome='Inst')
         db.session.add(inst)
         db.session.flush()
         est = Estabelecimento(codigo='E1', nome_fantasia='Estab', instituicao_id=inst.id)

--- a/tests/test_article_approval_review.py
+++ b/tests/test_article_approval_review.py
@@ -23,7 +23,7 @@ def base_setup(app_ctx):
     
     with app.app_context():
         
-        inst = Instituicao(nome='Inst')
+        inst = Instituicao(codigo='INST001', nome='Inst')
         est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao=inst)
         setor1 = Setor(nome='S1', estabelecimento=est)
         setor2 = Setor(nome='S2', estabelecimento=est)

--- a/tests/test_article_editing.py
+++ b/tests/test_article_editing.py
@@ -20,7 +20,7 @@ def base_setup(app_ctx):
     
     with app.app_context():
         
-        inst = Instituicao(nome='Inst')
+        inst = Instituicao(codigo='INST001', nome='Inst')
         est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao=inst)
         setor1 = Setor(nome='S1', estabelecimento=est)
         setor2 = Setor(nome='S2', estabelecimento=est)

--- a/tests/test_article_permissions.py
+++ b/tests/test_article_permissions.py
@@ -10,7 +10,7 @@ def client(app_ctx):
     
     with app.app_context():
         
-        inst = Instituicao(nome='Inst')
+        inst = Instituicao(codigo='INST001', nome='Inst')
         db.session.add(inst)
         db.session.flush()
         est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao_id=inst.id)

--- a/tests/test_article_visibility.py
+++ b/tests/test_article_visibility.py
@@ -9,7 +9,7 @@ def client(app_ctx):
     
     with app.app_context():
         
-        inst = Instituicao(nome='Inst 1')
+        inst = Instituicao(codigo='INST001', nome='Inst 1')
         est = Estabelecimento(codigo='EST1', nome_fantasia='Est', instituicao=inst)
         setor = Setor(nome='Setor 1', estabelecimento=est)
         cel = Celula(nome='Celula 1', estabelecimento=est, setor=setor)
@@ -251,7 +251,7 @@ def test_user_cannot_view_wrong_instituicao(client):
     with app.app_context():
         user1 = User.query.first()
         inst1 = user1.celula.estabelecimento.instituicao
-        inst2 = Instituicao(nome='Inst 2')
+        inst2 = Instituicao(codigo='INST002', nome='Inst 2')
         db.session.add(inst2)
         est2 = Estabelecimento(codigo='E4', nome_fantasia='Est 4', instituicao=inst2)
         db.session.add(est2)

--- a/tests/test_cargo.py
+++ b/tests/test_cargo.py
@@ -9,7 +9,7 @@ def client(app_ctx):
 
     with app.app_context():
         
-        inst = Instituicao(nome='Inst')
+        inst = Instituicao(codigo='INST001', nome='Inst')
         db.session.add(inst)
         db.session.flush()
         est = Estabelecimento(codigo='E1', nome_fantasia='Estab', instituicao_id=inst.id)

--- a/tests/test_celula.py
+++ b/tests/test_celula.py
@@ -9,7 +9,7 @@ def client(app_ctx):
     
     with app.app_context():
         
-        inst = Instituicao(nome='Inst')
+        inst = Instituicao(codigo='INST001', nome='Inst')
         db.session.add(inst)
         db.session.flush()
         est = Estabelecimento(codigo='E1', nome_fantasia='Estab', instituicao_id=inst.id)

--- a/tests/test_estabelecimento.py
+++ b/tests/test_estabelecimento.py
@@ -10,7 +10,7 @@ def client(app_ctx):
     
     with app.app_context():
         
-        inst = Instituicao(nome='Inst 1')
+        inst = Instituicao(codigo='INST001', nome='Inst 1')
         db.session.add(inst)
         db.session.commit()
         with app_ctx.test_client() as client:

--- a/tests/test_form_builder.py
+++ b/tests/test_form_builder.py
@@ -4,7 +4,7 @@ from core.models import Cargo, Instituicao, Estabelecimento, Setor, Celula, User
 from core.utils import user_can_access_form_builder
 
 def setup_org(prefix):
-    inst = Instituicao(nome=f'Inst_{prefix}')
+    inst = Instituicao(codigo=f'I{str(prefix)[:6]}', nome=f'Inst_{prefix}')
     db.session.add(inst)
     db.session.flush()
     est = Estabelecimento(codigo=f'E_{prefix}', nome_fantasia='Est', instituicao_id=inst.id)

--- a/tests/test_instituicao.py
+++ b/tests/test_instituicao.py
@@ -11,7 +11,7 @@ def client(app_ctx):
 
 def login_admin(client):
     with app.app_context():
-        inst = Instituicao.query.first() or Instituicao(nome='Base')
+        inst = Instituicao.query.first() or Instituicao(codigo='BASE001', nome='Base')
         if inst.id is None:
             db.session.add(inst)
             db.session.commit()
@@ -33,6 +33,7 @@ def login_admin(client):
 def test_create_instituicao(client):
     login_admin(client)
     response = client.post('/admin/instituicoes', data={
+        'codigo': 'INST001',
         'nome': 'Inst 1',
         'descricao': 'Descricao',
         'ativo_check': 'on'
@@ -47,13 +48,14 @@ def test_create_instituicao(client):
 
 def test_update_instituicao(client):
     with app.app_context():
-        inst = Instituicao(nome='Inst A', descricao='Old')
+        inst = Instituicao(codigo='INSTA', nome='Inst A', descricao='Old')
         db.session.add(inst)
         db.session.commit()
         inst_id = inst.id
     login_admin(client)
     response = client.post('/admin/instituicoes', data={
         'id_para_atualizar': inst_id,
+        'codigo': 'INSTB',
         'nome': 'Inst B',
         'descricao': 'Nova',
         'ativo_check': 'on'
@@ -68,7 +70,7 @@ def test_update_instituicao(client):
 
 def test_toggle_instituicao_active(client):
     with app.app_context():
-        inst = Instituicao(nome='Ativa')
+        inst = Instituicao(codigo='ATV001', nome='Ativa')
         db.session.add(inst)
         db.session.commit()
         inst_id = inst.id

--- a/tests/test_notification_filtering.py
+++ b/tests/test_notification_filtering.py
@@ -32,7 +32,7 @@ def client_with_users(app_ctx):
     
     with app.app_context():
         
-        inst = Instituicao(nome='Inst')
+        inst = Instituicao(codigo='INST001', nome='Inst')
         est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao=inst)
         setor = Setor(nome='S1', estabelecimento=est)
         cel1 = Celula(nome='C1', estabelecimento=est, setor=setor)

--- a/tests/test_notification_pagination.py
+++ b/tests/test_notification_pagination.py
@@ -5,7 +5,7 @@ from core.models import Notification, User, Instituicao, Estabelecimento, Setor,
 @pytest.fixture
 def client_with_notifications(app_ctx):
     with app.app_context():
-        inst = Instituicao(nome='Inst')
+        inst = Instituicao(codigo='INST001', nome='Inst')
         est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao=inst)
         setor = Setor(nome='S1', estabelecimento=est)
         cel = Celula(nome='C1', estabelecimento=est, setor=setor)

--- a/tests/test_notification_read.py
+++ b/tests/test_notification_read.py
@@ -5,7 +5,7 @@ from core.models import Notification, User, Instituicao, Estabelecimento, Setor,
 @pytest.fixture
 def client_with_notification(app_ctx):
     with app.app_context():
-        inst = Instituicao(nome='Inst')
+        inst = Instituicao(codigo='INST001', nome='Inst')
         est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao=inst)
         setor = Setor(nome='S1', estabelecimento=est)
         cel = Celula(nome='C1', estabelecimento=est, setor=setor)

--- a/tests/test_ordem_servico.py
+++ b/tests/test_ordem_servico.py
@@ -24,7 +24,7 @@ def client(app_ctx):
 
 def login_admin(client):
     with app.app_context():
-        inst = Instituicao(nome='Inst')
+        inst = Instituicao(codigo='INST001', nome='Inst')
         est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao=inst)
         setor = Setor(nome='S1', estabelecimento=est)
         cel = Celula(nome='C1', estabelecimento=est, setor=setor)

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -10,7 +10,7 @@ def client(app_ctx):
     
     with app.app_context():
         
-        inst = Instituicao(nome='Inst')
+        inst = Instituicao(codigo='INST001', nome='Inst')
         est = Estabelecimento(codigo='E1', nome_fantasia='Estab', instituicao=inst)
         setor = Setor(nome='Setor1', estabelecimento=est)
         cel = Celula(nome='Cel1', estabelecimento=est, setor=setor)

--- a/tests/test_processos.py
+++ b/tests/test_processos.py
@@ -5,7 +5,7 @@ from core.models import Processo, EtapaProcesso, CampoEtapa, RespostaEtapaOS, Us
 @pytest.fixture
 def base_app(app_ctx):
     with app.app_context():
-        inst = Instituicao(nome='Inst')
+        inst = Instituicao(codigo='INST001', nome='Inst')
         est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao=inst)
         setor = Setor(nome='S1', estabelecimento=est)
         cel = Celula(nome='C1', estabelecimento=est, setor=setor)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -6,7 +6,7 @@ from core.models import Instituicao, Estabelecimento, Setor, Celula, User, Artic
 @pytest.fixture
 def client(app_ctx):
     with app.app_context():
-        inst = Instituicao(nome='Inst')
+        inst = Instituicao(codigo='INST001', nome='Inst')
         est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao=inst)
         setor = Setor(nome='S', estabelecimento=est)
         cel = Celula(nome='C', estabelecimento=est, setor=setor)

--- a/tests/test_setor.py
+++ b/tests/test_setor.py
@@ -9,7 +9,7 @@ def client(app_ctx):
     
     with app.app_context():
         
-        inst = Instituicao(nome='Inst')
+        inst = Instituicao(codigo='INST001', nome='Inst')
         db.session.add(inst)
         db.session.flush()
         est = Estabelecimento(codigo='EST1', nome_fantasia='Estab 1', instituicao_id=inst.id)


### PR DESCRIPTION
## Summary
- add unique `codigo` field to Instituicao model
- handle codigo in admin CRUD views and templates
- create Alembic migration and update tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b2e641304832ea94b3d82b98de6c8