### PR TITLE
Simplify PDF OCR test

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,8 +42,7 @@ def test_extract_text_image_pdf(monkeypatch, tmp_path):
     )
 
     text = extract_text(str(pdf_file))
-    assert "Texto1" in text
-    assert "Texto2" in text
+    assert text == "Texto1\nTexto2"
 
 
 def test_extract_text_from_image_simple(monkeypatch):


### PR DESCRIPTION
## Summary
- simplify PDF OCR test to check concatenated text output only

## Testing
- `pytest tests/test_utils.py::test_extract_text_image_pdf -q`

------
https://chatgpt.com/codex/tasks/task_e_689cd30eb91c832e90d810b352f5f761