### PR TITLE
Filtra células por setor nas etapas do processo

### DIFF
--- a/blueprints/processos.py
+++ b/blueprints/processos.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, request, redirect, url_for, flash, current_app as app
+from flask import Blueprint, render_template, request, redirect, url_for, flash, current_app as app, jsonify
 
 try:
     from ..core.database import db
@@ -147,6 +147,13 @@ def admin_etapas(processo_id):
     setores = Setor.query.order_by(Setor.nome).all()
     celulas = Celula.query.order_by(Celula.nome).all()
     return render_template('admin/etapas.html', processo=proc, etapas=etapas, etapa_editar=etapa_para_editar, setores=setores, celulas=celulas)
+
+
+@processos_bp.get('/admin/setores/<int:setor_id>/celulas')
+@admin_required
+def celulas_por_setor(setor_id):
+    celulas = Celula.query.filter_by(setor_id=setor_id).order_by(Celula.nome).all()
+    return jsonify([{'id': c.id, 'nome': c.nome} for c in celulas])
 
 @processos_bp.route('/admin/etapas/delete/<etapa_id>', methods=['POST'])
 @admin_required

--- a/templates/admin/etapas.html
+++ b/templates/admin/etapas.html
@@ -175,6 +175,42 @@
 </div>
 {% endblock content %}
 {% block extra_js %}
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        function atualizarCelulas(setorSelect, celulaSelect, selecionada) {
+            celulaSelect.innerHTML = '<option value="">-- Nenhuma --</option>';
+            var setorId = setorSelect.value;
+            if (!setorId) return;
+            fetch(`/admin/setores/${setorId}/celulas`)
+                .then(r => r.json())
+                .then(data => {
+                    data.forEach(c => {
+                        var opt = document.createElement('option');
+                        opt.value = c.id;
+                        opt.textContent = c.nome;
+                        if (selecionada && selecionada == c.id) opt.selected = true;
+                        celulaSelect.appendChild(opt);
+                    });
+                });
+        }
+
+        function vincular(setorId, celulaId) {
+            var setorSelect = document.getElementById(setorId);
+            var celulaSelect = document.getElementById(celulaId);
+            if (!setorSelect || !celulaSelect) return;
+            setorSelect.addEventListener('change', function(){
+                atualizarCelulas(setorSelect, celulaSelect);
+            });
+            if (setorSelect.value) {
+                var selecionada = celulaSelect.value;
+                atualizarCelulas(setorSelect, celulaSelect, selecionada);
+            }
+        }
+
+        vincular('setor_responsavel_id', 'celula_responsavel_id');
+        vincular('edit_setor_responsavel_id', 'edit_celula_responsavel_id');
+    });
+</script>
 {% if etapa_editar %}
 <script>
     document.addEventListener('DOMContentLoaded', function() {

--- a/tests/test_processos.py
+++ b/tests/test_processos.py
@@ -1,6 +1,17 @@
 import pytest
 from app import app, db
-from core.models import Processo, EtapaProcesso, CampoEtapa, RespostaEtapaOS, User, Instituicao, Estabelecimento, Setor, Celula
+from core.models import (
+    Processo,
+    EtapaProcesso,
+    CampoEtapa,
+    RespostaEtapaOS,
+    User,
+    Instituicao,
+    Estabelecimento,
+    Setor,
+    Celula,
+    Funcao,
+)
 
 @pytest.fixture
 def base_app(app_ctx):
@@ -17,6 +28,23 @@ def base_app(app_ctx):
         with app_ctx.test_client() as c:
             c.user = user
             yield c
+
+
+def login_admin(client):
+    with app.app_context():
+        inst = Instituicao(codigo='INST001', nome='Inst')
+        est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao=inst)
+        setor = Setor(nome='S1', estabelecimento=est)
+        cel = Celula(nome='C1', estabelecimento=est, setor=setor)
+        func = Funcao(codigo='admin', nome='Admin')
+        user = User(username='admin', email='a@test', estabelecimento=est, setor=setor, celula=cel)
+        user.set_password('x')
+        user.permissoes_personalizadas.append(func)
+        db.session.add_all([inst, est, setor, cel, func, user])
+        db.session.commit()
+        uid = user.id
+    with client.session_transaction() as sess:
+        sess['user_id'] = uid
 
 def test_create_process_flow(base_app):
     with app.app_context():
@@ -36,3 +64,25 @@ def test_create_process_flow(base_app):
         assert etapa.processo_id == processo.id
         assert campo.etapa_id == etapa.id
         assert resp.campo_etapa_id == campo.id
+
+
+def test_celulas_por_setor_endpoint(client):
+    login_admin(client)
+    with app.app_context():
+        est = Estabelecimento.query.first()
+        setor1 = Setor.query.filter_by(nome='S1').first()
+        setor2 = Setor(nome='S2', estabelecimento=est)
+        cel1 = Celula.query.filter_by(nome='C1').first()
+        cel2 = Celula(nome='C2', estabelecimento=est, setor=setor2)
+        db.session.add_all([setor2, cel2])
+        db.session.commit()
+        s1_id, s2_id = setor1.id, setor2.id
+        c1_id, c2_id = cel1.id, cel2.id
+    resp = client.get(f'/admin/setores/{s1_id}/celulas')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1 and data[0]['id'] == c1_id
+    resp = client.get(f'/admin/setores/{s2_id}/celulas')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1 and data[0]['id'] == c2_id


### PR DESCRIPTION
## Resumo
- Adiciona endpoint que retorna células de um setor para uso no cadastro de etapas
- Atualiza formulário de etapas para preencher a lista de células conforme o setor selecionado
- Cobre nova rota com teste que garante o retorno correto das células

## Testes
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a47eb8b010832ea443d82bcdb0beb5