### PR TITLE
Atualiza templates de ordens de serviço para usar código

### DIFF
--- a/templates/ordens_servico/atendimento_detalhe.html
+++ b/templates/ordens_servico/atendimento_detalhe.html
@@ -12,7 +12,7 @@
     </div>
   </div>
   <div class="mb-3">
-    <form method="post" action="{{ url_for('ordens_servico_bp.os_mudar_status', ordem_id=ordem.id) }}" class="d-flex">
+    <form method="post" action="{{ url_for('ordens_servico_bp.os_mudar_status', ordem_id=ordem.codigo) }}" class="d-flex">
       <select class="form-select form-select-sm" name="status">
         {% for st in status_choices %}
           <option value="{{ st.value }}" {% if ordem.status==st.value %}selected{% endif %}>{{ st.label }}</option>
@@ -34,7 +34,7 @@
       {% else %}
         <p class="text-muted">Nenhum comentário.</p>
       {% endfor %}
-      <form method="post" action="{{ url_for('ordens_servico_bp.os_comentar', ordem_id=ordem.id) }}" class="mt-3">
+      <form method="post" action="{{ url_for('ordens_servico_bp.os_comentar', ordem_id=ordem.codigo) }}" class="mt-3">
         <div class="input-group">
           <input type="text" class="form-control form-control-sm" name="mensagem" placeholder="Adicionar comentário">
           <button class="btn btn-sm btn-primary">Enviar</button>

--- a/templates/ordens_servico/atendimento_list.html
+++ b/templates/ordens_servico/atendimento_list.html
@@ -32,7 +32,7 @@
     <table class="table table-sm table-hover align-middle">
       <thead>
         <tr>
-          <th>ID</th>
+          <th>Código</th>
           <th>Título</th>
           <th>Tipo</th>
           <th>Prioridade</th>
@@ -45,7 +45,7 @@
       <tbody>
         {% for os in ordens %}
         <tr>
-          <td>{{ os.id }}</td>
+          <td>{{ os.codigo }}</td>
           <td>{{ os.titulo }}</td>
           <td>{{ os.tipo_os.nome if os.tipo_os else '' }}</td>
           <td>{{ os.prioridade or '' }}</td>
@@ -53,22 +53,22 @@
           <td>{{ os.criado_por.nome_completo or os.criado_por.username }}</td>
           <td>{{ os.data_criacao.strftime('%d/%m/%Y') if os.data_criacao else '' }}</td>
           <td class="text-end">
-            <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('ordens_servico_bp.os_atendimento_detalhar', ordem_id=os.id) }}" title="Visualizar"><i class="bi bi-eye"></i></a>
+            <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('ordens_servico_bp.os_atendimento_detalhar', ordem_id=os.codigo) }}" title="Visualizar"><i class="bi bi-eye"></i></a>
             {% if os.status != 'em_atendimento' %}
-            <form method="post" action="{{ url_for('ordens_servico_bp.os_mudar_status', ordem_id=os.id) }}" style="display:inline-block">
+            <form method="post" action="{{ url_for('ordens_servico_bp.os_mudar_status', ordem_id=os.codigo) }}" style="display:inline-block">
               <input type="hidden" name="status" value="em_atendimento">
               <button class="btn btn-sm btn-outline-primary" title="Iniciar atendimento"><i class="bi bi-play-circle"></i></button>
             </form>
             {% else %}
-            <form method="post" action="{{ url_for('ordens_servico_bp.os_mudar_status', ordem_id=os.id) }}" style="display:inline-block">
+            <form method="post" action="{{ url_for('ordens_servico_bp.os_mudar_status', ordem_id=os.codigo) }}" style="display:inline-block">
               <input type="hidden" name="status" value="aguardando_info_solicitante">
               <button class="btn btn-sm btn-outline-warning" title="Aguardar informações do solicitante"><i class="bi bi-hourglass-split"></i></button>
             </form>
-            <form method="post" action="{{ url_for('ordens_servico_bp.os_mudar_status', ordem_id=os.id) }}" style="display:inline-block">
+            <form method="post" action="{{ url_for('ordens_servico_bp.os_mudar_status', ordem_id=os.codigo) }}" style="display:inline-block">
               <input type="hidden" name="status" value="concluida">
               <button class="btn btn-sm btn-outline-success" title="Concluir"><i class="bi bi-check2-circle"></i></button>
             </form>
-            <form method="post" action="{{ url_for('ordens_servico_bp.os_mudar_status', ordem_id=os.id) }}" style="display:inline-block">
+            <form method="post" action="{{ url_for('ordens_servico_bp.os_mudar_status', ordem_id=os.codigo) }}" style="display:inline-block">
               <input type="hidden" name="status" value="cancelada">
               <button class="btn btn-sm btn-outline-danger" title="Cancelar"><i class="bi bi-x-circle"></i></button>
             </form>

--- a/templates/ordens_servico/kanban.html
+++ b/templates/ordens_servico/kanban.html
@@ -13,7 +13,7 @@
           <div class="card mb-2">
             <div class="card-body p-2">
               <div class="fw-bold">{{ os.titulo }}</div>
-              <small>ID {{ os.id }}{% if os.prioridade %} - {{ os.prioridade }}{% endif %}</small>
+              <small>Código {{ os.codigo }}{% if os.prioridade %} - {{ os.prioridade }}{% endif %}</small>
             </div>
           </div>
           {% endfor %}

--- a/templates/ordens_servico/listar_os.html
+++ b/templates/ordens_servico/listar_os.html
@@ -21,7 +21,7 @@
               <td>{{ os.titulo }}</td>
               <td>{{ status_enum(os.status).label }}</td>
               <td class="text-end">
-                <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.id) }}" class="btn btn-sm btn-outline-primary">Detalhes</a>
+                <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.codigo) }}" class="btn btn-sm btn-outline-primary">Detalhes</a>
               </td>
             </tr>
           {% endfor %}

--- a/templates/ordens_servico/minhas_os.html
+++ b/templates/ordens_servico/minhas_os.html
@@ -9,7 +9,7 @@
       <h5 class="mt-3">Rascunhos</h5>
       <div class="list-group mb-3">
         {% for os in rascunhos %}
-        <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.id) }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+        <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.codigo) }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
           <span>{{ os.titulo }}</span>
           <span class="badge bg-warning text-dark">Rascunho</span>
         </a>
@@ -20,7 +20,7 @@
       <h5 class="mt-3">Em andamento</h5>
       <div class="list-group">
         {% for os in ordens %}
-        <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.id) }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+        <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.codigo) }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
           <span>{{ os.titulo }}</span>
           <span class="badge bg-secondary">{{ status_enum(os.status).label }}</span>
         </a>


### PR DESCRIPTION
## Summary
- substitui exibições de `os.id` por `os.codigo`
- ajusta colunas e links de Ordens de Serviço para o novo campo

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b34bbd87c832eb80e6f5558539cc6