### PR TITLE
Corrige travamento do botão Próximo em formulários ramificados

### DIFF
--- a/templates/formularios/preencher_formulario.html
+++ b/templates/formularios/preencher_formulario.html
@@ -287,7 +287,7 @@ document.addEventListener('DOMContentLoaded', () => {
           if (rule.destino === 'end') return -1;
           if (rule.destino !== 'next') {
             const destIdx = findSectionByQuestionId(rule.destino);
-            if (destIdx !== -1) return destIdx;
+            if (destIdx !== -1 && destIdx !== idx) return destIdx;
           }
         }
       }


### PR DESCRIPTION
## Summary
- Evita que a navegação de seções fique presa quando uma ramificação aponta para uma pergunta na mesma seção

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4960b7114832e8c791c63f2e417b2