### PR TITLE
Corrige consulta de OS e layout de listagens

### DIFF
--- a/blueprints/ordens_servico.py
+++ b/blueprints/ordens_servico.py
@@ -463,6 +463,9 @@ def os_listar():
     equipamentos = Equipamento.query.order_by(Equipamento.nome).all()
     usuarios = User.query.order_by(User.username).all()
 
+    modo = request.args.get('modo', 'abrir')
+    mostrar_atender = modo == 'atender' and getattr(usuario, 'pode_atender_os', False)
+
     return render_template(
         'ordens_servico/listar_os.html',
         ordens=ordens,
@@ -472,6 +475,7 @@ def os_listar():
         sistemas=sistemas,
         equipamentos=equipamentos,
         usuarios=usuarios,
+        mostrar_atender=mostrar_atender,
     )
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -343,7 +343,7 @@
                                     <div class="collapse" id="collapseOSAtender">
                                         <ul class="nav flex-column ps-3">
                                             <li class="nav-item"><a class="nav-link os-nav-item" data-os-item="atendimento" href="{{ url_for('ordens_servico_bp.os_atendimento') }}"><i class="bi bi-headset me-2"></i> Atendimento de OS</a></li>
-                                            <li class="nav-item"><a class="nav-link os-nav-item" data-os-item="atender_consultar" href="{{ url_for('ordens_servico_bp.os_listar') }}"><i class="bi bi-binoculars-fill me-2"></i> Consultar OS</a></li>
+                                            <li class="nav-item"><a class="nav-link os-nav-item" data-os-item="atender_consultar" href="{{ url_for('ordens_servico_bp.os_listar', modo='atender') }}"><i class="bi bi-binoculars-fill me-2"></i> Consultar OS</a></li>
                                             <li class="nav-item"><a class="nav-link os-nav-item" data-os-item="atender_kanban" href="{{ url_for('ordens_servico_bp.os_kanban_atendimento') }}"><i class="bi bi-kanban me-2"></i> Kanban de OS</a></li>
                                         </ul>
                                     </div>

--- a/templates/ordens_servico/listar_os.html
+++ b/templates/ordens_servico/listar_os.html
@@ -79,12 +79,12 @@
         </div>
       </div>
 
-      {% if ordens %}
-      <div class="card shadow-sm mb-4">
-        <div class="card-body">
-          <div class="list-group">
-            {% for os in ordens %}
-            <div class="list-group-item list-group-item-action">
+        {% if ordens %}
+        <div class="card shadow-sm mb-4 aprovacao-list">
+          <div class="card-body">
+            <div class="list-group">
+              {% for os in ordens %}
+              <div class="list-group-item list-group-item-action">
               <div class="d-flex w-100 justify-content-between">
                 <h5 class="mb-1">{{ os.titulo|striptags }} <small class="text-muted">#{{ os.codigo }}</small></h5>
                 <div>
@@ -103,15 +103,17 @@
                 {% if os.atribuido_para %}<strong>Responsável:</strong> {{ os.atribuido_para.nome_completo or os.atribuido_para.username }} |{% endif %}
                 <strong>Aberta em:</strong> {{ os.data_criacao.strftime('%d/%m/%Y %H:%M') }}
               </small>
-              <div class="mt-2">
-                <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.codigo, next=request.full_path) }}" class="btn btn-sm btn-outline-primary">Detalhes</a>
-                <a href="{{ url_for('ordens_servico_bp.os_atendimento_detalhar', ordem_id=os.codigo) }}" class="btn btn-sm btn-outline-success">Atender</a>
+                <div class="mt-2">
+                  <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.codigo, next=request.full_path) }}" class="btn btn-sm btn-outline-primary">Detalhes</a>
+                  {% if mostrar_atender %}
+                  <a href="{{ url_for('ordens_servico_bp.os_atendimento_detalhar', ordem_id=os.codigo) }}" class="btn btn-sm btn-outline-success">Atender</a>
+                  {% endif %}
+                </div>
               </div>
+              {% endfor %}
             </div>
-            {% endfor %}
           </div>
         </div>
-      </div>
       {% else %}
       <p class="text-muted">Nenhuma Ordem de Serviço encontrada.</p>
       {% endif %}

--- a/templates/ordens_servico/minhas_os.html
+++ b/templates/ordens_servico/minhas_os.html
@@ -63,56 +63,55 @@
         </div>
       </div>
 
-      {% if rascunhos %}
-      <div class="card shadow-sm mb-4">
-        <div class="card-body">
-          <h5 class="mb-3">Rascunhos</h5>
-          <div class="list-group">
-            {% for os in rascunhos %}
-            <div class="list-group-item list-group-item-action">
-              <div class="d-flex w-100 justify-content-between">
-                <div class="fw-bold">{{ os.titulo|striptags }} <small class="text-muted">#{{ os.codigo }}</small></div>
-                <span class="badge bg-warning text-dark">Rascunho</span>
+        {% if rascunhos %}
+        <div class="card shadow-sm mb-4 aprovacao-list">
+          <div class="card-body">
+            <h5 class="mb-3">Rascunhos</h5>
+            <div class="list-group">
+              {% for os in rascunhos %}
+              <div class="list-group-item list-group-item-action">
+                <div class="d-flex w-100 justify-content-between">
+                  <div class="fw-bold">{{ os.titulo|striptags }} <small class="text-muted">#{{ os.codigo }}</small></div>
+                  <span class="badge bg-warning text-dark">Rascunho</span>
+                </div>
+                <div class="mt-2">
+                  <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.codigo, next=request.full_path) }}" class="btn btn-sm btn-outline-primary">Detalhes</a>
+                </div>
               </div>
-              <div class="mt-2">
-                <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.codigo, next=request.full_path) }}" class="btn btn-sm btn-outline-primary">Detalhes</a>
-              </div>
+              {% endfor %}
             </div>
-            {% endfor %}
           </div>
         </div>
-      </div>
-      {% endif %}
+        {% endif %}
 
-      {% if ordens %}
-      <div class="card shadow-sm mb-4">
-        <div class="card-body">
-          <h5 class="mb-3">Em andamento</h5>
-          <div class="list-group">
-            {% for os in ordens %}
-            <div class="list-group-item list-group-item-action">
-              <div class="d-flex w-100 justify-content-between">
-                <div class="fw-bold">{{ os.titulo|striptags }} <small class="text-muted">#{{ os.codigo }}</small></div>
-                {% set st = status_enum(os.status) %}
-                <span class="badge rounded-pill bg-{{ st.color }} text-{{ st.text_color }}">{{ st.label }}</span>
+        {% if ordens %}
+        <div class="card shadow-sm mb-4 aprovacao-list">
+          <div class="card-body">
+            <h5 class="mb-3">Em andamento</h5>
+            <div class="list-group">
+              {% for os in ordens %}
+              <div class="list-group-item list-group-item-action">
+                <div class="d-flex w-100 justify-content-between">
+                  <div class="fw-bold">{{ os.titulo|striptags }} <small class="text-muted">#{{ os.codigo }}</small></div>
+                  {% set st = status_enum(os.status) %}
+                  <span class="badge rounded-pill bg-{{ st.color }} text-{{ st.text_color }}">{{ st.label }}</span>
+                </div>
+                <small class="text-muted">
+                  {% if os.tipo_os %}<strong>Tipo:</strong> {{ os.tipo_os.nome }} |{% endif %}
+                  {% if os.sistema %}<strong>Sistema:</strong> {{ os.sistema.nome }} |{% endif %}
+                  {% if os.equipamento %}<strong>Equipamento:</strong> {{ os.equipamento.nome }} |{% endif %}
+                  {% if os.prioridade %}<strong>Prioridade:</strong> {{ os.prioridade }} |{% endif %}
+                  <strong>Aberta em:</strong> {{ os.data_criacao.strftime('%d/%m/%Y %H:%M') }}
+                </small>
+                <div class="mt-2">
+                  <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.codigo, next=request.full_path) }}" class="btn btn-sm btn-outline-primary">Detalhes</a>
+                </div>
               </div>
-              <small class="text-muted">
-                {% if os.tipo_os %}<strong>Tipo:</strong> {{ os.tipo_os.nome }} |{% endif %}
-                {% if os.sistema %}<strong>Sistema:</strong> {{ os.sistema.nome }} |{% endif %}
-                {% if os.equipamento %}<strong>Equipamento:</strong> {{ os.equipamento.nome }} |{% endif %}
-                {% if os.prioridade %}<strong>Prioridade:</strong> {{ os.prioridade }} |{% endif %}
-                <strong>Aberta em:</strong> {{ os.data_criacao.strftime('%d/%m/%Y %H:%M') }}
-              </small>
-              <div class="mt-2">
-                <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.codigo, next=request.full_path) }}" class="btn btn-sm btn-outline-primary">Detalhes</a>
-                <a href="{{ url_for('ordens_servico_bp.os_atendimento_detalhar', ordem_id=os.codigo) }}" class="btn btn-sm btn-outline-success">Atender</a>
-              </div>
+              {% endfor %}
             </div>
-            {% endfor %}
           </div>
         </div>
-      </div>
-      {% elif not rascunhos %}
+        {% elif not rascunhos %}
       <p class="text-muted">Nenhuma Ordem de Serviço encontrada.</p>
       {% endif %}
     </div>


### PR DESCRIPTION
## Summary
- Exibe botão de atender somente na consulta de OS do menu de atendimento
- Ajusta layouts de listagens de OS para usar cards com espaçamento e animação

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b965ec7e0832eb5e2e14d685b0d72