### PR TITLE
Add NumPy requirement constraint and update installation docs

### DIFF
--- a/docs/GUIA_DE_INSTALACAO.md
+++ b/docs/GUIA_DE_INSTALACAO.md
@@ -171,6 +171,7 @@ configurá-las corretamente.
 Com o ambiente virtual (`venv`) ativo:
 ```bash
 pip install -r requirements.txt
+# O arquivo `requirements.txt` já impõe `numpy<2`, garantindo uma versão suportada.
 # Se ocorrerem erros de compilação (lxml, numpy ou opencv),
 # execute a reinstalação a seguir para Python 3.11:
 pip install --force-reinstall lxml "numpy<2" opencv-python python-docx

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,7 @@ Consulte o passo a passo de instalação dessas dependências e a configuração
 3.  **Instale as dependências:**
     ```bash
     pip install -r requirements.txt
+    # O arquivo `requirements.txt` já impõe `numpy<2`, garantindo uma versão suportada.
     # Caso ocorra erro envolvendo NumPy ou lxml em Python 3.11,
     # reinstale os pacotes compilados:
     pip install --force-reinstall lxml "numpy<2" opencv-python python-docx

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ Jinja2==3.1.6
 lxml==5.4.0
 Mako==1.3.10
 MarkupSafe==3.0.2
+numpy<2
 odfpy==1.4.1
 opencv-python==4.10.0.82
 openpyxl==3.1.5


### PR DESCRIPTION
## Summary
- add `numpy<2` constraint in requirements
- document that requirements install NumPy in supported version

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy - 403 Forbidden)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cdcf3bd00832eb34dde68c298fc27