### PR TITLE
feat: integrate dynamic form on OS creation

### DIFF
--- a/templates/ordens_servico/_formulario_vinculado.html
+++ b/templates/ordens_servico/_formulario_vinculado.html
@@ -137,17 +137,42 @@
 </div>
 {% endmacro %}
 
-{% set q_idx = namespace(value=0) %}
-{% for bloco in estrutura %}
-  {% if bloco.tipo == 'section' %}
-    <div class="section-block mb-4" data-section-index="{{ loop.index0 }}">
-      {% for campo in bloco.campos %}
-        {{ render_campo(campo, q_idx.value) }}
-        {% set q_idx.value = q_idx.value + 1 %}
-      {% endfor %}
+<div class="form-container">
+  <div class="mb-3">
+    <h5 id="sectionTitle" class="mb-2"></h5>
+    <div class="progress">
+      <div class="progress-bar" role="progressbar" style="width: 0%" id="progressBar"></div>
     </div>
-  {% else %}
-    {{ render_campo(bloco, q_idx.value) }}
-    {% set q_idx.value = q_idx.value + 1 %}
-  {% endif %}
-{% endfor %}
+  </div>
+
+  {% set q_idx = namespace(value=0) %}
+  {% for bloco in estrutura %}
+    {% if bloco.tipo == 'section' %}
+      <div class="section-block mb-4" data-section-index="{{ loop.index0 }}">
+        {% for campo in bloco.campos %}
+          {{ render_campo(campo, q_idx.value) }}
+          {% set q_idx.value = q_idx.value + 1 %}
+        {% endfor %}
+      </div>
+    {% else %}
+      {{ render_campo(bloco, q_idx.value) }}
+      {% set q_idx.value = q_idx.value + 1 %}
+    {% endif %}
+  {% endfor %}
+
+  <div class="d-flex mt-3 align-items-center flex-wrap gap-2" id="navButtons">
+    <button type="button" class="btn btn-secondary" id="backBtn">Voltar</button>
+    <div class="ms-auto d-flex gap-2">
+      <button type="button" class="btn btn-primary" id="nextBtn">Próximo</button>
+    </div>
+  </div>
+</div>
+<div class="modal fade" id="videoExpandModal" tabindex="-1">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-body p-0">
+        <iframe width="100%" height="400" src="" allowfullscreen></iframe>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/ordens_servico/nova_os.html
+++ b/templates/ordens_servico/nova_os.html
@@ -22,12 +22,15 @@
               </select>
             </div>
             <div class="mb-3">
-              <label for="alvo_tipo" class="form-label">Relacionado a</label>
-              <select class="form-select" id="alvo_tipo" name="alvo_tipo">
-                <option value="">--</option>
-                <option value="sistema">Sistema</option>
-                <option value="equipamento">Equipamento</option>
-              </select>
+              <label class="form-label d-block">Relacionado a</label>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="alvo_tipo" id="alvo_sistema" value="sistema">
+                <label class="form-check-label" for="alvo_sistema">Sistema</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="alvo_tipo" id="alvo_equipamento" value="equipamento">
+                <label class="form-check-label" for="alvo_equipamento">Equipamento</label>
+              </div>
             </div>
             <div class="mb-3 d-none" id="equipamento_field">
               <label for="equipamento_id" class="form-label">Equipamento</label>
@@ -78,29 +81,62 @@ document.addEventListener('DOMContentLoaded', () => {
   const sistema = document.getElementById('sistema_id');
   const equipamentoField = document.getElementById('equipamento_field');
   const sistemaField = document.getElementById('sistema_field');
-  const alvoSelect = document.getElementById('alvo_tipo');
+  const alvoRadios = document.querySelectorAll('input[name="alvo_tipo"]');
+
   function save() {
     const data = {};
-    inputs.forEach(i => data[i.id] = i.value);
+    inputs.forEach(i => {
+      if (i.type === 'radio') {
+        if (i.checked) data[i.name] = i.value;
+      } else if (i.type === 'checkbox') {
+        data[i.id] = i.checked;
+      } else {
+        data[i.id] = i.value;
+      }
+    });
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
   }
+
   function load() {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return;
     try {
       const data = JSON.parse(raw);
-      inputs.forEach(i => { if (data[i.id]) i.value = data[i.id]; });
+      inputs.forEach(i => {
+        if (i.type === 'radio') {
+          if (data[i.name] === i.value) i.checked = true;
+        } else if (i.type === 'checkbox') {
+          if (data[i.id]) i.checked = true;
+        } else {
+          if (data[i.id]) i.value = data[i.id];
+        }
+      });
     } catch (e) {
       console.warn('Falha ao carregar rascunho da OS', e);
     }
   }
+
+  function attachSaveListeners() {
+    inputs.forEach(i => {
+      i.addEventListener('input', save);
+      i.addEventListener('change', save);
+    });
+  }
+
   load();
-  inputs.forEach(i => i.addEventListener('input', save));
+  attachSaveListeners();
+
   const tipoSelect = document.getElementById('tipo_os_id');
   const formContainer = document.getElementById('formulario-vinculado');
   let formularioObrigatorio = false;
+
+  function getAlvoValue() {
+    const checked = document.querySelector('input[name="alvo_tipo"]:checked');
+    return checked ? checked.value : '';
+  }
+
   function atualizarCampos() {
-    const alvo = alvoSelect.value;
+    const alvo = getAlvoValue();
     if (alvo === 'sistema') {
       sistemaField.classList.remove('d-none');
       equipamentoField.classList.add('d-none');
@@ -125,9 +161,231 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  alvoSelect.addEventListener('change', () => {
-    atualizarCampos();
-  });
+  alvoRadios.forEach(r => r.addEventListener('change', atualizarCampos));
+
+  function initFormularioVinculado() {
+    const container = document.getElementById('formulario-vinculado');
+    if (!container || !container.querySelector('.section-block')) return;
+
+    container.querySelectorAll('.expand-video').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const url = btn.dataset.video;
+        const iframe = container.querySelector('#videoExpandModal iframe');
+        if (iframe) {
+          iframe.src = url;
+          const modal = new bootstrap.Modal(container.querySelector('#videoExpandModal'));
+          modal.show();
+        }
+      });
+    });
+    const videoModal = container.querySelector('#videoExpandModal');
+    if (videoModal) {
+      videoModal.addEventListener('hidden.bs.modal', () => {
+        const iframe = videoModal.querySelector('iframe');
+        if (iframe) iframe.src = '';
+      });
+    }
+
+    const sections = Array.from(container.querySelectorAll('.section-block'));
+    const questions = Array.from(container.querySelectorAll('.question-block'));
+    const questionById = new Map(questions.map(q => [q.dataset.id, q]));
+    const questionToSection = new Map();
+    sections.forEach((sec, sIdx) => {
+      sec.querySelectorAll('.question-block').forEach(q => questionToSection.set(q, sIdx));
+    });
+    let history = [0];
+
+    const branchDestinations = new Set();
+    questions.forEach(q => {
+      const ram = JSON.parse(q.dataset.ramificacoes || '[]');
+      ram.forEach(r => {
+        if (r.destino && r.destino !== 'next' && r.destino !== 'end') {
+          branchDestinations.add(r.destino);
+        }
+      });
+    });
+    branchDestinations.forEach(id => {
+      const el = questionById.get(id);
+      if (el) hideQuestionAndDescendants(el);
+    });
+
+    function hideQuestionAndDescendants(qEl) {
+      qEl.style.display = 'none';
+      qEl.querySelectorAll('[required]').forEach(inp => {
+        inp.dataset.wasRequired = 'true';
+        inp.required = false;
+      });
+      const ram = JSON.parse(qEl.dataset.ramificacoes || '[]');
+      ram.forEach(r => {
+        if (r.destino && r.destino !== 'next' && r.destino !== 'end') {
+          const destEl = questionById.get(r.destino);
+          if (destEl) hideQuestionAndDescendants(destEl);
+        }
+      });
+    }
+
+    function showQuestion(qEl) {
+      qEl.style.display = '';
+      qEl.querySelectorAll('[data-was-required]').forEach(inp => {
+        inp.required = true;
+        inp.removeAttribute('data-was-required');
+      });
+    }
+
+    function updateSectionsVisibility() {
+      sections.forEach(sec => {
+        const visible = Array.from(sec.querySelectorAll('.question-block')).some(q => q.style.display !== 'none');
+        sec.style.display = visible ? '' : 'none';
+      });
+    }
+
+    function findSectionByQuestionId(id) {
+      return sections.findIndex(sec => Array.from(sec.querySelectorAll('.question-block')).some(q => q.dataset.id === id));
+    }
+
+    function determineNext(idx) {
+      const qs = Array.from(sections[idx].querySelectorAll('.question-block')).filter(q => q.style.display !== 'none');
+      for (const q of qs) {
+        const ram = JSON.parse(q.dataset.ramificacoes || '[]');
+        if (!ram.length) continue;
+        let val = null;
+        const sel = q.querySelector('select');
+        if (sel) val = sel.value; else {
+          const checked = q.querySelector('input[type=radio]:checked');
+          if (checked) val = checked.value;
+        }
+        if (val) {
+          const rule = ram.find(r => r.opcao === val);
+          if (rule) {
+            if (rule.destino === 'end') return -1;
+            if (rule.destino !== 'next') {
+              const destIdx = findSectionByQuestionId(rule.destino);
+              if (destIdx !== -1 && destIdx !== idx) return destIdx;
+            }
+          }
+        }
+      }
+      let nextIdx = idx + 1;
+      while (nextIdx < sections.length) {
+        const hasVisible = Array.from(sections[nextIdx].querySelectorAll('.question-block')).some(q => q.style.display !== 'none');
+        if (hasVisible) break;
+        nextIdx++;
+      }
+      return nextIdx < sections.length ? nextIdx : -1;
+    }
+
+    function showSection(idx) {
+      sections.forEach((sec, i) => { sec.style.display = i === idx ? '' : 'none'; });
+      const title = sections[idx].querySelector('h4')?.textContent || `Seção ${idx + 1}`;
+      container.querySelector('#sectionTitle').textContent = title;
+      const pct = ((idx + 1) / sections.length) * 100;
+      container.querySelector('#progressBar').style.width = pct + '%';
+      const backBtn = container.querySelector('#backBtn');
+      const nextBtn = container.querySelector('#nextBtn');
+      backBtn.style.display = history.length > 1 ? '' : 'none';
+      if (determineNext(idx) === -1) {
+        nextBtn.classList.add('d-none');
+      } else {
+        nextBtn.classList.remove('d-none');
+      }
+    }
+
+    function handleBranchChange(q, idx) {
+      const ram = JSON.parse(q.dataset.ramificacoes || '[]');
+      let val = null;
+      const sel = q.querySelector('select');
+      if (sel) val = sel.value; else {
+        const checked = q.querySelector('input[type=radio]:checked');
+        if (checked) val = checked.value;
+      }
+
+      if (q.dataset.activeDest && q.dataset.activeDest !== 'next' && q.dataset.activeDest !== 'end') {
+        const prevEl = questionById.get(q.dataset.activeDest);
+        if (prevEl) hideQuestionAndDescendants(prevEl);
+      }
+
+      const currentSecIdx = questionToSection.get(q);
+      const pos = history.indexOf(currentSecIdx);
+      history = pos === -1 ? [currentSecIdx] : history.slice(0, pos + 1);
+
+      let rule = null;
+      if (val) {
+        rule = ram.find(r => r.opcao === val);
+      }
+      q.dataset.activeDest = rule ? rule.destino : '';
+
+      if (rule) {
+        if (rule.destino === 'end') {
+          for (let i = idx + 1; i < questions.length; i++) {
+            hideQuestionAndDescendants(questions[i]);
+          }
+          updateSectionsVisibility();
+          showSection(currentSecIdx);
+          return;
+        }
+        if (rule.destino && rule.destino !== 'next') {
+          const destEl = questionById.get(rule.destino);
+          if (destEl) {
+            showQuestion(destEl);
+            const destSecIdx = questionToSection.get(destEl);
+            sections[destSecIdx].style.display = '';
+            updateSectionsVisibility();
+            if (destSecIdx !== currentSecIdx) {
+              history.push(destSecIdx);
+              showSection(destSecIdx);
+              return;
+            }
+            const destIdx = questions.indexOf(destEl);
+            const nextAfterDest = questions[destIdx + 1];
+            if (nextAfterDest) showQuestion(nextAfterDest);
+          }
+        }
+      }
+      updateSectionsVisibility();
+      showSection(currentSecIdx);
+    }
+
+    questions.forEach((q, idx) => {
+      const ram = JSON.parse(q.dataset.ramificacoes || '[]');
+      if (!ram.length) return;
+      const inputs = q.querySelectorAll('select, input[type=radio]');
+      inputs.forEach(inp => {
+        inp.addEventListener('change', () => handleBranchChange(q, idx));
+      });
+    });
+
+    const nextBtn = container.querySelector('#nextBtn');
+    const backBtn = container.querySelector('#backBtn');
+
+    nextBtn.addEventListener('click', () => {
+      const currentSection = sections[history[history.length - 1]];
+      const inputs = currentSection.querySelectorAll('input, select, textarea');
+      for (const inp of inputs) {
+        if (!inp.checkValidity()) {
+          inp.reportValidity();
+          return;
+        }
+      }
+      const target = determineNext(history[history.length - 1]);
+      if (target === -1) {
+        return;
+      }
+      history.push(target);
+      showSection(target);
+    });
+
+    backBtn.addEventListener('click', () => {
+      if (history.length > 1) {
+        history.pop();
+        showSection(history[history.length - 1]);
+      }
+    });
+
+    updateSectionsVisibility();
+    sections.forEach((sec, i) => { if (i !== 0) sec.style.display = 'none'; });
+    backBtn.style.display = 'none';
+    showSection(0);
+  }
 
   tipoSelect.addEventListener('change', () => {
     const tipoId = tipoSelect.value;
@@ -135,7 +393,7 @@ document.addEventListener('DOMContentLoaded', () => {
       formContainer.innerHTML = '';
       formularioObrigatorio = false;
       inputs = form.querySelectorAll('input, textarea, select');
-      inputs.forEach(i => i.addEventListener('input', save));
+      attachSaveListeners();
       return;
     }
     fetch(`/os/tipo/${tipoId}/formulario`)
@@ -144,17 +402,20 @@ document.addEventListener('DOMContentLoaded', () => {
         formContainer.innerHTML = data.html || '';
         formularioObrigatorio = data.obrigatorio;
         inputs = form.querySelectorAll('input, textarea, select');
-        inputs.forEach(i => i.addEventListener('input', save));
+        attachSaveListeners();
+        initFormularioVinculado();
       })
       .catch(() => {
         formContainer.innerHTML = '';
         formularioObrigatorio = false;
       });
   });
+
   atualizarCampos();
+  initFormularioVinculado();
 
   form.addEventListener('submit', (e) => {
-    const alvo = alvoSelect.value;
+    const alvo = getAlvoValue();
     if (alvo === 'sistema' && !sistema.value) {
       e.preventDefault();
       alert('O campo Sistema é obrigatório.');


### PR DESCRIPTION
## Summary
- load dynamic form with section carousel and branching when selecting category on OS creation
- switch "Relacionado a" selector to radio options

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4b5023afc832ea200faabd90155ba