### PR TITLE
feat(admin): expand dashboard with animated charts

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -102,6 +102,21 @@ def admin_dashboard():
     notifications_unread = Notification.query.filter_by(lido=False).count()
     notifications_read = Notification.query.filter_by(lido=True).count()
 
+    system_counts = {
+        "Usuários": user_total,
+        "Artigos": Article.query.count(),
+        "Revisões": RevisionRequest.query.count(),
+        "Comentários": Comment.query.count(),
+        "Anexos": Attachment.query.count(),
+        "Instituições": Instituicao.query.count(),
+        "Estabelecimentos": Estabelecimento.query.count(),
+        "Setores": Setor.query.count(),
+        "Células": Celula.query.count(),
+        "Cargos": Cargo.query.count(),
+        "Funções": Funcao.query.count(),
+        "Notificações": notifications_read + notifications_unread,
+    }
+
     return render_template(
         "admin/dashboard.html",
         user_total=user_total,
@@ -110,6 +125,7 @@ def admin_dashboard():
         article_status_counts=status_counts,
         notifications_unread=notifications_unread,
         notifications_read=notifications_read,
+        system_counts=system_counts,
     )
 
 @admin_bp.route('/admin/instituicoes', methods=['GET', 'POST'])

--- a/static/css/admin_dashboard.css
+++ b/static/css/admin_dashboard.css
@@ -1,0 +1,21 @@
+.dashboard-chart {
+    animation: fadeIn 1.5s ease-in-out;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: scale(0.95); }
+    to { opacity: 1; transform: scale(1); }
+}
+
+.futuristic-card {
+    background: linear-gradient(145deg, #1e1e2f, #2e2e47);
+    box-shadow: 0 0 15px rgba(0, 255, 255, 0.3);
+    border: none;
+    color: #fff;
+}
+
+.futuristic-card .card-header {
+    background: transparent;
+    border-bottom: 1px solid rgba(0, 255, 255, 0.2);
+    color: #0ff;
+}

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -9,7 +9,7 @@
 
         <div class="row">
             <div class="col-md-6 mb-4">
-                <div class="card">
+                <div class="card futuristic-card">
                     <div class="card-header">Usuários Ativos</div>
                     <div class="card-body">
                         <canvas id="usersChart" class="dashboard-chart"></canvas>
@@ -17,7 +17,7 @@
                 </div>
             </div>
             <div class="col-md-6 mb-4">
-                <div class="card">
+                <div class="card futuristic-card">
                     <div class="card-header">Artigos por Status</div>
                     <div class="card-body">
                         <canvas id="articlesChart" class="dashboard-chart"></canvas>
@@ -25,13 +25,52 @@
                 </div>
             </div>
         </div>
+
+        <div class="row">
+            <div class="col-md-6 mb-4">
+                <div class="card futuristic-card">
+                    <div class="card-header">Notificações</div>
+                    <div class="card-body">
+                        <canvas id="notificationsChart" class="dashboard-chart"></canvas>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6 mb-4">
+                <div class="card futuristic-card">
+                    <div class="card-header">Entidades no Sistema</div>
+                    <div class="card-body">
+                        <canvas id="systemChart" class="dashboard-chart"></canvas>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
+{% endblock %}
+
+{% block extra_css %}
+    {{ super() }}
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/admin_dashboard.css') }}">
 {% endblock %}
 
 {% block extra_js %}
     {{ super() }}
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
+        const baseOptions = {
+            animation: {
+                duration: 2000,
+                easing: 'easeInOutQuart'
+            },
+            plugins: {
+                legend: { labels: { color: '#fff' } }
+            },
+            scales: {
+                r: { angleLines: { color: '#444' }, grid: { color: '#444' }, ticks: { color: '#aaa' }, pointLabels: { color: '#fff' } },
+                x: { ticks: { color: '#fff' }, grid: { color: '#333' } },
+                y: { ticks: { color: '#fff' }, grid: { color: '#333' }, beginAtZero: true }
+            }
+        };
+
         const usersData = {
             labels: ['Ativos', 'Inativos'],
             datasets: [{
@@ -41,7 +80,8 @@
         };
         new Chart(document.getElementById('usersChart'), {
             type: 'doughnut',
-            data: usersData
+            data: usersData,
+            options: baseOptions
         });
 
         const articleData = {{ article_status_counts|tojson }};
@@ -55,7 +95,40 @@
                     backgroundColor: 'rgba(54, 162, 235, 0.6)'
                 }]
             },
-            options: {scales: {y: {beginAtZero: true}}}
+            options: baseOptions
+        });
+
+        const notificationsData = {
+            labels: ['Lidas', 'Não Lidas'],
+            datasets: [{
+                data: [{{ notifications_read }}, {{ notifications_unread }}],
+                backgroundColor: ['#0d6efd', '#ffc107']
+            }]
+        };
+        new Chart(document.getElementById('notificationsChart'), {
+            type: 'doughnut',
+            data: notificationsData,
+            options: baseOptions
+        });
+
+        const systemData = {{ system_counts|tojson }};
+        const ctxSys = document.getElementById('systemChart').getContext('2d');
+        const gradient = ctxSys.createLinearGradient(0, 0, 0, 300);
+        gradient.addColorStop(0, 'rgba(0, 255, 255, 0.6)');
+        gradient.addColorStop(1, 'rgba(0, 0, 255, 0.6)');
+        new Chart(ctxSys, {
+            type: 'radar',
+            data: {
+                labels: Object.keys(systemData),
+                datasets: [{
+                    label: 'Quantidade',
+                    data: Object.values(systemData),
+                    backgroundColor: gradient,
+                    borderColor: 'rgba(0, 255, 255, 0.8)',
+                    borderWidth: 2
+                }]
+            },
+            options: baseOptions
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enrich admin dashboard with counts from all core models
- add futuristic styling and animated charts for users, articles, notifications and entities

## Testing
- `pytest tests/test_admin_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_689cfad66564832e9c6db5ad3b433c6e