### PR TITLE
Gerar código automático para Ordem de Serviço

### DIFF
--- a/blueprints/ordens_servico.py
+++ b/blueprints/ordens_servico.py
@@ -39,9 +39,9 @@ except ImportError:  # pragma: no cover
     from core.enums import OSStatus, OSPrioridade
 
 try:
-    from ..core.utils import send_email
+    from ..core.utils import send_email, gerar_codigo_os
 except ImportError:  # pragma: no cover
-    from core.utils import send_email
+    from core.utils import send_email, gerar_codigo_os
 
 try:
     from ..core.decorators import admin_required
@@ -103,6 +103,7 @@ def admin_ordens_servico():
                 action_msg = 'atualizada'
             else:
                 ordem = OrdemServico(
+                    codigo=gerar_codigo_os(),
                     titulo=titulo,
                     descricao=descricao,
                     tipo_os_id=tipo_os_id,
@@ -270,6 +271,7 @@ def os_nova():
             flash('Título da Ordem de Serviço é obrigatório.', 'danger')
         else:
             ordem = OrdemServico(
+                codigo=gerar_codigo_os(),
                 titulo=titulo,
                 descricao=descricao,
                 tipo_os_id=tipo_os_id,

--- a/core/models.py
+++ b/core/models.py
@@ -545,6 +545,7 @@ class OrdemServico(db.Model):
     __tablename__ = 'ordem_servico'
 
     id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    codigo = db.Column(db.String(7), unique=True, nullable=False)
     titulo = db.Column(db.String(255), nullable=False)
     descricao = db.Column(db.Text, nullable=False)
     tipo_os_id = db.Column(db.Integer, db.ForeignKey('tipo_os.id'), nullable=False)

--- a/tests/test_ordem_servico.py
+++ b/tests/test_ordem_servico.py
@@ -14,6 +14,7 @@ from core.models import (
     Funcao,
     Formulario,
 )
+from core.utils import gerar_codigo_os
 
 
 @pytest.fixture
@@ -101,6 +102,7 @@ def test_os_mudar_status_bloqueia_quando_form_obrigatorio(client):
         etapa.tipos_os.append(tipo)
         user = User.query.filter_by(username='admin').first()
         os_obj = OrdemServico(
+            codigo=gerar_codigo_os(),
             titulo='OS2',
             descricao='desc',
             tipo_os=tipo,


### PR DESCRIPTION
## Summary
- Adiciona coluna `codigo` ao modelo de Ordem de Serviço
- Gera automaticamente o código sequencial ao criar uma OS, tanto em rotas de usuário quanto administrativas
- Ajusta testes para contemplar o novo campo `codigo`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b32604500832e991472130bce9f2f