### PR TITLE
Refatora listagem de cargos e adiciona gráfico de OS por célula

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -20,6 +20,7 @@ try:
         Setor,
         Cargo,
         Funcao,
+        OrdemServico,
     )
 except ImportError:  # pragma: no cover
     from core.models import (
@@ -35,6 +36,7 @@ except ImportError:  # pragma: no cover
         Setor,
         Cargo,
         Funcao,
+        OrdemServico,
     )
 
 try:
@@ -101,21 +103,12 @@ def admin_dashboard():
 
     notifications_unread = Notification.query.filter_by(lido=False).count()
     notifications_read = Notification.query.filter_by(lido=True).count()
-
-    system_counts = {
-        "Usuários": user_total,
-        "Artigos": Article.query.count(),
-        "Revisões": RevisionRequest.query.count(),
-        "Comentários": Comment.query.count(),
-        "Anexos": Attachment.query.count(),
-        "Instituições": Instituicao.query.count(),
-        "Estabelecimentos": Estabelecimento.query.count(),
-        "Setores": Setor.query.count(),
-        "Células": Celula.query.count(),
-        "Cargos": Cargo.query.count(),
-        "Funções": Funcao.query.count(),
-        "Notificações": notifications_read + notifications_unread,
-    }
+    os_por_celula = dict(
+        db.session.query(Celula.nome, func.count(OrdemServico.id))
+        .join(OrdemServico, OrdemServico.equipe_responsavel_id == Celula.id)
+        .group_by(Celula.nome)
+        .all()
+    )
 
     return render_template(
         "admin/dashboard.html",
@@ -125,7 +118,7 @@ def admin_dashboard():
         article_status_counts=status_counts,
         notifications_unread=notifications_unread,
         notifications_read=notifications_read,
-        system_counts=system_counts,
+        os_por_celula=os_por_celula,
     )
 
 @admin_bp.route('/admin/instituicoes', methods=['GET', 'POST'])

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -227,24 +227,66 @@ body > .container {
 
 /* Hierarquia de cargos */
 .caret-toggle .bi {
-  transition: transform .2s ease;
+  transition: none;
 }
-.caret-toggle.expanded .bi {
-  transform: rotate(90deg);
+
+.instituicao-container {
+  margin-bottom: 1.5rem;
+}
+
+.estabelecimento-wrapper {
+  background-color: var(--bg-muted);
+  border: 1px solid var(--border-default);
+  border-radius: 0.25rem;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.instituicao-container .estabelecimento-wrapper:first-child {
+  margin-top: 1rem;
 }
 
 .setor-container {
   margin-left: 1rem;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+  background-color: var(--bg-hover);
+  border: 1px solid var(--border-light);
+  border-radius: 0.25rem;
 }
+
 .celula-container {
   margin-left: 2rem;
+  margin-bottom: 0.5rem;
   border-left: 1px solid var(--border-default);
   padding-left: 1rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  background-color: var(--bg-hover-subtle);
 }
+
 .cargo-item {
   margin-left: 3rem;
+  margin-bottom: 0.25rem;
   border-left: 1px solid var(--border-lighter);
   padding-left: 1rem;
+  background-color: var(--bg-default);
+}
+
+.linha-cargo {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.nome-cargo {
+  cursor: pointer;
+}
+
+.acoes-cargo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .search-highlight {

--- a/templates/admin/cargos.html
+++ b/templates/admin/cargos.html
@@ -23,13 +23,12 @@
                 <div class="tab-pane fade show active p-3" id="consulta" role="tabpanel" aria-labelledby="consulta-tab">
                     <div class="card shadow-sm mb-4">
                         <div class="card-header">
-                            <h5 class="mb-0"><i class="bi bi-list-ul me-2"></i>Cargos Cadastrados ({{ cargos|length }})</h5>
+                            <h5 class="mb-0">Cargos Cadastrados</h5>
                         </div>
                         <div class="card-body">
                             {% if estrutura %}
                                 <div class="mb-3">
                                     <div class="input-group">
-                                        <span class="input-group-text"><i class="bi bi-search"></i></span>
                                         <input type="text" id="cargoSearch" class="form-control" placeholder="Buscar por cargo, setor, célula ou instituição">
                                     </div>
                                 </div>
@@ -42,10 +41,11 @@
                                             </div>
                                             <div id="inst-{{ inst.obj.id }}" class="collapse show">
                                                 {% for est in inst.estabelecimentos %}
-                                                    <div class="ms-4 estabelecimento-container">
+                                                    <div class="ms-4 mb-3 p-2 border rounded estabelecimento-wrapper">
                                                         <h6 class="fw-bold">Estabelecimento: <span class="est-name" data-name="{{ est.obj.nome_fantasia }}">{{ est.obj.nome_fantasia }}</span></h6>
-                                                        {% for setor in est.setores %}
-                                                            <div class="setor-container border rounded p-2 mb-2">
+                                                        <div class="estabelecimento-conteudo mt-2">
+                                                            {% for setor in est.setores %}
+                                                            <div class="setor-container p-2 mb-2 rounded">
                                                                 <div class="d-flex align-items-center">
                                                                     <button class="btn btn-sm btn-link p-0 me-2 toggle-section caret-toggle expanded" data-level="celulas" data-bs-toggle="collapse" data-bs-target="#setor-{{ setor.obj.id }}" aria-expanded="true"><i class="bi bi-caret-right-fill"></i></button>
                                                                     <strong class="mb-0">Setor: <span class="setor-name" data-name="{{ setor.obj.nome }}">{{ setor.obj.nome }}</span></strong>
@@ -54,37 +54,31 @@
                                                                     {% if setor.cargos %}
                                                                         <ul class="list-group list-group-flush mb-2">
                                                                             {% for cargo in setor.cargos %}
-                                                                            <li class="list-group-item d-flex justify-content-between align-items-center cargo-item {{ 'text-muted' if not cargo.ativo else '' }}" data-cargo="{{ cargo.nome }}" data-setor="{{ setor.obj.nome }}" data-celula="" data-instituicao="{{ inst.obj.nome }}">
-                                                                                <span>
-                                                                                    <span class="cargo-name" data-name="{{ cargo.nome }}">{{ cargo.nome }}</span>
-                                                                                {% if cargo.pode_atender_os %}
-                                                                                    <span class="badge bg-info text-dark ms-2">Atende OS</span>
-                                                                                {% endif %}
-                                                                            </span>
-                                                                            <div class="d-flex align-items-center">
-                                                                                <a href="{{ url_for('admin_cargos', edit_id=cargo.id) }}#cadastro" class="btn btn-sm btn-outline-primary me-1" title="Editar Cargo">
-                                                                                    <i class="bi bi-pencil-fill"></i>
-                                                                                </a>
-                                                                                {% set confirm_message_text = 'DESATIVAR' if cargo.ativo else 'ATIVAR' %}
-                                                                                {% set cargo_nome_js = cargo.nome | tojson %}
-                                                                                <form action="{{ url_for('admin_toggle_ativo_cargo', id=cargo.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_message_text }} o cargo ' + {{ cargo_nome_js }} + '?');">
-                                                                                    {% if cargo.ativo %}
-                                                                                        <button type="submit" class="btn btn-sm btn-outline-warning me-1" title="Desativar Cargo">
-                                                                                            <i class="bi bi-archive-fill"></i>
-                                                                                        </button>
-                                                                                    {% else %}
-                                                                                        <button type="submit" class="btn btn-sm btn-outline-success me-1" title="Ativar Cargo">
-                                                                                            <i class="bi bi-archive-restore-fill"></i>
-                                                                                        </button>
-                                                                                    {% endif %}
-                                                                                </form>
-                                                                                <a href="{{ url_for('admin_cargos', edit_id=cargo.id) }}#permissoes" class="btn btn-sm btn-outline-secondary" title="Gerenciar Permissões">
-                                                                                    <i class="bi bi-shield-lock-fill"></i>
-                                                                                </a>
-                                                                            </div>
-                                                                        </li>
-                                                                        {% endfor %}
-                                                                    </ul>
+                                                                                <li class="list-group-item cargo-item {{ 'text-muted' if not cargo.ativo else '' }}" data-cargo="{{ cargo.nome }}" data-setor="{{ setor.obj.nome }}" data-celula="" data-instituicao="{{ inst.obj.nome }}">
+                                                                                    <div class="linha-cargo">
+                                                                                        <div class="nome-cargo cargo-name" data-name="{{ cargo.nome }}" data-url="{{ url_for('admin_cargos', edit_id=cargo.id) }}#cadastro">{{ cargo.nome }}</div>
+                                                                                        <div class="acoes-cargo">
+                                                                                            {% if cargo.pode_atender_os %}
+                                                                                                <span class="badge bg-info text-dark">Atende OS</span>
+                                                                                            {% endif %}
+                                                                                            {% set confirm_message_text = 'DESATIVAR' if cargo.ativo else 'ATIVAR' %}
+                                                                                            {% set cargo_nome_js = cargo.nome | tojson %}
+                                                                                            <form action="{{ url_for('admin_toggle_ativo_cargo', id=cargo.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_message_text }} o cargo ' + {{ cargo_nome_js }} + '?');">
+                                                                                                {% if cargo.ativo %}
+                                                                                                    <button type="submit" class="btn btn-sm btn-outline-warning" title="Desativar Cargo">
+                                                                                                        <i class="bi bi-archive-fill"></i>
+                                                                                                    </button>
+                                                                                                {% else %}
+                                                                                                    <button type="submit" class="btn btn-sm btn-outline-success" title="Ativar Cargo">
+                                                                                                        <i class="bi bi-archive-restore-fill"></i>
+                                                                                                    </button>
+                                                                                                {% endif %}
+                                                                                            </form>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                </li>
+                                                                            {% endfor %}
+                                                                        </ul>
                                                                     {% endif %}
                                                                     {% for cel in setor.celulas %}
                                                                         <div class="celula-container ps-3 mb-2">
@@ -96,35 +90,29 @@
                                                                                 {% if cel.cargos %}
                                                                                     <ul class="list-group list-group-flush">
                                                                                         {% for cargo in cel.cargos %}
-                                                                                        <li class="list-group-item d-flex justify-content-between align-items-center cargo-item {{ 'text-muted' if not cargo.ativo else '' }}" data-cargo="{{ cargo.nome }}" data-setor="{{ setor.obj.nome }}" data-celula="{{ cel.obj.nome }}" data-instituicao="{{ inst.obj.nome }}">
-                                                                                            <span>
-                                                                                                <span class="cargo-name" data-name="{{ cargo.nome }}">{{ cargo.nome }}</span>
-                                                                                                {% if cargo.pode_atender_os %}
-                                                                                                    <span class="badge bg-info text-dark ms-2">Atende OS</span>
-                                                                                                {% endif %}
-                                                                                            </span>
-                                                                                            <div class="d-flex align-items-center">
-                                                                                                <a href="{{ url_for('admin_cargos', edit_id=cargo.id) }}#cadastro" class="btn btn-sm btn-outline-primary me-1" title="Editar Cargo">
-                                                                                                    <i class="bi bi-pencil-fill"></i>
-                                                                                                </a>
-                                                                                                {% set confirm_message_text = 'DESATIVAR' if cargo.ativo else 'ATIVAR' %}
-                                                                                                {% set cargo_nome_js = cargo.nome | tojson %}
-                                                                                                <form action="{{ url_for('admin_toggle_ativo_cargo', id=cargo.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_message_text }} o cargo ' + {{ cargo_nome_js }} + '?');">
-                                                                                                    {% if cargo.ativo %}
-                                                                                                        <button type="submit" class="btn btn-sm btn-outline-warning me-1" title="Desativar Cargo">
-                                                                                                            <i class="bi bi-archive-fill"></i>
-                                                                                                        </button>
-                                                                                                    {% else %}
-                                                                                                        <button type="submit" class="btn btn-sm btn-outline-success me-1" title="Ativar Cargo">
-                                                                                                            <i class="bi bi-archive-restore-fill"></i>
-                                                                                                        </button>
-                                                                                                    {% endif %}
-                                                                                                </form>
-                                                                                                <a href="{{ url_for('admin_cargos', edit_id=cargo.id) }}#permissoes" class="btn btn-sm btn-outline-secondary" title="Gerenciar Permissões">
-                                                                                                    <i class="bi bi-shield-lock-fill"></i>
-                                                                                                </a>
-                                                                                            </div>
-                                                                                        </li>
+                                                                                            <li class="list-group-item cargo-item {{ 'text-muted' if not cargo.ativo else '' }}" data-cargo="{{ cargo.nome }}" data-setor="{{ setor.obj.nome }}" data-celula="{{ cel.obj.nome }}" data-instituicao="{{ inst.obj.nome }}">
+                                                                                                <div class="linha-cargo">
+                                                                                                    <div class="nome-cargo cargo-name" data-name="{{ cargo.nome }}" data-url="{{ url_for('admin_cargos', edit_id=cargo.id) }}#cadastro">{{ cargo.nome }}</div>
+                                                                                                    <div class="acoes-cargo">
+                                                                                                        {% if cargo.pode_atender_os %}
+                                                                                                            <span class="badge bg-info text-dark">Atende OS</span>
+                                                                                                        {% endif %}
+                                                                                                        {% set confirm_message_text = 'DESATIVAR' if cargo.ativo else 'ATIVAR' %}
+                                                                                                        {% set cargo_nome_js = cargo.nome | tojson %}
+                                                                                                        <form action="{{ url_for('admin_toggle_ativo_cargo', id=cargo.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_message_text }} o cargo ' + {{ cargo_nome_js }} + '?');">
+                                                                                                            {% if cargo.ativo %}
+                                                                                                                <button type="submit" class="btn btn-sm btn-outline-warning" title="Desativar Cargo">
+                                                                                                                    <i class="bi bi-archive-fill"></i>
+                                                                                                                </button>
+                                                                                                            {% else %}
+                                                                                                                <button type="submit" class="btn btn-sm btn-outline-success" title="Ativar Cargo">
+                                                                                                                    <i class="bi bi-archive-restore-fill"></i>
+                                                                                                                </button>
+                                                                                                            {% endif %}
+                                                                                                        </form>
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                            </li>
                                                                                         {% endfor %}
                                                                                     </ul>
                                                                                 {% else %}
@@ -135,7 +123,8 @@
                                                                     {% endfor %}
                                                                 </div>
                                                             </div>
-                                                        {% endfor %}
+                                                            {% endfor %}
+                                                        </div>
                                                     </div>
                                                 {% endfor %}
                                             </div>
@@ -467,27 +456,28 @@
 {% block extra_js %}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    const mostrarSetores = {};
-    const mostrarCelulas = {};
-    const mostrarCargos = {};
-
     document.querySelectorAll('.toggle-section').forEach(function(btn) {
         const targetSelector = btn.getAttribute('data-bs-target');
-        const level = btn.dataset.level;
         const target = document.querySelector(targetSelector);
-        const stateMap = level === 'celulas' ? mostrarCelulas : level === 'cargos' ? mostrarCargos : mostrarSetores;
-        stateMap[targetSelector] = true;
+        const icon = btn.querySelector('i');
 
-        btn.addEventListener('click', function() {
-            setTimeout(function() {
-                if (target.classList.contains('show')) {
-                    btn.classList.add('expanded');
-                    stateMap[targetSelector] = true;
-                } else {
-                    btn.classList.remove('expanded');
-                    stateMap[targetSelector] = false;
-                }
-            }, 200);
+        if (target.classList.contains('show') && icon) {
+            icon.classList.replace('bi-caret-right-fill', 'bi-caret-down-fill');
+        }
+
+        target.addEventListener('shown.bs.collapse', function() {
+            if (icon) icon.classList.replace('bi-caret-right-fill', 'bi-caret-down-fill');
+        });
+
+        target.addEventListener('hidden.bs.collapse', function() {
+            if (icon) icon.classList.replace('bi-caret-down-fill', 'bi-caret-right-fill');
+        });
+    });
+
+    document.querySelectorAll('.cargo-name').forEach(function(el) {
+        el.addEventListener('click', function() {
+            const url = el.dataset.url;
+            if (url) window.location.href = url;
         });
     });
 

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -37,9 +37,9 @@
             </div>
             <div class="col-md-6 mb-4">
                 <div class="card futuristic-card">
-                    <div class="card-header">Entidades no Sistema</div>
+                    <div class="card-header">OS por Célula</div>
                     <div class="card-body">
-                        <canvas id="systemChart" class="dashboard-chart"></canvas>
+                        <canvas id="osCellChart" class="dashboard-chart"></canvas>
                     </div>
                 </div>
             </div>
@@ -111,21 +111,15 @@
             options: baseOptions
         });
 
-        const systemData = {{ system_counts|tojson }};
-        const ctxSys = document.getElementById('systemChart').getContext('2d');
-        const gradient = ctxSys.createLinearGradient(0, 0, 0, 300);
-        gradient.addColorStop(0, 'rgba(0, 255, 255, 0.6)');
-        gradient.addColorStop(1, 'rgba(0, 0, 255, 0.6)');
-        new Chart(ctxSys, {
-            type: 'radar',
+        const osCellData = {{ os_por_celula|tojson }};
+        new Chart(document.getElementById('osCellChart'), {
+            type: 'bar',
             data: {
-                labels: Object.keys(systemData),
+                labels: Object.keys(osCellData),
                 datasets: [{
-                    label: 'Quantidade',
-                    data: Object.values(systemData),
-                    backgroundColor: gradient,
-                    borderColor: 'rgba(0, 255, 255, 0.8)',
-                    borderWidth: 2
+                    label: 'OS',
+                    data: Object.values(osCellData),
+                    backgroundColor: 'rgba(255, 99, 132, 0.6)'
                 }]
             },
             options: baseOptions


### PR DESCRIPTION
## Resumo
- Ajusta espaçamento e cores hierárquicas dos cargos compatíveis com temas claro e escuro
- Corrige ícones de colapso/expansão e torna nome do cargo uma div clicável que abre o modal
- Substitui gráfico de entidades por gráfico de OS por célula no dashboard

## Testes
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e22a2c200832e8f32423e4e41bfac