### PR TITLE
Ajusta exibição de status e ordenação de dados de OS

### DIFF
--- a/core/enums.py
+++ b/core/enums.py
@@ -66,22 +66,39 @@ class Permissao(Enum):
 class OSStatus(Enum):
     """Status possíveis de uma Ordem de Serviço."""
 
-    def __new__(cls, value: str, label: str):
+    def __new__(cls, value: str, label: str, color: str, text_color: str):
         obj = object.__new__(cls)
         obj._value_ = value
         obj.label = label
+        obj.color = color
+        obj.text_color = text_color
         return obj
 
-    RASCUNHO = ("rascunho", "Rascunho")
-    AGUARDANDO_ATENDIMENTO = ("aguardando_atendimento", "Aguardando Atendimento")
-    EM_ATENDIMENTO = ("em_atendimento", "Em Atendimento")
-    AGUARDANDO_INFORMACOES_SOLICITANTE = ("aguardando_info_solicitante", "Aguardando Informações do Solicitante")
-    AGUARDANDO_INTERACAO_TERCEIRO = ("aguardando_terceiro", "Aguardando Interação com Terceiro")
-    ENCAMINHADA_PARA_OUTRA_EQUIPE = ("encaminhada_outra_equipe", "Encaminhada para Outra Equipe")
-    PAUSADA = ("pausada", "Pausada")
-    CONCLUIDA = ("concluida", "Concluída")
-    CANCELADA = ("cancelada", "Cancelada")
-    REJEITADA = ("rejeitada", "Rejeitada")
+    RASCUNHO = ("rascunho", "Rascunho", "secondary", "white")
+    AGUARDANDO_ATENDIMENTO = ("aguardando_atendimento", "Aguardando Atendimento", "primary", "white")
+    EM_ATENDIMENTO = ("em_atendimento", "Em Atendimento", "info", "dark")
+    AGUARDANDO_INFORMACOES_SOLICITANTE = (
+        "aguardando_info_solicitante",
+        "Aguardando Informações do Solicitante",
+        "warning",
+        "dark",
+    )
+    AGUARDANDO_INTERACAO_TERCEIRO = (
+        "aguardando_terceiro",
+        "Aguardando Interação com Terceiro",
+        "warning",
+        "dark",
+    )
+    ENCAMINHADA_PARA_OUTRA_EQUIPE = (
+        "encaminhada_outra_equipe",
+        "Encaminhada para Outra Equipe",
+        "info",
+        "dark",
+    )
+    PAUSADA = ("pausada", "Pausada", "secondary", "white")
+    CONCLUIDA = ("concluida", "Concluída", "success", "white")
+    CANCELADA = ("cancelada", "Cancelada", "danger", "white")
+    REJEITADA = ("rejeitada", "Rejeitada", "danger", "white")
 
 
 class OSPrioridade(Enum):

--- a/templates/ordens_servico/kanban.html
+++ b/templates/ordens_servico/kanban.html
@@ -12,8 +12,9 @@
           {% for os in columns[key] %}
           <div class="card mb-2 os-card" data-os="{{ os.codigo }}" style="cursor:pointer;">
             <div class="card-body p-2">
-              <div class="fw-bold">{{ os.titulo }}</div>
-              <small>Código {{ os.codigo }}{% if os.prioridade %} - {{ os.prioridade }}{% endif %}</small>
+              <div><strong>Código OS:</strong> {{ os.codigo }}</div>
+              <div class="fw-bold"><strong>Título:</strong> {{ os.titulo }}</div>
+              {% if os.prioridade %}<small class="text-muted">Prioridade: {{ os.prioridade }}</small>{% endif %}
             </div>
           </div>
           {% endfor %}

--- a/templates/ordens_servico/listar_os.html
+++ b/templates/ordens_servico/listar_os.html
@@ -86,7 +86,10 @@
               {% for os in ordens %}
               <div class="list-group-item list-group-item-action">
               <div class="d-flex w-100 justify-content-between">
-                <h5 class="mb-1">{{ os.titulo|striptags }} <small class="text-muted">#{{ os.codigo }}</small></h5>
+                <div>
+                  <div><strong>Código OS:</strong> {{ os.codigo }}</div>
+                  <div><strong>Título:</strong> {{ os.titulo|striptags }}</div>
+                </div>
                 <div>
                   {% set st = status_enum(os.status) %}
                   <span class="badge rounded-pill bg-{{ st.color }} text-{{ st.text_color }}">{{ st.label }}</span>

--- a/templates/ordens_servico/minhas_os.html
+++ b/templates/ordens_servico/minhas_os.html
@@ -71,8 +71,12 @@
               {% for os in rascunhos %}
               <div class="list-group-item list-group-item-action">
                 <div class="d-flex w-100 justify-content-between">
-                  <div class="fw-bold">{{ os.titulo|striptags }} <small class="text-muted">#{{ os.codigo }}</small></div>
-                  <span class="badge bg-warning text-dark">Rascunho</span>
+                  <div>
+                    <div><strong>Código OS:</strong> {{ os.codigo }}</div>
+                    <div><strong>Título:</strong> {{ os.titulo|striptags }}</div>
+                  </div>
+                  {% set st = status_enum(os.status) %}
+                  <span class="badge rounded-pill bg-{{ st.color }} text-{{ st.text_color }}">{{ st.label }}</span>
                 </div>
                 <div class="mt-2">
                   <a href="{{ url_for('ordens_servico_bp.os_detalhar', ordem_id=os.codigo, next=request.full_path) }}" class="btn btn-sm btn-outline-primary">Detalhes</a>
@@ -92,7 +96,10 @@
               {% for os in ordens %}
               <div class="list-group-item list-group-item-action">
                 <div class="d-flex w-100 justify-content-between">
-                  <div class="fw-bold">{{ os.titulo|striptags }} <small class="text-muted">#{{ os.codigo }}</small></div>
+                  <div>
+                    <div><strong>Código OS:</strong> {{ os.codigo }}</div>
+                    <div><strong>Título:</strong> {{ os.titulo|striptags }}</div>
+                  </div>
                   {% set st = status_enum(os.status) %}
                   <span class="badge rounded-pill bg-{{ st.color }} text-{{ st.text_color }}">{{ st.label }}</span>
                 </div>


### PR DESCRIPTION
## Summary
- adiciona cor e contraste aos status das Ordens de Serviço
- exibe o código antes do título nos cards de OS
- reorganiza cards do kanban para alinhar campos

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b9964eed0832eaca1f1715c21b40c