### PR TITLE
feat: add number field to form builder

### DIFF
--- a/static/js/form_builder.js
+++ b/static/js/form_builder.js
@@ -303,6 +303,7 @@ document.addEventListener('DOMContentLoaded', () => {
             <option value="option">Opção</option>
             <option value="rating">Classificação</option>
             <option value="date">Data</option>
+            <option value="number">Número</option>
             <option value="likert">Likert</option>
             <option value="file">Carregar Arquivo</option>
             <option value="nps">Net Promoter Score®</option>
@@ -625,6 +626,7 @@ document.addEventListener('DOMContentLoaded', () => {
               <li><button class="dropdown-item" type="button" data-type="option">Opção</button></li>
               <li><button class="dropdown-item" type="button" data-type="rating">Classificação</button></li>
               <li><button class="dropdown-item" type="button" data-type="date">Data</button></li>
+              <li><button class="dropdown-item" type="button" data-type="number">Número</button></li>
               <li><button class="dropdown-item" type="button" data-type="likert">Likert</button></li>
               <li><button class="dropdown-item" type="button" data-type="file">Carregar Arquivo</button></li>
               <li><button class="dropdown-item" type="button" data-type="nps">Net Promoter Score®</button></li>
@@ -835,6 +837,7 @@ document.addEventListener('DOMContentLoaded', () => {
             <li><button class="dropdown-item" type="button" data-type="option">Opção</button></li>
             <li><button class="dropdown-item" type="button" data-type="rating">Classificação</button></li>
             <li><button class="dropdown-item" type="button" data-type="date">Data</button></li>
+            <li><button class="dropdown-item" type="button" data-type="number">Número</button></li>
             <li><button class="dropdown-item" type="button" data-type="likert">Likert</button></li>
             <li><button class="dropdown-item" type="button" data-type="file">Carregar Arquivo</button></li>
             <li><button class="dropdown-item" type="button" data-type="nps">Net Promoter Score®</button></li>

--- a/templates/formularios/cadastro_formulario.html
+++ b/templates/formularios/cadastro_formulario.html
@@ -33,6 +33,7 @@
                 <li><button class="dropdown-item" type="button" onclick="addField('option')">Opção</button></li>
                 <li><button class="dropdown-item" type="button" onclick="addField('rating')">Classificação</button></li>
                 <li><button class="dropdown-item" type="button" onclick="addField('date')">Data</button></li>
+                <li><button class="dropdown-item" type="button" onclick="addField('number')">Número</button></li>
                 <li><button class="dropdown-item" type="button" onclick="addField('likert')">Likert</button></li>
                 <li><button class="dropdown-item" type="button" onclick="addField('file')">Carregar Arquivo</button></li>
                 <li><button class="dropdown-item" type="button" onclick="addField('nps')">Net Promoter Score®</button></li>

--- a/templates/formularios/preencher_formulario.html
+++ b/templates/formularios/preencher_formulario.html
@@ -73,6 +73,8 @@
             </select>
           {% elif campo.tipo == 'date' %}
             <input type="date" class="form-control date-field" placeholder="dd/mm/aaaa" {% if campo.obrigatoria %}required{% endif %}>
+          {% elif campo.tipo == 'number' %}
+            <input type="number" class="form-control" {% if campo.obrigatoria %}required{% endif %}>
           {% elif campo.tipo == 'likert' %}
             {% set linhas = campo.linhas if campo.linhas else ['Item 1'] %}
             {% set colunas = campo.colunas if campo.colunas else ['Discordo totalmente','Discordo','Neutro','Concordo','Concordo totalmente'] %}

--- a/templates/ordens_servico/_formulario_vinculado.html
+++ b/templates/ordens_servico/_formulario_vinculado.html
@@ -61,6 +61,8 @@
     </select>
   {% elif campo.tipo == 'date' %}
     <input type="date" class="form-control date-field" placeholder="dd/mm/aaaa" {% if campo.obrigatoria %}required{% endif %}>
+  {% elif campo.tipo == 'number' %}
+    <input type="number" class="form-control" {% if campo.obrigatoria %}required{% endif %}>
   {% elif campo.tipo == 'likert' %}
     {% set linhas = campo.linhas if campo.linhas else ['Item 1'] %}
     {% set colunas = campo.colunas if campo.colunas else ['Discordo totalmente','Discordo','Neutro','Concordo','Concordo totalmente'] %}

--- a/tests/test_form_builder.py
+++ b/tests/test_form_builder.py
@@ -122,6 +122,22 @@ def test_field_added_after_type_selection(client):
     html = resp.data.decode('utf-8')
     assert 'id="previewContainer"' in html
     assert "onclick=\"addField('text')\"" in html
+    assert "onclick=\"addField('number')\"" in html
+
+
+def test_render_number_field(client):
+    with app.app_context():
+        user_allowed_id = create_user('number_field', True)
+    login(client, user_allowed_id)
+    estrutura = '[{"id":1,"tipo":"number","label":"Idade","ordem":0}]'
+    resp = client.post('/ordem-servico/formularios/', data={'nome': 'FormNum', 'estrutura': estrutura}, follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        form = Formulario.query.filter_by(nome='FormNum').first()
+        form_id = form.id
+    resp = client.get(f'/ordem-servico/formularios/{form_id}/preencher')
+    assert resp.status_code == 200
+    assert '<input type="number"' in resp.data.decode('utf-8')
 
 
 def test_section_model_relationship(app_ctx):


### PR DESCRIPTION
## Summary
- allow adding numeric questions in form builder UI
- render numeric fields when filling forms
- cover new number field with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a48f909ecc832eb34fa401289fcaa4