### PR TITLE
Add process selection to OS type admin with step filtering

### DIFF
--- a/templates/admin/tipos_os.html
+++ b/templates/admin/tipos_os.html
@@ -65,6 +65,15 @@
               <textarea class="form-control form-control-sm" id="descricao" name="descricao" rows="2">{{ request.form.get('descricao', tipo_editar.descricao if tipo_editar else '') }}</textarea>
             </div>
             <div class="mb-1">
+              <label for="processo_id" class="form-label">Processo <span class="text-danger">*</span></label>
+              <select class="form-select form-select-sm" id="processo_id" name="processo_id" required>
+                <option value="">--</option>
+                {% for p in processos %}
+                <option value="{{ p.id }}" {% if processo_selecionado == p.id|string %}selected{% endif %}>{{ p.nome }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="mb-1">
               <label for="etapa_id" class="form-label">Etapa <span class="text-danger">*</span></label>
               <select class="form-select form-select-sm" id="etapa_id" name="etapa_id" required>
                 <option value="">--</option>
@@ -105,6 +114,27 @@
     </div>
   </div>
 </div>
+<script>
+  document.addEventListener('DOMContentLoaded', function(){
+    const processoSelect = document.getElementById('processo_id');
+    const etapaSelect = document.getElementById('etapa_id');
+    processoSelect.addEventListener('change', function(){
+      const procId = this.value;
+      etapaSelect.innerHTML = '<option value="">--</option>';
+      if (!procId) return;
+      fetch(`/admin/tipos_os/etapas/${procId}`)
+        .then(r => r.json())
+        .then(data => {
+          data.forEach(e => {
+            const opt = document.createElement('option');
+            opt.value = e.id;
+            opt.textContent = e.nome;
+            etapaSelect.appendChild(opt);
+          });
+        });
+    });
+  });
+</script>
 {% if tipo_editar %}
 <script>
   document.addEventListener('DOMContentLoaded', function(){

--- a/tests/test_ordem_servico.py
+++ b/tests/test_ordem_servico.py
@@ -436,3 +436,26 @@ def test_os_modal_endpoint(client):
     assert resp.status_code == 200
     assert 'OS modal test' in resp.get_data(as_text=True)
 
+
+def test_etapas_por_processo_endpoint(client):
+    login_admin(client)
+    with app.app_context():
+        proc1 = Processo(nome='ProcA')
+        proc2 = Processo(nome='ProcB')
+        e1 = ProcessoEtapa(nome='EtapaA', ordem=1, processo=proc1)
+        e2 = ProcessoEtapa(nome='EtapaB', ordem=1, processo=proc2)
+        db.session.add_all([proc1, proc2, e1, e2])
+        db.session.commit()
+        proc1_id, proc2_id = proc1.id, proc2.id
+        e1_id, e2_id = e1.id, e2.id
+    resp = client.get(f'/admin/tipos_os/etapas/{proc1_id}')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]['id'] == e1_id
+    resp = client.get(f'/admin/tipos_os/etapas/{proc2_id}')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]['id'] == e2_id
+


### PR DESCRIPTION
## Summary
- add Processo dropdown and Etapa filtering when managing Tipos de OS
- expose endpoint to list etapas for a given processo
- test etapas retrieval API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cf5d91644832ead64426ef0df6340