### PR TITLE
Improve OCR preprocessing and configurability

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -79,6 +79,41 @@ texto = extract_text_from_pdf(
 )
 ```
 
+### Configuração avançada de OCR
+
+O fluxo de OCR pode ser ajustado dinamicamente por meio do arquivo
+`ocr_config.json` localizado na raiz do projeto. Esse arquivo permite controlar
+parâmetros do Tesseract (idioma, `psm`, `oem`, _whitelist_/ _blacklist_ de
+caracteres) e diversas etapas de pré-processamento das imagens:
+
+* conversão para tons de cinza;
+* ajuste de brilho e contraste;
+* aumento de contraste e remoção de ruído (``gaussian`` ou ``median``);
+* binarização adaptativa;
+* correção automática de rotação e perspectiva;
+* divisão da página em múltiplas regiões de texto;
+* múltiplas tentativas de OCR com combinações diferentes de parâmetros.
+
+Um exemplo simplificado do arquivo:
+
+```json
+{
+  "lang": "por",
+  "oem": 3,
+  "psm": 6,
+  "multiple_passes": [{"psm": "6"}, {"psm": "11"}],
+  "preprocess": {
+    "adaptive_threshold": true,
+    "denoise": "gaussian",
+    "deskew": true,
+    "perspective": true
+  }
+}
+```
+
+A variável de ambiente `OCR_CONFIG_PATH` pode ser usada para apontar para um
+arquivo de configuração alternativo.
+
 
 ## Como Rodar o Projeto (Desenvolvimento)
 

--- a/ocr_config.json
+++ b/ocr_config.json
@@ -1,0 +1,23 @@
+{
+  "lang": "por",
+  "oem": 3,
+  "psm": 6,
+  "whitelist": "",
+  "blacklist": "",
+  "split_regions": false,
+  "multiple_passes": [
+    {"psm": "6"},
+    {"psm": "11"}
+  ],
+  "preprocess": {
+    "apply_sharpen": true,
+    "apply_threshold": true,
+    "adaptive_threshold": true,
+    "denoise": "gaussian",
+    "denoise_ksize": 3,
+    "brightness": 0,
+    "contrast": 1.0,
+    "deskew": true,
+    "perspective": true
+  }
+}


### PR DESCRIPTION
## Summary
- add configurable OCR pipeline with brightness/contrast, noise removal, adaptive threshold and geometric correction
- support region splitting, multiple OCR passes and character lists
- document OCR configuration options and provide default `ocr_config.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689bb1799b30832e890deee73fa944d7