### PR TITLE
feat: add equipment and system to OS

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -534,6 +534,37 @@ class CampoEtapa(db.Model):
         return f"<CampoEtapa {self.nome} ({self.tipo})>"
 
 
+# --- Novos modelos para Equipamento e Sistema ---
+
+
+class Equipamento(db.Model):
+    __tablename__ = 'equipamento'
+
+    id = db.Column(db.Integer, primary_key=True)
+    nome = db.Column(db.String(255), nullable=False)
+    patrimonio = db.Column(db.String(100), nullable=True)
+    serial = db.Column(db.String(100), nullable=True)
+    localizacao = db.Column(db.String(255), nullable=True)
+    status = db.Column(db.String(50), nullable=True)
+    observacoes = db.Column(db.Text, nullable=True)
+
+    def __repr__(self):  # pragma: no cover - representação simples
+        return f"<Equipamento {self.nome}>"
+
+
+class Sistema(db.Model):
+    __tablename__ = 'sistema'
+
+    id = db.Column(db.Integer, primary_key=True)
+    nome = db.Column(db.String(255), unique=True, nullable=False)
+    descricao = db.Column(db.Text, nullable=True)
+    responsavel = db.Column(db.String(255), nullable=True)
+    observacoes = db.Column(db.Text, nullable=True)
+
+    def __repr__(self):  # pragma: no cover
+        return f"<Sistema {self.nome}>"
+
+
 ordem_servico_participante = db.Table(
     'ordem_servico_participante',
     db.Column('ordem_servico_id', db.String(36), db.ForeignKey('ordem_servico.id'), primary_key=True),
@@ -562,13 +593,16 @@ class OrdemServico(db.Model):
     data_conclusao = db.Column(db.DateTime(timezone=True), nullable=True)
     formulario_respostas_id = db.Column(db.Integer, nullable=True)
     prioridade = db.Column(db.String(10), nullable=True)
-    origem = db.Column(db.String(255), nullable=True)
+    equipamento_id = db.Column(db.Integer, db.ForeignKey('equipamento.id'), nullable=True)
+    sistema_id = db.Column(db.Integer, db.ForeignKey('sistema.id'), nullable=True)
     observacoes = db.Column(db.Text, nullable=True)
 
     criado_por = db.relationship('User', foreign_keys=[criado_por_id])
     atribuido_para = db.relationship('User', foreign_keys=[atribuido_para_id])
     participantes = db.relationship('User', secondary=ordem_servico_participante, backref='participando_os')
     tipo_os = db.relationship('TipoOS')
+    equipamento = db.relationship('Equipamento')
+    sistema = db.relationship('Sistema')
 
     def __repr__(self):
         return f"<OrdemServico {self.titulo} ({self.status})>"

--- a/migrations/versions/1c2d3e4f5g7h_add_equipamento_sistema.py
+++ b/migrations/versions/1c2d3e4f5g7h_add_equipamento_sistema.py
@@ -1,0 +1,47 @@
+"""add equipamento and sistema tables"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '1c2d3e4f5g7h'
+down_revision = 'e8b4b622ad3f'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'equipamento',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('nome', sa.String(length=255), nullable=False),
+        sa.Column('patrimonio', sa.String(length=100), nullable=True),
+        sa.Column('serial', sa.String(length=100), nullable=True),
+        sa.Column('localizacao', sa.String(length=255), nullable=True),
+        sa.Column('status', sa.String(length=50), nullable=True),
+        sa.Column('observacoes', sa.Text(), nullable=True),
+    )
+    op.create_table(
+        'sistema',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('nome', sa.String(length=255), nullable=False, unique=True),
+        sa.Column('descricao', sa.Text(), nullable=True),
+        sa.Column('responsavel', sa.String(length=255), nullable=True),
+        sa.Column('observacoes', sa.Text(), nullable=True),
+    )
+    with op.batch_alter_table('ordem_servico') as batch_op:
+        batch_op.add_column(sa.Column('equipamento_id', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('sistema_id', sa.Integer(), nullable=True))
+        batch_op.drop_column('origem')
+        batch_op.create_foreign_key('ordem_servico_equipamento_id_fkey', 'equipamento', ['equipamento_id'], ['id'])
+        batch_op.create_foreign_key('ordem_servico_sistema_id_fkey', 'sistema', ['sistema_id'], ['id'])
+
+
+def downgrade():
+    with op.batch_alter_table('ordem_servico') as batch_op:
+        batch_op.drop_constraint('ordem_servico_equipamento_id_fkey', type_='foreignkey')
+        batch_op.drop_constraint('ordem_servico_sistema_id_fkey', type_='foreignkey')
+        batch_op.add_column(sa.Column('origem', sa.String(length=255), nullable=True))
+        batch_op.drop_column('equipamento_id')
+        batch_op.drop_column('sistema_id')
+    op.drop_table('sistema')
+    op.drop_table('equipamento')

--- a/templates/admin/ordens_servico.html
+++ b/templates/admin/ordens_servico.html
@@ -41,8 +41,22 @@
           </select>
         </div>
         <div class="mb-3">
-          <label for="origem" class="form-label">Origem</label>
-          <input type="text" class="form-control" id="origem" name="origem" value="{{ request.form.get('origem', ordem_editar.origem if ordem_editar else '') }}">
+          <label for="equipamento_id" class="form-label">Equipamento</label>
+          <select class="form-select" id="equipamento_id" name="equipamento_id">
+            <option value="">--</option>
+            {% for e in equipamentos %}
+            <option value="{{ e.id }}" {% if ordem_editar and ordem_editar.equipamento_id==e.id %}selected{% endif %}>{{ e.nome }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="mb-3">
+          <label for="sistema_id" class="form-label">Sistema</label>
+          <select class="form-select" id="sistema_id" name="sistema_id">
+            <option value="">--</option>
+            {% for s in sistemas %}
+            <option value="{{ s.id }}" {% if ordem_editar and ordem_editar.sistema_id==s.id %}selected{% endif %}>{{ s.nome }}</option>
+            {% endfor %}
+          </select>
         </div>
         <div class="mb-3">
           <label for="observacoes" class="form-label">Observações</label>

--- a/templates/ordens_servico/nova_os.html
+++ b/templates/ordens_servico/nova_os.html
@@ -13,19 +13,6 @@
               <input type="text" class="form-control" id="titulo" name="titulo" required>
             </div>
             <div class="mb-3">
-              <label for="descricao" class="form-label">Descrição</label>
-              <textarea class="form-control" id="descricao" name="descricao" rows="4"></textarea>
-            </div>
-            <div class="mb-3">
-              <label for="tipo_os_id" class="form-label">Tipo</label>
-              <select class="form-select" id="tipo_os_id" name="tipo_os_id">
-                <option value="">--</option>
-                {% for t in tipos_os %}
-                <option value="{{ t.id }}">{{ t.nome }}</option>
-                {% endfor %}
-              </select>
-            </div>
-            <div class="mb-3">
               <label for="prioridade" class="form-label">Prioridade</label>
               <select class="form-select" id="prioridade" name="prioridade">
                 <option value="">--</option>
@@ -35,12 +22,51 @@
               </select>
             </div>
             <div class="mb-3">
-              <label for="origem" class="form-label">Origem</label>
-              <input type="text" class="form-control" id="origem" name="origem">
+              <label for="equipamento_id" class="form-label">Equipamento</label>
+              <select class="form-select" id="equipamento_id" name="equipamento_id">
+                <option value="">--</option>
+                {% for e in equipamentos %}
+                <option value="{{ e.id }}">{{ e.nome }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="mb-3">
+              <label for="sistema_id" class="form-label">Sistema</label>
+              <select class="form-select" id="sistema_id" name="sistema_id">
+                <option value="">--</option>
+                {% for s in sistemas %}
+                <option value="{{ s.id }}">{{ s.nome }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="mb-3">
+              <label for="descricao" class="form-label">Descrição</label>
+              <textarea class="form-control" id="descricao" name="descricao" rows="4"></textarea>
             </div>
             <div class="mb-3">
               <label for="observacoes" class="form-label">Observações</label>
               <textarea class="form-control" id="observacoes" name="observacoes" rows="3"></textarea>
+            </div>
+            <div class="mb-3">
+              <label for="cargo" class="form-label">Cargo</label>
+              <input type="text" class="form-control" id="cargo" value="{{ usuario.cargo.nome if usuario and usuario.cargo else '' }}" readonly data-bs-toggle="tooltip" title="Essas informações são derivadas do seu cargo no sistema.">
+            </div>
+            <div class="mb-3">
+              <label for="setor" class="form-label">Setor</label>
+              <input type="text" class="form-control" id="setor" value="{{ usuario.setor.nome if usuario and usuario.setor else '' }}" readonly data-bs-toggle="tooltip" title="Essas informações são derivadas do seu cargo no sistema.">
+            </div>
+            <div class="mb-3">
+              <label for="celula" class="form-label">Célula</label>
+              <input type="text" class="form-control" id="celula" value="{{ usuario.celula.nome if usuario and usuario.celula else '' }}" readonly data-bs-toggle="tooltip" title="Essas informações são derivadas do seu cargo no sistema.">
+            </div>
+            <div class="mb-3">
+              <label for="tipo_os_id" class="form-label">Tipo</label>
+              <select class="form-select" id="tipo_os_id" name="tipo_os_id">
+                <option value="">--</option>
+                {% for t in tipos_os %}
+                <option value="{{ t.id }}">{{ t.nome }}</option>
+                {% endfor %}
+              </select>
             </div>
             <div class="mb-3" id="formulario-vinculado"></div>
             <div class="d-flex gap-2">
@@ -60,6 +86,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const form = document.querySelector('form');
   let inputs = form.querySelectorAll('input, textarea, select');
   const STORAGE_KEY = 'draft_nova_os';
+  const equipamento = document.getElementById('equipamento_id');
+  const sistema = document.getElementById('sistema_id');
   function save() {
     const data = {};
     inputs.forEach(i => data[i.id] = i.value);
@@ -105,6 +133,11 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   form.addEventListener('submit', (e) => {
+    if (!equipamento.value && !sistema.value) {
+      e.preventDefault();
+      alert('Informe ao menos Equipamento ou Sistema.');
+      return;
+    }
     if (formularioObrigatorio) {
       const campos = formContainer.querySelectorAll('input, textarea, select');
       const algumPreenchido = Array.from(campos).some(c => {
@@ -119,6 +152,9 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     localStorage.removeItem(STORAGE_KEY);
   });
+
+  const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+  tooltipTriggerList.forEach(t => new bootstrap.Tooltip(t));
 });
 </script>
 {% endblock %}

--- a/tests/test_ordem_servico.py
+++ b/tests/test_ordem_servico.py
@@ -14,6 +14,7 @@ from core.models import (
     User,
     Funcao,
     Formulario,
+    Equipamento,
 )
 from core.utils import gerar_codigo_os
 
@@ -50,14 +51,17 @@ def test_crud_ordem_servico(client):
         cel = Celula.query.first()
         tipo = TipoOS(nome='Tipo', descricao='d', equipe_responsavel_id=cel.id)
         etapa.tipos_os.append(tipo)
-        db.session.add_all([proc, etapa, tipo])
+        equip = Equipamento(nome='Eq1')
+        db.session.add_all([proc, etapa, tipo, equip])
         db.session.commit()
         proc_id = tipo.id
+        equip_id = equip.id
     # create
     resp = client.post('/admin/ordens_servico', data={
         'titulo': 'OS1',
         'descricao': 'desc',
         'tipo_os_id': proc_id,
+        'equipamento_id': equip_id,
         'status': 'rascunho',
         'prioridade': 'baixa'
     }, follow_redirects=True)
@@ -69,12 +73,14 @@ def test_crud_ordem_servico(client):
         os_codigo = os_obj.codigo
         assert re.match(r'^[A-Z]\d{6}$', os_codigo)
         assert os_obj.tipo_os_id == proc_id
+        assert os_obj.equipamento_id == equip_id
     # update
     resp = client.post('/admin/ordens_servico', data={
         'id_para_atualizar': os_id,
         'titulo': 'OS1 edit',
         'descricao': 'd2',
         'tipo_os_id': proc_id,
+        'equipamento_id': equip_id,
         'status': 'cancelada'
     }, follow_redirects=True)
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add Equipamento and Sistema models and link them to orders of service
- require at least one of the new fields when creating an OS
- expose equipment/system selectors and auto-filled department info on OS form

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b3ededf14832ebc6bd62bc0380af5