### PR TITLE
Improve OCR dependency checks and document Pillow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ Orquetask é um sistema web integrado construído com Flask e Python, projetado 
 * **Frontend:** HTML5, CSS3 (Bootstrap 5), JavaScript (Vanilla JS), Quill.js
 * **Banco de Dados:** PostgreSQL
 * **ORM / Migrations:** SQLAlchemy, Alembic (via Flask-SQLAlchemy, Flask-Migrate)
-* **Principais Bibliotecas:** Werkzeug, Jinja2, psycopg2-binary, python-docx, openpyxl, xlrd, odfpy, pdf2image, pytesseract, Bleach, python-dotenv.
+* **Principais Bibliotecas:** Werkzeug, Jinja2, psycopg2-binary, python-docx, openpyxl, xlrd, odfpy, pdf2image, pytesseract, Pillow, opencv-python, Bleach, python-dotenv.
 
 ## Pré-requisitos
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ pdf2image==1.17.0
 pytesseract==0.3.10
 opencv-python==4.10.0.82
 pypdf==4.2.0
+Pillow==11.3.0


### PR DESCRIPTION
## Summary
- expand OCR dependency checks to report missing modules individually
- document Pillow and OpenCV usage
- add Pillow to requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c7674c68c832e80428b6f777d2532