### PR TITLE
Sanitize OCR text before storing

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -277,6 +277,7 @@ def extract_text_from_image(
     text = pytesseract.image_to_string(
         rotated, lang=lang, config=f"--oem 3 --psm {best_psm}"
     )
+    text = text.replace('\x0c', '').strip()
     processing_time = time.perf_counter() - start_time
     metadata = {
         "best_psm": best_psm,
@@ -355,6 +356,7 @@ def extract_text_from_pdf(
                 text = pytesseract.image_to_string(
                     pre, lang=lang, config=f"--oem 3 --psm {best_psm}"
                 )
+                text = text.replace('\x0c', '').strip()
                 text_parts.append(text)
                 mean_conf, word_count = next(
                     ((m, w) for p, m, w in stats if p == best_psm),
@@ -401,6 +403,7 @@ def extract_text_from_pdf(
             text = pytesseract.image_to_string(
                 pre, lang=lang, config=f"--oem 3 --psm {best_psm}"
             )
+            text = text.replace('\x0c', '').strip()
             text_parts.append(text)
             mean_conf, word_count = next(
                 ((m, w) for p, m, w in stats if p == best_psm),


### PR DESCRIPTION
## Summary
- Clean OCR output by stripping form-feed characters and whitespace in `extract_text_from_image`
- Sanitize OCR output for PDF pages before adding to `text_parts`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cbc0fb3f0832ea456595edfb1d0c9