### PR TITLE
Render HTML in Kanban card modal

### DIFF
--- a/templates/ordens_servico/os_modal.html
+++ b/templates/ordens_servico/os_modal.html
@@ -12,10 +12,10 @@
       {% if ordem.equipamento %}<p class="mb-1"><strong>Equipamento:</strong> {{ ordem.equipamento.nome }}</p>{% endif %}
       {% if ordem.sistema %}<p class="mb-1"><strong>Sistema:</strong> {{ ordem.sistema.nome }}</p>{% endif %}
       <p class="mt-2 mb-1"><strong>Descrição:</strong></p>
-      <p class="mb-1">{{ ordem.descricao }}</p>
+      <p class="mb-1">{{ ordem.descricao|safe }}</p>
       {% if ordem.observacoes %}
       <p class="mt-2 mb-1"><strong>Observações:</strong></p>
-      <p class="mb-0">{{ ordem.observacoes }}</p>
+      <p class="mb-0">{{ ordem.observacoes|safe }}</p>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Render description and observations HTML in OS modal cards so paragraphs display correctly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cf53cf3ec832e9c62eaf0a4cfb407