### PR TITLE
Require comments for article approval

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash, session, current_app as app
 from sqlalchemy import or_, func
+import re
 
 try:
     from ..core.database import db
@@ -468,9 +469,10 @@ def aprovacao_detail(artigo_id):
 
     if request.method=='POST':
         acao       = request.form['acao']                 # aprovar / ajustar / rejeitar
-        comentario = request.form.get('comentario','').strip()
+        raw_comment = request.form.get('comentario', '').strip()
+        comentario = re.sub(r'<[^>]*?>', '', raw_comment).strip()
 
-        # Comentário obrigatório
+        # Comentário obrigatório (após remover tags HTML)
         if not comentario:
             flash('Comentário é obrigatório.', 'warning')
             return redirect(url_for('aprovacao_detail', artigo_id=artigo_id))

--- a/templates/artigos/aprovacao_detail.html
+++ b/templates/artigos/aprovacao_detail.html
@@ -60,7 +60,7 @@
             <label for="comentario" class="form-label">
               Comentário <span class="text-danger">*</span>
             </label>
-            <textarea id="comentario" name="comentario" class="form-control" rows="4" required aria-required="true"
+            <textarea id="comentario" name="comentario" class="form-control no-quill" rows="4" required aria-required="true"
               placeholder="Descreva o motivo da aprovação, ajustes ou rejeição…">{{ artigo.review_comment or '' }}</textarea>
             <div class="invalid-feedback">
               O comentário é obrigatório para prosseguir.

--- a/tests/test_required_fields.py
+++ b/tests/test_required_fields.py
@@ -58,7 +58,8 @@ def _login_user(client, perms=None):
     return uid
 
 
-def test_approve_requires_comment(client):
+@pytest.mark.parametrize("comentario", [" ", "<p><br></p>"])
+def test_approve_requires_comment(client, comentario):
     _login_user(client, [Permissao.ARTIGO_APROVAR_CELULA])
     with app.app_context():
         inst = Instituicao.query.first()
@@ -77,7 +78,7 @@ def test_approve_requires_comment(client):
         db.session.add(art)
         db.session.commit()
         aid = art.id
-    client.post(f'/aprovacao/{aid}', data={'acao': 'aprovar', 'comentario': ' '}, follow_redirects=True)
+    client.post(f'/aprovacao/{aid}', data={'acao': 'aprovar', 'comentario': comentario}, follow_redirects=True)
     with app.app_context():
         art = Article.query.get(aid)
         assert art.status == ArticleStatus.PENDENTE


### PR DESCRIPTION
## Summary
- Sanitize approval comments to strip HTML and ensure blank comments are rejected
- Avoid Quill initialization on approval comment field
- Test approval without comment, including Quill's empty output

## Testing
- `pytest tests/test_required_fields.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689cf05172d4832e87e661c20933c1fb