### PR TITLE
feat: enhance PDF OCR metadata

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -122,7 +122,7 @@ def novo_artigo():
                 filenames.append(unique_name)
 
                 # extrai texto e descobre MIME
-                texto_extraido = extract_text(dest)
+                texto_extraido, _ = extract_text(dest)
                 mime_type, _   = guess_type(dest)
 
                 # cria o registro de attachment
@@ -317,7 +317,7 @@ def editar_artigo(artigo_id):
                 existing.append(unique_name)
 
                 # 1) extrai texto
-                texto_extraido = extract_text(dest)
+                texto_extraido, _ = extract_text(dest)
                 # 2) descobre o MIME
                 mime_type, _ = guess_type(dest)
                 # 3) adiciona o attachment ao session


### PR DESCRIPTION
## Summary
- expose OCR language and PSM list via environment variables or settings
- return consolidated metadata from extract_text and extract_text_from_pdf
- update PDF OCR to process each page with preprocessing and best PSM selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ca3393678832e843707294b28cc86