### PR TITLE
Handle missing PDF images during OCR

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -349,6 +349,25 @@ def extract_text_from_pdf(
                 except Exception as e:  # pragma: no cover - erro ao converter
                     logger.error("Erro ao converter PDF %s: %s", path, e)
                     return "\n".join(text_parts), metadata
+            if len(images) < page_number:
+                logger.error(
+                    "convert_from_path gerou apenas %s imagens para %s; pagina %s ausente",
+                    len(images),
+                    path,
+                    page_number,
+                )
+                text_parts.append("")
+                metadata.append(
+                    {
+                        "page": page_number,
+                        "best_psm": None,
+                        "mean_conf": None,
+                        "word_count": None,
+                        "conversion_failed": True,
+                    }
+                )
+                continue
+
             img = images[page_number - 1]
             try:
                 rotated_img, angle = detect_and_rotate(img)


### PR DESCRIPTION
## Summary
- guard against missing pages after converting PDFs to images
- record conversion failure in metadata when a page image is absent
- test PDF extraction when convert_from_path returns too few images

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689cbe652770832ead0ef5ea24c34bb7