### PR TITLE
Refatora campos da Ordem de Serviço

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -584,7 +584,6 @@ class OrdemServico(db.Model):
     id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     codigo = db.Column(db.String(7), unique=True, nullable=False)
     titulo = db.Column(db.String(255), nullable=False)
-    descricao = db.Column(db.Text, nullable=False)
     tipo_os_id = db.Column(db.Integer, db.ForeignKey('tipo_os.id'), nullable=False)
     status = db.Column(
         db.String(50),
@@ -601,7 +600,6 @@ class OrdemServico(db.Model):
     prioridade = db.Column(db.String(10), nullable=True)
     equipamento_id = db.Column(db.Integer, db.ForeignKey('equipamento.id'), nullable=True)
     sistema_id = db.Column(db.Integer, db.ForeignKey('sistema.id'), nullable=True)
-    observacoes = db.Column(db.Text, nullable=True)
 
     criado_por = db.relationship('User', foreign_keys=[criado_por_id])
     atribuido_para = db.relationship('User', foreign_keys=[atribuido_para_id])

--- a/migrations/versions/d4e5f6a7b8c9_remove_descricao_observacoes_from_os.py
+++ b/migrations/versions/d4e5f6a7b8c9_remove_descricao_observacoes_from_os.py
@@ -1,0 +1,20 @@
+"""remove descricao and observacoes from ordem_servico"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'd4e5f6a7b8c9'
+down_revision = 'd3f1a2b4c5e6'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    with op.batch_alter_table('ordem_servico') as batch_op:
+        batch_op.drop_column('descricao')
+        batch_op.drop_column('observacoes')
+
+
+def downgrade():
+    with op.batch_alter_table('ordem_servico') as batch_op:
+        batch_op.add_column(sa.Column('observacoes', sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column('descricao', sa.Text(), nullable=False))

--- a/templates/admin/ordens_servico.html
+++ b/templates/admin/ordens_servico.html
@@ -15,11 +15,7 @@
           <input type="text" class="form-control" id="titulo" name="titulo" value="{{ request.form.get('titulo', ordem_editar.titulo if ordem_editar else '') }}" required>
         </div>
         <div class="mb-3">
-          <label for="descricao" class="form-label">Descrição</label>
-          <textarea class="form-control" id="descricao" name="descricao" rows="3">{{ request.form.get('descricao', ordem_editar.descricao if ordem_editar else '') }}</textarea>
-        </div>
-        <div class="mb-3">
-          <label for="tipo_os_id" class="form-label">Tipo</label>
+          <label for="tipo_os_id" class="form-label">Categoria</label>
           <select class="form-select" id="tipo_os_id" name="tipo_os_id" required>
             <option value="">--</option>
             {% for t in tipos_os %}
@@ -40,6 +36,14 @@
             {% endfor %}
           </select>
         </div>
+        <div class="mb-3">
+          <label for="alvo_tipo" class="form-label">Relacionado a</label>
+          <select class="form-select" id="alvo_tipo" name="alvo_tipo">
+            <option value="">--</option>
+            <option value="sistema" {% if request.form.get('alvo_tipo')=='sistema' or (ordem_editar and ordem_editar.sistema_id) %}selected{% endif %}>Sistema</option>
+            <option value="equipamento" {% if request.form.get('alvo_tipo')=='equipamento' or (ordem_editar and ordem_editar.equipamento_id) %}selected{% endif %}>Equipamento</option>
+          </select>
+        </div>
         <div class="mb-3 d-none" id="equipamento_field">
           <label for="equipamento_id" class="form-label">Equipamento</label>
           <select class="form-select" id="equipamento_id" name="equipamento_id">
@@ -57,10 +61,6 @@
             <option value="{{ s.id }}" {% if ordem_editar and ordem_editar.sistema_id==s.id %}selected{% endif %}>{{ s.nome }}</option>
             {% endfor %}
           </select>
-        </div>
-        <div class="mb-3">
-          <label for="observacoes" class="form-label">Observações</label>
-          <textarea class="form-control" id="observacoes" name="observacoes" rows="3">{{ request.form.get('observacoes', ordem_editar.observacoes if ordem_editar else '') }}</textarea>
         </div>
         <div class="mb-3">
           <label for="status" class="form-label">Status</label>
@@ -107,7 +107,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let inputs = form.querySelectorAll('input, textarea, select');
   const idField = form.querySelector('input[name="id_para_atualizar"]');
   const STORAGE_KEY = 'draft_admin_os_' + (idField ? idField.value || 'novo' : 'novo');
-  const tipoSelect = document.getElementById('tipo_os_id');
+  const alvoSelect = document.getElementById('alvo_tipo');
   const equipamento = document.getElementById('equipamento_id');
   const sistema = document.getElementById('sistema_id');
   const equipamentoField = document.getElementById('equipamento_field');
@@ -128,15 +128,15 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
   function atualizarCampos() {
-    const texto = tipoSelect.options[tipoSelect.selectedIndex]?.text || '';
-    if (texto === 'Suporte ao Sistema') {
+    const alvo = alvoSelect.value;
+    if (alvo === 'sistema') {
       sistemaField.classList.remove('d-none');
       equipamentoField.classList.add('d-none');
       sistema.setAttribute('required', 'required');
       equipamento.removeAttribute('required');
       sistemaField.querySelector('label').innerHTML = 'Sistema <span class="text-danger">*</span>';
       equipamentoField.querySelector('label').innerHTML = 'Equipamento';
-    } else if (texto === 'Manutenção de Equipamento') {
+    } else if (alvo === 'equipamento') {
       equipamentoField.classList.remove('d-none');
       sistemaField.classList.add('d-none');
       equipamento.setAttribute('required', 'required');
@@ -155,19 +155,19 @@ document.addEventListener('DOMContentLoaded', () => {
   load();
   atualizarCampos();
   inputs.forEach(i => i.addEventListener('input', save));
-  tipoSelect.addEventListener('change', () => {
+  alvoSelect.addEventListener('change', () => {
     atualizarCampos();
   });
   form.addEventListener('submit', (e) => {
-    const texto = tipoSelect.options[tipoSelect.selectedIndex]?.text || '';
-    if (texto === 'Suporte ao Sistema' && !sistema.value) {
+    const alvo = alvoSelect.value;
+    if (alvo === 'sistema' && !sistema.value) {
       e.preventDefault();
-      alert("O campo Sistema é obrigatório para OS do tipo 'Suporte ao Sistema'.");
+      alert('O campo Sistema é obrigatório.');
       return;
     }
-    if (texto === 'Manutenção de Equipamento' && !equipamento.value) {
+    if (alvo === 'equipamento' && !equipamento.value) {
       e.preventDefault();
-      alert("O campo Equipamento é obrigatório para OS do tipo 'Manutenção de Equipamento'.");
+      alert('O campo Equipamento é obrigatório.');
       return;
     }
     localStorage.removeItem(STORAGE_KEY);

--- a/templates/ordens_servico/atendimento_detalhe.html
+++ b/templates/ordens_servico/atendimento_detalhe.html
@@ -5,10 +5,9 @@
   <div class="card shadow-sm mb-3">
     <div class="card-body">
       <h3>{{ ordem.titulo }}</h3>
-      <p class="text-muted mb-1">Tipo: {{ ordem.tipo_os.nome if ordem.tipo_os else '' }}</p>
+      <p class="text-muted mb-1">Categoria: {{ ordem.tipo_os.nome if ordem.tipo_os else '' }}</p>
       <p class="text-muted mb-1">Prioridade: {{ ordem.prioridade or 'N/A' }}</p>
       <p class="text-muted">Status atual: {{ status_choices(ordem.status).label }}</p>
-      <p>{{ ordem.descricao }}</p>
     </div>
   </div>
   <div class="mb-3">

--- a/templates/ordens_servico/atendimento_list.html
+++ b/templates/ordens_servico/atendimento_list.html
@@ -14,7 +14,7 @@
     </div>
     <div class="col-md-3">
       <select class="form-select form-select-sm" name="tipo">
-        <option value="">Todos os Tipos</option>
+        <option value="">Todas as Categorias</option>
         {% for t in tipos_os %}
           <option value="{{ t.id }}" {% if request.args.get('tipo') == t.id|string %}selected{% endif %}>{{ t.nome }}</option>
         {% endfor %}
@@ -34,7 +34,7 @@
         <tr>
           <th>Código</th>
           <th>Título</th>
-          <th>Tipo</th>
+          <th>Categoria</th>
           <th>Prioridade</th>
           <th>Status</th>
           <th>Criado por</th>

--- a/templates/ordens_servico/detalhe_os.html
+++ b/templates/ordens_servico/detalhe_os.html
@@ -16,15 +16,13 @@
           <p class="text-muted">Protocolo: {{ ordem.codigo }}</p>
           <p><strong>Status:</strong> {{ status_enum(ordem.status).label }}</p>
           {% if ordem.prioridade %}<p><strong>Prioridade:</strong> {{ ordem.prioridade }}</p>{% endif %}
-          {% if ordem.tipo_os %}<p><strong>Tipo:</strong> {{ ordem.tipo_os.nome }}</p>{% endif %}
+          {% if ordem.tipo_os %}<p><strong>Categoria:</strong> {{ ordem.tipo_os.nome }}</p>{% endif %}
           {% if ordem.sistema %}<p><strong>Sistema:</strong> {{ ordem.sistema.nome }}</p>{% endif %}
           {% if ordem.equipamento %}<p><strong>Equipamento:</strong> {{ ordem.equipamento.nome }}</p>{% endif %}
           <p><strong>Solicitante:</strong> {{ ordem.criado_por.nome_completo or ordem.criado_por.username }}</p>
           {% if ordem.atribuido_para %}<p><strong>Responsável:</strong> {{ ordem.atribuido_para.nome_completo or ordem.atribuido_para.username }}</p>{% endif %}
           <p><strong>Aberta em:</strong> {{ ordem.data_criacao.strftime('%d/%m/%Y %H:%M') }}</p>
           {% if ordem.data_conclusao %}<p><strong>Concluída em:</strong> {{ ordem.data_conclusao.strftime('%d/%m/%Y %H:%M') }}</p>{% endif %}
-          <p><strong>Descrição:</strong> {{ ordem.descricao|striptags }}</p>
-          {% if ordem.observacoes %}<p><strong>Observações:</strong> {{ ordem.observacoes|striptags }}</p>{% endif %}
         </div>
       </div>
 

--- a/templates/ordens_servico/listar_os.html
+++ b/templates/ordens_servico/listar_os.html
@@ -8,7 +8,7 @@
         <div class="card-body">
           <form method="get" class="row g-2 align-items-end">
             <div class="col-md-3">
-              <input name="q" value="{{ request.args.get('q','') }}" class="form-control" placeholder="Buscar por título ou descrição" />
+              <input name="q" value="{{ request.args.get('q','') }}" class="form-control" placeholder="Buscar por título" />
             </div>
             <div class="col-md-2">
               <select name="status" class="form-select">
@@ -28,7 +28,7 @@
             </div>
             <div class="col-md-2">
               <select name="tipo" class="form-select">
-                <option value="">Tipo</option>
+                <option value="">Categoria</option>
                 {% for t in tipos_os %}
                 <option value="{{ t.id }}" {% if request.args.get('tipo', type=int)==t.id %}selected{% endif %}>{{ t.nome }}</option>
                 {% endfor %}

--- a/templates/ordens_servico/minhas_os.html
+++ b/templates/ordens_servico/minhas_os.html
@@ -8,7 +8,7 @@
         <div class="card-body">
           <form method="get" class="row g-2 align-items-end">
             <div class="col-md-3">
-              <input name="q" value="{{ request.args.get('q','') }}" class="form-control" placeholder="Buscar por título ou descrição" />
+              <input name="q" value="{{ request.args.get('q','') }}" class="form-control" placeholder="Buscar por título" />
             </div>
             <div class="col-md-2">
               <select name="status" class="form-select">
@@ -28,7 +28,7 @@
             </div>
             <div class="col-md-2">
               <select name="tipo" class="form-select">
-                <option value="">Tipo</option>
+                <option value="">Categoria</option>
                 {% for t in tipos_os %}
                 <option value="{{ t.id }}" {% if request.args.get('tipo', type=int)==t.id %}selected{% endif %}>{{ t.nome }}</option>
                 {% endfor %}

--- a/templates/ordens_servico/nova_os.html
+++ b/templates/ordens_servico/nova_os.html
@@ -21,6 +21,14 @@
                 {% endfor %}
               </select>
             </div>
+            <div class="mb-3">
+              <label for="alvo_tipo" class="form-label">Relacionado a</label>
+              <select class="form-select" id="alvo_tipo" name="alvo_tipo">
+                <option value="">--</option>
+                <option value="sistema">Sistema</option>
+                <option value="equipamento">Equipamento</option>
+              </select>
+            </div>
             <div class="mb-3 d-none" id="equipamento_field">
               <label for="equipamento_id" class="form-label">Equipamento</label>
               <select class="form-select" id="equipamento_id" name="equipamento_id">
@@ -40,27 +48,7 @@
               </select>
             </div>
             <div class="mb-3">
-              <label for="descricao" class="form-label">Descrição</label>
-              <textarea class="form-control" id="descricao" name="descricao" rows="4"></textarea>
-            </div>
-            <div class="mb-3">
-              <label for="observacoes" class="form-label">Observações</label>
-              <textarea class="form-control" id="observacoes" name="observacoes" rows="3"></textarea>
-            </div>
-            <div class="mb-3">
-              <label for="cargo" class="form-label">Cargo</label>
-              <input type="text" class="form-control" id="cargo" value="{{ usuario.cargo.nome if usuario and usuario.cargo else '' }}" readonly data-bs-toggle="tooltip" title="Essas informações são derivadas do seu cargo no sistema.">
-            </div>
-            <div class="mb-3">
-              <label for="setor" class="form-label">Setor</label>
-              <input type="text" class="form-control" id="setor" value="{{ usuario.setor.nome if usuario and usuario.setor else '' }}" readonly data-bs-toggle="tooltip" title="Essas informações são derivadas do seu cargo no sistema.">
-            </div>
-            <div class="mb-3">
-              <label for="celula" class="form-label">Célula</label>
-              <input type="text" class="form-control" id="celula" value="{{ usuario.celula.nome if usuario and usuario.celula else '' }}" readonly data-bs-toggle="tooltip" title="Essas informações são derivadas do seu cargo no sistema.">
-            </div>
-            <div class="mb-3">
-              <label for="tipo_os_id" class="form-label">Tipo</label>
+              <label for="tipo_os_id" class="form-label">Categoria</label>
               <select class="form-select" id="tipo_os_id" name="tipo_os_id">
                 <option value="">--</option>
                 {% for t in tipos_os %}
@@ -90,6 +78,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const sistema = document.getElementById('sistema_id');
   const equipamentoField = document.getElementById('equipamento_field');
   const sistemaField = document.getElementById('sistema_field');
+  const alvoSelect = document.getElementById('alvo_tipo');
   function save() {
     const data = {};
     inputs.forEach(i => data[i.id] = i.value);
@@ -111,15 +100,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const formContainer = document.getElementById('formulario-vinculado');
   let formularioObrigatorio = false;
   function atualizarCampos() {
-    const texto = tipoSelect.options[tipoSelect.selectedIndex]?.text || '';
-    if (texto === 'Suporte ao Sistema') {
+    const alvo = alvoSelect.value;
+    if (alvo === 'sistema') {
       sistemaField.classList.remove('d-none');
       equipamentoField.classList.add('d-none');
       sistema.setAttribute('required', 'required');
       equipamento.removeAttribute('required');
       sistemaField.querySelector('label').innerHTML = 'Sistema <span class="text-danger">*</span>';
       equipamentoField.querySelector('label').innerHTML = 'Equipamento';
-    } else if (texto === 'Manutenção de Equipamento') {
+    } else if (alvo === 'equipamento') {
       equipamentoField.classList.remove('d-none');
       sistemaField.classList.add('d-none');
       equipamento.setAttribute('required', 'required');
@@ -136,8 +125,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  tipoSelect.addEventListener('change', () => {
+  alvoSelect.addEventListener('change', () => {
     atualizarCampos();
+  });
+
+  tipoSelect.addEventListener('change', () => {
     const tipoId = tipoSelect.value;
     if (!tipoId) {
       formContainer.innerHTML = '';
@@ -162,15 +154,15 @@ document.addEventListener('DOMContentLoaded', () => {
   atualizarCampos();
 
   form.addEventListener('submit', (e) => {
-    const texto = tipoSelect.options[tipoSelect.selectedIndex]?.text || '';
-    if (texto === 'Suporte ao Sistema' && !sistema.value) {
+    const alvo = alvoSelect.value;
+    if (alvo === 'sistema' && !sistema.value) {
       e.preventDefault();
-      alert("O campo Sistema é obrigatório para OS do tipo 'Suporte ao Sistema'.");
+      alert('O campo Sistema é obrigatório.');
       return;
     }
-    if (texto === 'Manutenção de Equipamento' && !equipamento.value) {
+    if (alvo === 'equipamento' && !equipamento.value) {
       e.preventDefault();
-      alert("O campo Equipamento é obrigatório para OS do tipo 'Manutenção de Equipamento'.");
+      alert('O campo Equipamento é obrigatório.');
       return;
     }
     if (formularioObrigatorio) {
@@ -188,8 +180,6 @@ document.addEventListener('DOMContentLoaded', () => {
     localStorage.removeItem(STORAGE_KEY);
   });
 
-  const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
-  tooltipTriggerList.forEach(t => new bootstrap.Tooltip(t));
 });
 </script>
 {% endblock %}

--- a/templates/ordens_servico/os_modal.html
+++ b/templates/ordens_servico/os_modal.html
@@ -7,16 +7,10 @@
     <div class="modal-body small">
       <p class="mb-1"><strong>Código:</strong> {{ ordem.codigo }}</p>
       <p class="mb-1"><strong>Status:</strong> {{ status_enum(ordem.status).label }}</p>
-      {% if ordem.tipo_os %}<p class="mb-1"><strong>Tipo:</strong> {{ ordem.tipo_os.nome }}</p>{% endif %}
+      {% if ordem.tipo_os %}<p class="mb-1"><strong>Categoria:</strong> {{ ordem.tipo_os.nome }}</p>{% endif %}
       {% if ordem.prioridade %}<p class="mb-1"><strong>Prioridade:</strong> {{ ordem.prioridade }}</p>{% endif %}
       {% if ordem.equipamento %}<p class="mb-1"><strong>Equipamento:</strong> {{ ordem.equipamento.nome }}</p>{% endif %}
       {% if ordem.sistema %}<p class="mb-1"><strong>Sistema:</strong> {{ ordem.sistema.nome }}</p>{% endif %}
-      <p class="mt-2 mb-1"><strong>Descrição:</strong></p>
-      <p class="mb-1">{{ ordem.descricao|safe }}</p>
-      {% if ordem.observacoes %}
-      <p class="mt-2 mb-1"><strong>Observações:</strong></p>
-      <p class="mb-0">{{ ordem.observacoes|safe }}</p>
-      {% endif %}
     </div>
   </div>
 </div>

--- a/tests/test_ordem_servico.py
+++ b/tests/test_ordem_servico.py
@@ -63,8 +63,8 @@ def test_crud_ordem_servico(client):
     # create
     resp = client.post('/admin/ordens_servico', data={
         'titulo': 'OS1',
-        'descricao': 'desc',
         'tipo_os_id': proc_id,
+        'alvo_tipo': 'equipamento',
         'equipamento_id': equip_id,
         'status': 'rascunho',
         'prioridade': 'baixa'
@@ -82,8 +82,8 @@ def test_crud_ordem_servico(client):
     resp = client.post('/admin/ordens_servico', data={
         'id_para_atualizar': os_id,
         'titulo': 'OS1 edit',
-        'descricao': 'd2',
         'tipo_os_id': proc_id,
+        'alvo_tipo': 'equipamento',
         'equipamento_id': equip_id,
         'status': 'cancelada'
     }, follow_redirects=True)
@@ -117,7 +117,6 @@ def test_os_mudar_status_bloqueia_quando_form_obrigatorio(client):
         os_obj = OrdemServico(
             codigo=gerar_codigo_os(),
             titulo='OS2',
-            descricao='desc',
             tipo_os=tipo,
             status='rascunho',
             criado_por_id=user.id,
@@ -156,30 +155,30 @@ def test_validacao_condicional_campos(client):
         sist_id = sist.id
     resp = client.post('/admin/ordens_servico', data={
         'titulo': 'OS S',
-        'descricao': 'd',
         'tipo_os_id': tipo_sis_id,
+        'alvo_tipo': 'sistema',
         'status': 'rascunho'
     }, follow_redirects=True)
     assert "O campo Sistema é obrigatório" in resp.get_data(as_text=True)
     resp = client.post('/admin/ordens_servico', data={
         'titulo': 'OS E',
-        'descricao': 'd',
         'tipo_os_id': tipo_eq_id,
+        'alvo_tipo': 'equipamento',
         'status': 'rascunho'
     }, follow_redirects=True)
     assert "O campo Equipamento é obrigatório" in resp.get_data(as_text=True)
     resp = client.post('/admin/ordens_servico', data={
         'titulo': 'OS S ok',
-        'descricao': 'd',
         'tipo_os_id': tipo_sis_id,
+        'alvo_tipo': 'sistema',
         'sistema_id': sist_id,
         'status': 'rascunho'
     }, follow_redirects=True)
     assert resp.status_code == 200
     resp = client.post('/admin/ordens_servico', data={
         'titulo': 'OS E ok',
-        'descricao': 'd',
         'tipo_os_id': tipo_eq_id,
+        'alvo_tipo': 'equipamento',
         'equipamento_id': equip_id,
         'status': 'rascunho'
     }, follow_redirects=True)
@@ -202,7 +201,6 @@ def test_codigo_os_formato_unicidade_incremento(client):
         os1 = OrdemServico(
             codigo=codigo1,
             titulo='OS A',
-            descricao='d',
             tipo_os=tipo,
             status='rascunho',
             criado_por_id=user.id,
@@ -214,7 +212,6 @@ def test_codigo_os_formato_unicidade_incremento(client):
         os2 = OrdemServico(
             codigo=codigo2,
             titulo='OS B',
-            descricao='d',
             tipo_os=tipo,
             status='rascunho',
             criado_por_id=user.id,
@@ -294,7 +291,6 @@ def test_os_listar_filtra_por_celulas(client):
         os1 = OrdemServico(
             codigo=gerar_codigo_os(),
             titulo='OS A',
-            descricao='d',
             tipo_os=tipo1,
             equipe_responsavel_id=cel1.id,
             status=OSStatus.AGUARDANDO_ATENDIMENTO.value,
@@ -305,7 +301,6 @@ def test_os_listar_filtra_por_celulas(client):
         os2 = OrdemServico(
             codigo=gerar_codigo_os(),
             titulo='OS B',
-            descricao='d',
             tipo_os=tipo2,
             equipe_responsavel_id=cel2.id,
             status=OSStatus.AGUARDANDO_ATENDIMENTO.value,
@@ -338,7 +333,6 @@ def test_os_detalhar_respeita_permissoes(client):
         os_permitida = OrdemServico(
             codigo=gerar_codigo_os(),
             titulo='OS OK',
-            descricao='d',
             tipo_os=tipo1,
             equipe_responsavel_id=cel1.id,
             status=OSStatus.AGUARDANDO_ATENDIMENTO.value,
@@ -349,7 +343,6 @@ def test_os_detalhar_respeita_permissoes(client):
         os_negada = OrdemServico(
             codigo=gerar_codigo_os(),
             titulo='OS NO',
-            descricao='d',
             tipo_os=tipo2,
             equipe_responsavel_id=cel2.id,
             status=OSStatus.AGUARDANDO_ATENDIMENTO.value,
@@ -406,7 +399,6 @@ def test_acesso_os_celulas_por_hierarquia(app_ctx):
         os_obj = OrdemServico(
             codigo=gerar_codigo_os(),
             titulo='OS',
-            descricao='d',
             tipo_os=tipo,
             equipe_responsavel_id=cel_sub.id,
             criado_por_id=lider.id,
@@ -430,7 +422,6 @@ def test_os_modal_endpoint(client):
         os_obj = OrdemServico(
             codigo=gerar_codigo_os(),
             titulo='OS modal test',
-            descricao='desc',
             tipo_os=tipo,
             status=OSStatus.AGUARDANDO_ATENDIMENTO.value,
             criado_por=user,


### PR DESCRIPTION
## Summary
- remove campos de descrição e observações da Ordem de Serviço
- adiciona seleção de destino (sistema ou equipamento) nas OS
- renomeia campo de tipo para categoria

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4af009de0832e9fb5cc62cc12e49f