### PR TITLE
Make PDF OCR DPI configurable

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -94,11 +94,19 @@ def sanitize_html(text: str) -> str:
 #-------------------------------------------------------------------------------------------
 # Extração de texto dos anexos
 #-------------------------------------------------------------------------------------------
-def extract_text(path: str) -> str:
+def extract_text(path: str, pdf_dpi: int = 300) -> str:
     """
     Extrai texto de vários formatos de arquivo:
     - .txt, .docx, .xlsx, .xls, .ods, .pdf
     Retorna todo o texto concatenado como string.
+
+    Parameters
+    ----------
+    path: str
+        Caminho do arquivo a ser processado.
+    pdf_dpi: int, opcional
+        DPI utilizado quando ``path`` aponta para um PDF. O valor pode ser
+        redefinido pela variável de ambiente ``PDF_OCR_DPI``. Padrão: 300.
     """
     ext = os.path.splitext(path)[1].lower()
     text_parts = []
@@ -146,7 +154,7 @@ def extract_text(path: str) -> str:
 
     # PDF (texto ou imagem)
     if ext == '.pdf':
-        return extract_text_from_pdf(path)
+        return extract_text_from_pdf(path, dpi=pdf_dpi)
 
     # outros formatos não suportados
     return ''
@@ -180,13 +188,27 @@ def extract_text_from_image(image, lang="por") -> str:
     return pytesseract.image_to_string(image, lang=lang, config="--oem 3 --psm 6")
 
 
-def extract_text_from_pdf(path: str) -> str:
+def extract_text_from_pdf(path: str, dpi: int = 300) -> str:
     """Extrai texto de PDFs.
 
     Primeiro tenta usar o texto embutido com ``pypdf``/``PyPDF2``. Se não houver
     esse texto ou a biblioteca não estiver disponível, recorre ao OCR usando
     ``pdf2image`` + ``pytesseract``.
+
+    Parameters
+    ----------
+    path: str
+        Caminho para o arquivo PDF.
+    dpi: int, opcional
+        Resolução em *dots per inch* utilizada ao converter o PDF em imagens.
+        Valores mais altos tendem a melhorar a acurácia do OCR, mas aumentam o
+        tempo de processamento e o consumo de memória. Valor padrão: 300. Pode
+        ser sobrescrito pela variável de ambiente ``PDF_OCR_DPI`` quando o
+        parâmetro não for informado.
     """
+    env_dpi = os.getenv("PDF_OCR_DPI")
+    if env_dpi and dpi == 300:
+        dpi = int(env_dpi)
     text_parts: list[str] = []
 
     # 1) Tenta extrair texto nativo do PDF -------------------------------
@@ -208,7 +230,7 @@ def extract_text_from_pdf(path: str) -> str:
         return ""
 
     try:
-        images = convert_from_path(path, dpi=300)
+        images = convert_from_path(path, dpi=dpi)
     except Exception as e:  # pragma: no cover - erro ao converter
         logger.error("Erro ao converter PDF %s: %s", path, e)
         return ""

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,17 @@ Para rodar este projeto em um ambiente de desenvolvimento, você precisará ter 
 Consulte o passo a passo de instalação dessas dependências e a configuração do
 `PATH` em nosso [Guia de Instalação](./GUIA_DE_INSTALACAO.md#6-instalacao-do-poppler-e-do-tesseract-dependencias-de-ocr).
 
+### Ajuste de DPI para OCR
+
+Ao extrair texto de PDFs baseados em imagem, cada página é convertida em imagem
+antes de passar pelo Tesseract. O DPI (*dots per inch*) utilizado nessa etapa
+impacta diretamente o resultado: valores maiores tendem a gerar reconhecimento
+mais preciso, porém aumentam o tempo de processamento e o consumo de memória.
+
+O sistema utiliza por padrão **300 DPI**, mas é possível ajustar esse valor por
+meio da variável de ambiente `PDF_OCR_DPI` ou passando o parâmetro `pdf_dpi` para
+as funções utilitárias de extração de texto.
+
 ## Como Rodar o Projeto (Desenvolvimento)
 
 1.  **Clone o repositório:**

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,3 +42,50 @@ def test_extract_text_image_pdf(monkeypatch, tmp_path):
     assert "Texto1" in text
     assert "Texto2" in text
     assert len(calls) == 2
+
+
+def test_extract_text_custom_dpi(monkeypatch, tmp_path):
+    pdf_file = tmp_path / "dummy.pdf"
+    pdf_file.write_bytes(b"%PDF-1.4")
+
+    from PIL import Image
+
+    captured = {}
+
+    def dummy_convert(p, dpi=0):
+        captured["dpi"] = dpi
+        return [Image.new("RGB", (10, 10))]
+
+    monkeypatch.setattr("core.utils.convert_from_path", dummy_convert)
+    monkeypatch.setattr(
+        "core.utils.pytesseract", types.SimpleNamespace(image_to_string=lambda *a, **k: "texto")
+    )
+    monkeypatch.setattr("core.utils.preprocess_image", lambda img, **k: img)
+
+    extract_text(str(pdf_file), pdf_dpi=200)
+
+    assert captured["dpi"] == 200
+
+
+def test_extract_text_env_dpi(monkeypatch, tmp_path):
+    pdf_file = tmp_path / "dummy.pdf"
+    pdf_file.write_bytes(b"%PDF-1.4")
+
+    from PIL import Image
+
+    captured = {}
+
+    def dummy_convert(p, dpi=0):
+        captured["dpi"] = dpi
+        return [Image.new("RGB", (10, 10))]
+
+    monkeypatch.setattr("core.utils.convert_from_path", dummy_convert)
+    monkeypatch.setattr(
+        "core.utils.pytesseract", types.SimpleNamespace(image_to_string=lambda *a, **k: "texto")
+    )
+    monkeypatch.setattr("core.utils.preprocess_image", lambda img, **k: img)
+    monkeypatch.setenv("PDF_OCR_DPI", "250")
+
+    extract_text(str(pdf_file))
+
+    assert captured["dpi"] == 250


### PR DESCRIPTION
## Summary
- allow callers to set DPI when extracting text from PDFs and honor `PDF_OCR_DPI`
- document how DPI impacts OCR performance
- add tests covering custom and environment-driven DPI values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ba8655820832e9e9142d2eca2bb4c