### PR TITLE
Allow configuring Tesseract OEM and PSM

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,19 @@ Para rodar este projeto em um ambiente de desenvolvimento, você precisará ter 
 Consulte o passo a passo de instalação dessas dependências e a configuração do
 `PATH` em nosso [Guia de Instalação](./GUIA_DE_INSTALACAO.md#6-instalacao-do-poppler-e-do-tesseract-dependencias-de-ocr).
 
+### Configuração do OCR
+
+O Tesseract é executado por padrão com `OEM 3` e `PSM 6`. Em cenários que
+requerem ajustes diferentes (por exemplo, documentos com layout complexo),
+defina as variáveis de ambiente `OCR_OEM` e `OCR_PSM` ou informe esses valores
+diretamente ao chamar as funções `extract_text_from_pdf` ou
+`extract_text_from_image`.
+
+```bash
+export OCR_OEM=1  # LSTM apenas
+export OCR_PSM=4  # Segmentação por coluna
+```
+
 ## Como Rodar o Projeto (Desenvolvimento)
 
 1.  **Clone o repositório:**

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,11 @@
 import pytest
-
 import types
-from core.utils import sanitize_html, extract_text
+from core.utils import (
+    sanitize_html,
+    extract_text,
+    extract_text_from_image,
+    extract_text_from_pdf,
+)
 
 
 def test_sanitize_html_removes_disallowed_tags():
@@ -42,3 +46,48 @@ def test_extract_text_image_pdf(monkeypatch, tmp_path):
     assert "Texto1" in text
     assert "Texto2" in text
     assert len(calls) == 2
+
+
+def test_extract_text_from_image_custom_config(monkeypatch):
+    from PIL import Image
+
+    img = Image.new("RGB", (10, 10), color="white")
+    captured = {}
+
+    def dummy_image_to_string(img, lang, config):
+        captured["config"] = config
+        return ""
+
+    monkeypatch.setattr(
+        "core.utils.pytesseract",
+        types.SimpleNamespace(image_to_string=dummy_image_to_string),
+    )
+
+    extract_text_from_image(img, oem="1", psm="4")
+    assert captured["config"] == "--oem 1 --psm 4"
+
+
+def test_extract_text_from_pdf_uses_env(monkeypatch, tmp_path):
+    pdf_file = tmp_path / "dummy.pdf"
+    pdf_file.write_bytes(b"%PDF-1.4")
+
+    from PIL import Image
+
+    img = Image.new("RGB", (10, 10), color="white")
+    monkeypatch.setattr("core.utils.convert_from_path", lambda p, dpi=300: [img])
+
+    captured = {}
+
+    def dummy_image_to_string(img, lang, config):
+        captured["config"] = config
+        return "texto"
+
+    monkeypatch.setattr(
+        "core.utils.pytesseract",
+        types.SimpleNamespace(image_to_string=dummy_image_to_string),
+    )
+    monkeypatch.setenv("OCR_OEM", "1")
+    monkeypatch.setenv("OCR_PSM", "4")
+
+    extract_text_from_pdf(str(pdf_file))
+    assert captured["config"] == "--oem 1 --psm 4"


### PR DESCRIPTION
## Summary
- enable `extract_text_from_image` to accept `oem`/`psm` and build pytesseract config dynamically
- let `extract_text_from_pdf` forward OEM/PSM values or read `OCR_OEM`/`OCR_PSM` env vars
- document how to tweak OCR modes via environment variables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ba6efb9c0832ea9ceea07d0d2403a