### PR TITLE
Fix collapse on drag in form builder

### DIFF
--- a/static/js/form_builder.js
+++ b/static/js/form_builder.js
@@ -251,10 +251,10 @@ document.addEventListener('DOMContentLoaded', () => {
       ghostClass: 'sortable-ghost',
       chosenClass: 'sortable-chosen',
       onStart: () => {
-        if (container === fieldsContainer) fieldsContainer.classList.add('sorting');
+        fieldsContainer.classList.add('sorting');
       },
       onEnd: () => {
-        if (container === fieldsContainer) fieldsContainer.classList.remove('sorting');
+        fieldsContainer.classList.remove('sorting');
         updateNumbers();
         updateJSON();
         const ids = Array.from(fieldsContainer.querySelectorAll('.field'))


### PR DESCRIPTION
## Summary
- Always toggle `sorting` class when dragging form questions so all fields collapse

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a493ef6994832ea9e35b66221875cc