### PR TITLE
Corrige rota de Tipos de OS e reordena Cadastros Base

### DIFF
--- a/blueprints/ordens_servico.py
+++ b/blueprints/ordens_servico.py
@@ -186,9 +186,9 @@ def admin_delete_ordem(ordem_id):
     return redirect(url_for('ordens_servico_bp.admin_ordens_servico'))
 
 
-@ordens_servico_bp.route('/admin/tipos_os', methods=['GET', 'POST'], endpoint='admin_tipos_os')
+@ordens_servico_bp.route('/admin/tipos_os', methods=['GET', 'POST'], endpoint='tipos_os_admin')
 @admin_required
-def admin_tipos_os():
+def tipos_os_admin():
     tipo_editar = None
     if request.method == 'GET':
         edit_id = request.args.get('edit_id', type=int)
@@ -230,7 +230,7 @@ def admin_tipos_os():
             try:
                 db.session.commit()
                 flash(f'Tipo de OS {action_msg} com sucesso!', 'success')
-                return redirect(url_for('ordens_servico_bp.admin_tipos_os'))
+                return redirect(url_for('ordens_servico_bp.tipos_os_admin'))
             except Exception as e:
                 db.session.rollback()
                 flash(f'Erro ao salvar tipo de OS: {str(e)}', 'danger')
@@ -252,9 +252,9 @@ def admin_tipos_os():
     )
 
 
-@ordens_servico_bp.route('/admin/tipos_os/delete/<int:id>', methods=['POST'], endpoint='admin_tipos_os_delete')
+@ordens_servico_bp.route('/admin/tipos_os/delete/<int:id>', methods=['POST'], endpoint='tipos_os_admin_delete')
 @admin_required
-def admin_tipos_os_delete(id):
+def tipos_os_admin_delete(id):
     tipo = TipoOS.query.get_or_404(id)
     try:
         db.session.delete(tipo)
@@ -263,7 +263,7 @@ def admin_tipos_os_delete(id):
     except Exception as e:
         db.session.rollback()
         flash(f'Erro ao remover Tipo de OS: {str(e)}', 'danger')
-    return redirect(url_for('ordens_servico_bp.admin_tipos_os'))
+    return redirect(url_for('ordens_servico_bp.tipos_os_admin'))
 
 
 @ordens_servico_bp.route('/os/nova', methods=['GET', 'POST'], endpoint='os_nova')

--- a/templates/admin/tipos_os.html
+++ b/templates/admin/tipos_os.html
@@ -27,15 +27,15 @@
                   <tbody>
                     {% for t in tipos %}
                     {% set primeira_etapa = t.etapas.first() %}
-                    <tr class="clickable-row" data-href="{{ url_for('ordens_servico_bp.admin_tipos_os', edit_id=t.id) }}">
+                      <tr class="clickable-row" data-href="{{ url_for('ordens_servico_bp.tipos_os_admin', edit_id=t.id) }}">
                       <td>{{ t.nome }}</td>
                       <td>{{ primeira_etapa.nome if primeira_etapa else '-' }}</td>
                       <td>{{ t.equipe_responsavel.nome if t.equipe_responsavel else '-' }}</td>
                       <td>{{ formularios_dict.get(t.formulario_vinculado_id).nome if t.formulario_vinculado_id else '-' }}</td>
                       <td>{{ 'Sim' if t.obrigatorio_preenchimento else 'Não' }}</td>
                       <td class="text-end">
-                        <a href="{{ url_for('ordens_servico_bp.admin_tipos_os', edit_id=t.id) }}" class="btn btn-sm btn-outline-primary" title="Editar"><i class="bi bi-pencil-fill"></i></a>
-                        <form method="POST" action="{{ url_for('ordens_servico_bp.admin_tipos_os_delete', id=t.id) }}" class="d-inline" onsubmit="return confirm('Excluir tipo de OS?');">
+                          <a href="{{ url_for('ordens_servico_bp.tipos_os_admin', edit_id=t.id) }}" class="btn btn-sm btn-outline-primary" title="Editar"><i class="bi bi-pencil-fill"></i></a>
+                          <form method="POST" action="{{ url_for('ordens_servico_bp.tipos_os_admin_delete', id=t.id) }}" class="d-inline" onsubmit="return confirm('Excluir tipo de OS?');">
                           <button class="btn btn-sm btn-outline-danger" type="submit"><i class="bi bi-trash-fill"></i></button>
                         </form>
                       </td>
@@ -52,7 +52,7 @@
         </div>
         <div class="tab-pane fade p-3" id="cadastro" role="tabpanel" aria-labelledby="cadastro-tab">
           <h5 class="mb-3"><i class="bi bi-plus-circle-fill me-2"></i>{{ 'Editar Tipo de OS' if tipo_editar else 'Adicionar Tipo de OS' }}</h5>
-          <form method="POST" action="{{ url_for('ordens_servico_bp.admin_tipos_os') }}" class="compact-form" novalidate>
+            <form method="POST" action="{{ url_for('ordens_servico_bp.tipos_os_admin') }}" class="compact-form" novalidate>
             {% if tipo_editar %}
             <input type="hidden" name="id_para_atualizar" value="{{ tipo_editar.id }}">
             {% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -229,11 +229,11 @@
                                         </a>
                                         <div class="collapse {{ 'show' if endpoint_base in cadastros_base else '' }}" id="collapseCadastrosOrgSub">
                                             <ul class="nav flex-column ps-3">
-                                                <li class="nav-item"><a class="nav-link {{ 'active' if endpoint_base == 'admin_cargos' else '' }}" href="{{ url_for('admin_cargos') }}"><i class="bi bi-person-badge-fill me-2"></i> Cargos</a></li>
-                                                <li class="nav-item"><a class="nav-link {{ 'active' if endpoint_base == 'admin_celulas' else '' }}" href="{{ url_for('admin_celulas') }}"><i class="bi bi-diagram-2-fill me-2"></i> Células</a></li>
-                                                <li class="nav-item"><a class="nav-link {{ 'active' if endpoint_base == 'admin_estabelecimentos' else '' }}" href="{{ url_for('admin_estabelecimentos') }}"><i class="bi bi-building me-2"></i> Estabelecimentos</a></li>
                                                 <li class="nav-item"><a class="nav-link {{ 'active' if endpoint_base == 'admin_instituicoes' else '' }}" href="{{ url_for('admin_instituicoes') }}"><i class="bi bi-bank me-2"></i> Instituições</a></li>
+                                                <li class="nav-item"><a class="nav-link {{ 'active' if endpoint_base == 'admin_estabelecimentos' else '' }}" href="{{ url_for('admin_estabelecimentos') }}"><i class="bi bi-building me-2"></i> Estabelecimentos</a></li>
                                                 <li class="nav-item"><a class="nav-link {{ 'active' if endpoint_base == 'admin_setores' else '' }}" href="{{ url_for('admin_setores') }}"><i class="bi bi-tags-fill me-2"></i> Setores</a></li>
+                                                <li class="nav-item"><a class="nav-link {{ 'active' if endpoint_base == 'admin_celulas' else '' }}" href="{{ url_for('admin_celulas') }}"><i class="bi bi-diagram-2-fill me-2"></i> Células</a></li>
+                                                <li class="nav-item"><a class="nav-link {{ 'active' if endpoint_base == 'admin_cargos' else '' }}" href="{{ url_for('admin_cargos') }}"><i class="bi bi-person-badge-fill me-2"></i> Cargos</a></li>
                                             </ul>
                                         </div>
                                     </li>
@@ -377,7 +377,7 @@
                                     <div class="collapse" id="collapseOSCadastros">
                                         <ul class="nav flex-column ps-3">
                                             {% if current_user.is_authenticated and current_user.has_permissao('admin') %}
-                                            <li class="nav-item"><a class="nav-link os-nav-item" data-os-item="cadastros_tipos" href="{{ url_for('ordens_servico_bp.admin_tipos_os') }}"><i class="bi bi-card-text me-2"></i> Tipos de OS</a></li>
+                                            <li class="nav-item"><a class="nav-link os-nav-item" data-os-item="cadastros_tipos" href="{{ url_for('ordens_servico_bp.tipos_os_admin') }}"><i class="bi bi-card-text me-2"></i> Tipos de OS</a></li>
                                             <li class="nav-item"><a class="nav-link os-nav-item" data-os-item="cadastros_sistemas" href="{{ url_for('ordens_servico_bp.sistemas_list') }}"><i class="bi bi-hdd-network me-2"></i> Sistemas</a></li>
                                             <li class="nav-item"><a class="nav-link os-nav-item" data-os-item="cadastros_equipamentos" href="{{ url_for('ordens_servico_bp.equipamentos_list') }}"><i class="bi bi-cpu me-2"></i> Equipamentos</a></li>
                                             {% endif %}


### PR DESCRIPTION
## Summary
- impede abertura do menu Administração ao acessar Tipos de OS, renomeando a rota e ajustando links
- reorganiza itens do menu Administração > Cadastros Base conforme ordem desejada

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b4d0cedcc832eb9623cf0ebddfd84