### PR TITLE
Color-code OS cards by priority

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -467,8 +467,22 @@ body > .container {
 /* Card layout for Ordens de Serviço */
 .os-card {
   min-height: 180px;
+  border-left: 5px solid transparent;
 }
 
 .os-card .card-footer .btn {
   min-width: 90px;
+}
+
+/* Priority colors for Ordem de Serviço cards */
+.os-card.prioridade-baixa {
+  border-left-color: var(--bs-success);
+}
+
+.os-card.prioridade-media {
+  border-left-color: var(--bs-warning);
+}
+
+.os-card.prioridade-alta {
+  border-left-color: var(--bs-danger);
 }

--- a/templates/ordens_servico/kanban.html
+++ b/templates/ordens_servico/kanban.html
@@ -10,7 +10,7 @@
         <h5>{{ labels[key] }}</h5>
         {% if columns[key] %}
           {% for os in columns[key] %}
-          <div class="card mb-2 os-card" data-os="{{ os.codigo }}" style="cursor:pointer;">
+          <div class="card mb-2 os-card {% if os.prioridade %}prioridade-{{ os.prioridade }}{% endif %}" data-os="{{ os.codigo }}" style="cursor:pointer;">
             <div class="card-body p-2">
               <div><strong>Código OS:</strong> {{ os.codigo }}</div>
               <div class="fw-bold"><strong>Título:</strong> {{ os.titulo }}</div>

--- a/templates/ordens_servico/listar_os.html
+++ b/templates/ordens_servico/listar_os.html
@@ -85,14 +85,15 @@
             <div class="row row-cols-1 g-3">
               {% for os in ordens %}
               <div class="col">
-                <div class="card os-card h-100 shadow-sm">
+                <div class="card os-card h-100 shadow-sm {% if os.prioridade %}prioridade-{{ os.prioridade }}{% endif %}">
                   <div class="card-header d-flex justify-content-between align-items-start">
                     <strong>{{ os.codigo }}</strong>
                     <div>
                       {% set st = status_enum(os.status) %}
                       <span class="badge rounded-pill bg-{{ st.color }} text-{{ st.text_color }}">{{ st.label }}</span>
                       {% if os.prioridade %}
-                      <span class="badge bg-secondary">{{ os.prioridade }}</span>
+                      {% set pr_colors = {'baixa':'success','media':'warning','alta':'danger'} %}
+                      <span class="badge bg-{{ pr_colors[os.prioridade] }}">{{ os.prioridade }}</span>
                       {% endif %}
                     </div>
                   </div>

--- a/templates/ordens_servico/minhas_os.html
+++ b/templates/ordens_servico/minhas_os.html
@@ -70,14 +70,15 @@
             <div class="row row-cols-1 g-3">
               {% for os in rascunhos %}
               <div class="col">
-                <div class="card os-card h-100 shadow-sm">
+                <div class="card os-card h-100 shadow-sm {% if os.prioridade %}prioridade-{{ os.prioridade }}{% endif %}">
                   <div class="card-header d-flex justify-content-between align-items-start">
                     <strong>{{ os.codigo }}</strong>
                     <div>
                       {% set st = status_enum(os.status) %}
                       <span class="badge rounded-pill bg-{{ st.color }} text-{{ st.text_color }}">{{ st.label }}</span>
                       {% if os.prioridade %}
-                      <span class="badge bg-secondary">{{ os.prioridade }}</span>
+                      {% set pr_colors = {'baixa':'success','media':'warning','alta':'danger'} %}
+                      <span class="badge bg-{{ pr_colors[os.prioridade] }}">{{ os.prioridade }}</span>
                       {% endif %}
                     </div>
                   </div>
@@ -111,14 +112,15 @@
             <div class="row row-cols-1 g-3">
               {% for os in ordens %}
               <div class="col">
-                <div class="card os-card h-100 shadow-sm">
+                <div class="card os-card h-100 shadow-sm {% if os.prioridade %}prioridade-{{ os.prioridade }}{% endif %}">
                   <div class="card-header d-flex justify-content-between align-items-start">
                     <strong>{{ os.codigo }}</strong>
                     <div>
                       {% set st = status_enum(os.status) %}
                       <span class="badge rounded-pill bg-{{ st.color }} text-{{ st.text_color }}">{{ st.label }}</span>
                       {% if os.prioridade %}
-                      <span class="badge bg-secondary">{{ os.prioridade }}</span>
+                      {% set pr_colors = {'baixa':'success','media':'warning','alta':'danger'} %}
+                      <span class="badge bg-{{ pr_colors[os.prioridade] }}">{{ os.prioridade }}</span>
                       {% endif %}
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- color-code OS cards according to priority across listing, personal, and kanban views
- add CSS classes to style cards and badges for baixa, media, and alta priorities

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4b4258658832e94a1c92fcb6ddcdc