### PR TITLE
feat(os): improve os listings and details

### DIFF
--- a/templates/ordens_servico/detalhe_os.html
+++ b/templates/ordens_servico/detalhe_os.html
@@ -1,19 +1,68 @@
 {% extends "base.html" %}
-{% block title %}{{ ordem.titulo }}{% endblock %}
+{% block title %}{{ ordem.titulo|striptags }}{% endblock %}
 {% block content %}
 <div class="container-fluid px-5 mt-3">
   <div class="row">
-    <div class="col-md-8 mx-auto">
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <h3>{{ ordem.titulo }}</h3>
-          <p class="text-muted">Status: {{ status_enum(ordem.status).label }}</p>
-          {% if ordem.processo %}
-          <p class="text-muted">Processo: {{ ordem.processo.nome }}</p>
-          {% endif %}
-          <p>{{ ordem.descricao }}</p>
+    <div class="col-md-10 mx-auto">
+      <div class="d-flex justify-content-between mb-3">
+        <div>
+          <a href="{{ next or url_for('ordens_servico_bp.os_listar') }}" class="btn btn-outline-secondary">Voltar</a>
+          <a href="{{ url_for('ordens_servico_bp.os_atendimento_detalhar', ordem_id=ordem.codigo) }}" class="btn btn-outline-success">Atender</a>
         </div>
       </div>
+      <div class="card shadow-sm mb-4">
+        <div class="card-body">
+          <h3>{{ ordem.titulo|striptags }}</h3>
+          <p class="text-muted">Protocolo: {{ ordem.codigo }}</p>
+          <p><strong>Status:</strong> {{ status_enum(ordem.status).label }}</p>
+          {% if ordem.prioridade %}<p><strong>Prioridade:</strong> {{ ordem.prioridade }}</p>{% endif %}
+          {% if ordem.tipo_os %}<p><strong>Tipo:</strong> {{ ordem.tipo_os.nome }}</p>{% endif %}
+          {% if ordem.sistema %}<p><strong>Sistema:</strong> {{ ordem.sistema.nome }}</p>{% endif %}
+          {% if ordem.equipamento %}<p><strong>Equipamento:</strong> {{ ordem.equipamento.nome }}</p>{% endif %}
+          <p><strong>Solicitante:</strong> {{ ordem.criado_por.nome_completo or ordem.criado_por.username }}</p>
+          {% if ordem.atribuido_para %}<p><strong>Responsável:</strong> {{ ordem.atribuido_para.nome_completo or ordem.atribuido_para.username }}</p>{% endif %}
+          <p><strong>Aberta em:</strong> {{ ordem.data_criacao.strftime('%d/%m/%Y %H:%M') }}</p>
+          {% if ordem.data_conclusao %}<p><strong>Concluída em:</strong> {{ ordem.data_conclusao.strftime('%d/%m/%Y %H:%M') }}</p>{% endif %}
+          <p><strong>Descrição:</strong> {{ ordem.descricao|striptags }}</p>
+          {% if ordem.observacoes %}<p><strong>Observações:</strong> {{ ordem.observacoes|striptags }}</p>{% endif %}
+        </div>
+      </div>
+
+      {% if comentarios %}
+      <div class="card shadow-sm mb-4">
+        <div class="card-body">
+          <h5>Comentários</h5>
+          <ul class="list-group">
+            {% for c in comentarios %}
+            <li class="list-group-item">
+              <strong>{{ c.usuario.nome_completo or c.usuario.username }}</strong>
+              <span class="text-muted">{{ c.data_hora.strftime('%d/%m/%Y %H:%M') }}</span>
+              <div>{{ c.mensagem|striptags }}</div>
+              {% if c.anexo %}
+              <a href="{{ url_for('static', filename=c.anexo) }}" class="d-block mt-1" target="_blank">Anexo</a>
+              {% endif %}
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+      {% endif %}
+
+      {% if logs %}
+      <div class="card shadow-sm mb-4">
+        <div class="card-body">
+          <h5>Histórico</h5>
+          <ul class="list-group">
+            {% for log in logs %}
+            <li class="list-group-item">
+              <strong>{{ log.data_hora.strftime('%d/%m/%Y %H:%M') }}</strong> - {{ log.acao|striptags }}
+              {% if log.usuario %}<em>({{ log.usuario.nome_completo or log.usuario.username }})</em>{% endif %}
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/templates/ordens_servico/listar_os.html
+++ b/templates/ordens_servico/listar_os.html
@@ -2,31 +2,115 @@
 {% block title %}Ordens de Serviço{% endblock %}
 {% block content %}
 <div class="container-fluid px-5 mt-3">
-  <div class="card shadow-sm">
-    <div class="card-body">
-      <h3>Ordens de Serviço</h3>
+  <div class="row">
+    <div class="col-md-10 mx-auto">
+      <div class="card shadow-sm mb-4">
+        <div class="card-body">
+          <form method="get" class="row g-2 align-items-end">
+            <div class="col-md-3">
+              <input name="q" value="{{ request.args.get('q','') }}" class="form-control" placeholder="Buscar por título ou descrição" />
+            </div>
+            <div class="col-md-2">
+              <select name="status" class="form-select">
+                <option value="">Status</option>
+                {% for st in status_enum %}
+                <option value="{{ st.value }}" {% if request.args.get('status')==st.value %}selected{% endif %}>{{ st.label }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-md-2">
+              <select name="prioridade" class="form-select">
+                <option value="">Prioridade</option>
+                {% for pr in prioridades %}
+                <option value="{{ pr.value }}" {% if request.args.get('prioridade')==pr.value %}selected{% endif %}>{{ pr.label }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-md-2">
+              <select name="tipo" class="form-select">
+                <option value="">Tipo</option>
+                {% for t in tipos_os %}
+                <option value="{{ t.id }}" {% if request.args.get('tipo', type=int)==t.id %}selected{% endif %}>{{ t.nome }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-md-3">
+              <input type="date" name="data_de" value="{{ request.args.get('data_de','') }}" class="form-control" />
+            </div>
+            <div class="col-md-3">
+              <input type="date" name="data_ate" value="{{ request.args.get('data_ate','') }}" class="form-control" />
+            </div>
+            <div class="col-md-2">
+              <select name="sistema" class="form-select">
+                <option value="">Sistema</option>
+                {% for s in sistemas %}
+                <option value="{{ s.id }}" {% if request.args.get('sistema', type=int)==s.id %}selected{% endif %}>{{ s.nome }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-md-2">
+              <select name="equipamento" class="form-select">
+                <option value="">Equipamento</option>
+                {% for e in equipamentos %}
+                <option value="{{ e.id }}" {% if request.args.get('equipamento', type=int)==e.id %}selected{% endif %}>{{ e.nome }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-md-2">
+              <select name="responsavel" class="form-select">
+                <option value="">Responsável</option>
+                {% for u in usuarios %}
+                <option value="{{ u.id }}" {% if request.args.get('responsavel', type=int)==u.id %}selected{% endif %}>{{ u.nome_completo or u.username }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-md-2">
+              <select name="solicitante" class="form-select">
+                <option value="">Solicitante</option>
+                {% for u in usuarios %}
+                <option value="{{ u.id }}" {% if request.args.get('solicitante', type=int)==u.id %}selected{% endif %}>{{ u.nome_completo or u.username }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-md-2">
+              <button class="btn btn-outline-primary w-100">Filtrar</button>
+            </div>
+          </form>
+        </div>
+      </div>
+
       {% if ordens %}
-      <div class="table-responsive">
-        <table class="table table-hover table-sm align-middle">
-          <thead>
-            <tr>
-              <th>Título</th>
-              <th>Status</th>
-              <th class="text-end">Ações</th>
-            </tr>
-          </thead>
-          <tbody>
-          {% for os in ordens %}
-            <tr>
-              <td>{{ os.titulo }}</td>
-              <td>{{ status_enum(os.status).label }}</td>
-              <td class="text-end">
-                <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.codigo) }}" class="btn btn-sm btn-outline-primary">Detalhes</a>
-              </td>
-            </tr>
-          {% endfor %}
-          </tbody>
-        </table>
+      <div class="card shadow-sm mb-4">
+        <div class="card-body">
+          <div class="list-group">
+            {% for os in ordens %}
+            <div class="list-group-item list-group-item-action">
+              <div class="d-flex w-100 justify-content-between">
+                <h5 class="mb-1">{{ os.titulo|striptags }} <small class="text-muted">#{{ os.codigo }}</small></h5>
+                <div>
+                  {% set st = status_enum(os.status) %}
+                  <span class="badge rounded-pill bg-{{ st.color }} text-{{ st.text_color }}">{{ st.label }}</span>
+                  {% if os.prioridade %}
+                  <span class="badge bg-secondary">{{ os.prioridade }}</span>
+                  {% endif %}
+                </div>
+              </div>
+              <small class="text-muted">
+                {% if os.tipo_os %}<strong>Tipo:</strong> {{ os.tipo_os.nome }} |{% endif %}
+                {% if os.sistema %}<strong>Sistema:</strong> {{ os.sistema.nome }} |{% endif %}
+                {% if os.equipamento %}<strong>Equipamento:</strong> {{ os.equipamento.nome }} |{% endif %}
+                <strong>Solicitante:</strong> {{ os.criado_por.nome_completo or os.criado_por.username }} |
+                {% if os.atribuido_para %}<strong>Responsável:</strong> {{ os.atribuido_para.nome_completo or os.atribuido_para.username }} |{% endif %}
+                <strong>Aberta em:</strong> {{ os.data_criacao.strftime('%d/%m/%Y %H:%M') }}
+              </small>
+              <div class="mt-2">
+                <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.codigo, next=request.full_path) }}" class="btn btn-sm btn-outline-primary">Detalhes</a>
+                <a href="{{ url_for('ordens_servico_bp.os_atendimento_detalhar', ordem_id=os.codigo) }}" class="btn btn-sm btn-outline-success">Atender</a>
+              </div>
+            </div>
+            {% endfor %}
+          </div>
+        </div>
       </div>
       {% else %}
       <p class="text-muted">Nenhuma Ordem de Serviço encontrada.</p>

--- a/templates/ordens_servico/minhas_os.html
+++ b/templates/ordens_servico/minhas_os.html
@@ -2,29 +2,115 @@
 {% block title %}Minhas Ordens de Serviço{% endblock %}
 {% block content %}
 <div class="container-fluid px-5 mt-3">
-  <div class="card shadow-sm">
-    <div class="card-body">
-      <h3>Minhas Ordens de Serviço</h3>
+  <div class="row">
+    <div class="col-md-10 mx-auto">
+      <div class="card shadow-sm mb-4">
+        <div class="card-body">
+          <form method="get" class="row g-2 align-items-end">
+            <div class="col-md-3">
+              <input name="q" value="{{ request.args.get('q','') }}" class="form-control" placeholder="Buscar por título ou descrição" />
+            </div>
+            <div class="col-md-2">
+              <select name="status" class="form-select">
+                <option value="">Status</option>
+                {% for st in status_enum %}
+                <option value="{{ st.value }}" {% if request.args.get('status')==st.value %}selected{% endif %}>{{ st.label }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-md-2">
+              <select name="prioridade" class="form-select">
+                <option value="">Prioridade</option>
+                {% for pr in prioridades %}
+                <option value="{{ pr.value }}" {% if request.args.get('prioridade')==pr.value %}selected{% endif %}>{{ pr.label }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-md-2">
+              <select name="tipo" class="form-select">
+                <option value="">Tipo</option>
+                {% for t in tipos_os %}
+                <option value="{{ t.id }}" {% if request.args.get('tipo', type=int)==t.id %}selected{% endif %}>{{ t.nome }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-md-3">
+              <input type="date" name="data_de" value="{{ request.args.get('data_de','') }}" class="form-control" />
+            </div>
+            <div class="col-md-3">
+              <input type="date" name="data_ate" value="{{ request.args.get('data_ate','') }}" class="form-control" />
+            </div>
+            <div class="col-md-2">
+              <select name="sistema" class="form-select">
+                <option value="">Sistema</option>
+                {% for s in sistemas %}
+                <option value="{{ s.id }}" {% if request.args.get('sistema', type=int)==s.id %}selected{% endif %}>{{ s.nome }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-md-2">
+              <select name="equipamento" class="form-select">
+                <option value="">Equipamento</option>
+                {% for e in equipamentos %}
+                <option value="{{ e.id }}" {% if request.args.get('equipamento', type=int)==e.id %}selected{% endif %}>{{ e.nome }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-md-2">
+              <button class="btn btn-outline-primary w-100">Filtrar</button>
+            </div>
+          </form>
+        </div>
+      </div>
+
       {% if rascunhos %}
-      <h5 class="mt-3">Rascunhos</h5>
-      <div class="list-group mb-3">
-        {% for os in rascunhos %}
-        <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.codigo) }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-          <span>{{ os.titulo }}</span>
-          <span class="badge bg-warning text-dark">Rascunho</span>
-        </a>
-        {% endfor %}
+      <div class="card shadow-sm mb-4">
+        <div class="card-body">
+          <h5 class="mb-3">Rascunhos</h5>
+          <div class="list-group">
+            {% for os in rascunhos %}
+            <div class="list-group-item list-group-item-action">
+              <div class="d-flex w-100 justify-content-between">
+                <div class="fw-bold">{{ os.titulo|striptags }} <small class="text-muted">#{{ os.codigo }}</small></div>
+                <span class="badge bg-warning text-dark">Rascunho</span>
+              </div>
+              <div class="mt-2">
+                <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.codigo, next=request.full_path) }}" class="btn btn-sm btn-outline-primary">Detalhes</a>
+              </div>
+            </div>
+            {% endfor %}
+          </div>
+        </div>
       </div>
       {% endif %}
+
       {% if ordens %}
-      <h5 class="mt-3">Em andamento</h5>
-      <div class="list-group">
-        {% for os in ordens %}
-        <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.codigo) }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-          <span>{{ os.titulo }}</span>
-          <span class="badge bg-secondary">{{ status_enum(os.status).label }}</span>
-        </a>
-        {% endfor %}
+      <div class="card shadow-sm mb-4">
+        <div class="card-body">
+          <h5 class="mb-3">Em andamento</h5>
+          <div class="list-group">
+            {% for os in ordens %}
+            <div class="list-group-item list-group-item-action">
+              <div class="d-flex w-100 justify-content-between">
+                <div class="fw-bold">{{ os.titulo|striptags }} <small class="text-muted">#{{ os.codigo }}</small></div>
+                {% set st = status_enum(os.status) %}
+                <span class="badge rounded-pill bg-{{ st.color }} text-{{ st.text_color }}">{{ st.label }}</span>
+              </div>
+              <small class="text-muted">
+                {% if os.tipo_os %}<strong>Tipo:</strong> {{ os.tipo_os.nome }} |{% endif %}
+                {% if os.sistema %}<strong>Sistema:</strong> {{ os.sistema.nome }} |{% endif %}
+                {% if os.equipamento %}<strong>Equipamento:</strong> {{ os.equipamento.nome }} |{% endif %}
+                {% if os.prioridade %}<strong>Prioridade:</strong> {{ os.prioridade }} |{% endif %}
+                <strong>Aberta em:</strong> {{ os.data_criacao.strftime('%d/%m/%Y %H:%M') }}
+              </small>
+              <div class="mt-2">
+                <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.codigo, next=request.full_path) }}" class="btn btn-sm btn-outline-primary">Detalhes</a>
+                <a href="{{ url_for('ordens_servico_bp.os_atendimento_detalhar', ordem_id=os.codigo) }}" class="btn btn-sm btn-outline-success">Atender</a>
+              </div>
+            </div>
+            {% endfor %}
+          </div>
+        </div>
       </div>
       {% elif not rascunhos %}
       <p class="text-muted">Nenhuma Ordem de Serviço encontrada.</p>


### PR DESCRIPTION
## Summary
- add comprehensive filters to OS listing
- display OS info with card layout and action buttons
- expand OS detail view with history and comments

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b9333c630832e820fc89d9befa7b5