### PR TITLE
Exibir titulos de seções e formularios em OS

### DIFF
--- a/blueprints/ordens_servico.py
+++ b/blueprints/ordens_servico.py
@@ -508,12 +508,21 @@ def os_detalhar(ordem_id):
         abort(403)
     logs = OrdemServicoLog.query.filter_by(os_id=ordem.id).order_by(OrdemServicoLog.data_hora.asc()).all()
     comentarios = OrdemServicoComentario.query.filter_by(os_id=ordem.id).order_by(OrdemServicoComentario.data_hora.asc()).all()
+    formulario_estrutura = None
+    if ordem.tipo_os and ordem.tipo_os.formulario_vinculado_id:
+        formulario = Formulario.query.get(ordem.tipo_os.formulario_vinculado_id)
+        if formulario and formulario.estrutura:
+            try:
+                formulario_estrutura = json.loads(formulario.estrutura)
+            except ValueError:
+                formulario_estrutura = []
     return render_template(
         'ordens_servico/detalhe_os.html',
         ordem=ordem,
         status_enum=OSStatus,
         logs=logs,
         comentarios=comentarios,
+        formulario_estrutura=formulario_estrutura,
         next=request.args.get('next'),
     )
 
@@ -526,7 +535,20 @@ def os_modal(ordem_id):
     usuario = User.query.get(session['user_id'])
     if not _usuario_pode_acessar_os(usuario, ordem):
         abort(403)
-    return render_template('ordens_servico/os_modal.html', ordem=ordem, status_enum=OSStatus)
+    formulario_estrutura = None
+    if ordem.tipo_os and ordem.tipo_os.formulario_vinculado_id:
+        formulario = Formulario.query.get(ordem.tipo_os.formulario_vinculado_id)
+        if formulario and formulario.estrutura:
+            try:
+                formulario_estrutura = json.loads(formulario.estrutura)
+            except ValueError:
+                formulario_estrutura = []
+    return render_template(
+        'ordens_servico/os_modal.html',
+        ordem=ordem,
+        status_enum=OSStatus,
+        formulario_estrutura=formulario_estrutura,
+    )
 
 
 @ordens_servico_bp.route('/os/minhas', endpoint='os_minhas')
@@ -741,11 +763,20 @@ def os_atendimento_detalhar(ordem_id):
     if not _usuario_pode_acessar_os(usuario, ordem):
         abort(403)
     comentarios = OrdemServicoComentario.query.filter_by(os_id=ordem.id).order_by(OrdemServicoComentario.data_hora.asc()).all()
+    formulario_estrutura = None
+    if ordem.tipo_os and ordem.tipo_os.formulario_vinculado_id:
+        formulario = Formulario.query.get(ordem.tipo_os.formulario_vinculado_id)
+        if formulario and formulario.estrutura:
+            try:
+                formulario_estrutura = json.loads(formulario.estrutura)
+            except ValueError:
+                formulario_estrutura = []
     return render_template(
         'ordens_servico/atendimento_detalhe.html',
         ordem=ordem,
         comentarios=comentarios,
         status_choices=OSStatus,
+        formulario_estrutura=formulario_estrutura,
     )
 
 

--- a/templates/formularios/preencher_formulario.html
+++ b/templates/formularios/preencher_formulario.html
@@ -316,8 +316,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function showSection(idx) {
     sections.forEach((sec, i) => { sec.style.display = i === idx ? '' : 'none'; });
-    const title = sections[idx].querySelector('h4')?.textContent || `Seção ${idx + 1}`;
-    document.getElementById('sectionTitle').textContent = title;
+    const titleEl = sections[idx].querySelector('h4');
+    const subtitleEl = sections[idx].querySelector('p.text-muted');
+    let title = titleEl?.textContent.trim();
+    let subtitle = subtitleEl?.textContent.trim();
+    let display = title || `Seção ${idx + 1}`;
+    if (subtitle) display += ` - ${subtitle}`;
+    document.getElementById('sectionTitle').textContent = display;
     const pct = ((idx + 1) / sections.length) * 100;
     document.getElementById('progressBar').style.width = pct + '%';
     document.getElementById('backBtn').style.display = history.length > 1 ? '' : 'none';

--- a/templates/ordens_servico/_formulario_vinculado.html
+++ b/templates/ordens_servico/_formulario_vinculado.html
@@ -149,6 +149,16 @@
   {% for bloco in estrutura %}
     {% if bloco.tipo == 'section' %}
       <div class="section-block mb-4" data-section-index="{{ loop.index0 }}">
+        <div class="d-flex justify-content-between">
+          <div class="flex-grow-1 me-3">
+            <h4 class="mb-1 d-none">{{ bloco.titulo }}</h4>
+            {% if bloco.subtitulo %}<p class="text-muted mb-2">{{ bloco.subtitulo }}</p>{% endif %}
+          </div>
+          <div class="text-end">
+            {% if bloco.imagem_url %}<img src="{{ bloco.imagem_url }}" class="img-fluid mb-2" style="max-width: 200px;" alt="">{% endif %}
+            {% if bloco.video_url %}<div class="video-holder"><iframe width="250" height="140" src="{{ bloco.video_url }}" allowfullscreen></iframe><button type="button" class="btn btn-link p-0 mt-1 expand-video" data-video="{{ bloco.video_url }}">Expandir</button></div>{% endif %}
+          </div>
+        </div>
         {% for campo in bloco.campos %}
           {{ render_campo(campo, q_idx.value) }}
           {% set q_idx.value = q_idx.value + 1 %}

--- a/templates/ordens_servico/_formulario_vinculado_readonly.html
+++ b/templates/ordens_servico/_formulario_vinculado_readonly.html
@@ -1,0 +1,17 @@
+{% for bloco in estrutura %}
+  {% if bloco.tipo == 'section' %}
+    <div class="mb-4">
+      {% if bloco.titulo %}<h5 class="mb-1">{{ bloco.titulo }}</h5>{% endif %}
+      {% if bloco.subtitulo %}<p class="text-muted mb-2">{{ bloco.subtitulo }}</p>{% endif %}
+      {% for campo in bloco.campos %}
+        <p class="ms-3 mb-1">{{ campo.label }}</p>
+        {% if campo.subtitulo %}<p class="ms-3 text-muted mb-2">{{ campo.subtitulo }}</p>{% endif %}
+      {% endfor %}
+    </div>
+  {% else %}
+    <div class="mb-3">
+      <p class="mb-1">{{ bloco.label }}</p>
+      {% if bloco.subtitulo %}<p class="text-muted mb-2">{{ bloco.subtitulo }}</p>{% endif %}
+    </div>
+  {% endif %}
+{% endfor %}

--- a/templates/ordens_servico/atendimento_detalhe.html
+++ b/templates/ordens_servico/atendimento_detalhe.html
@@ -10,6 +10,14 @@
       <p class="text-muted">Status atual: {{ status_choices(ordem.status).label }}</p>
     </div>
   </div>
+  {% if formulario_estrutura %}
+  <div class="card shadow-sm mb-3">
+    <div class="card-body">
+      {% set estrutura = formulario_estrutura %}
+      {% include 'ordens_servico/_formulario_vinculado_readonly.html' %}
+    </div>
+  </div>
+  {% endif %}
   <div class="mb-3">
     <form method="post" action="{{ url_for('ordens_servico_bp.os_mudar_status', ordem_id=ordem.codigo) }}" class="d-flex">
       <select class="form-select form-select-sm" name="status">

--- a/templates/ordens_servico/detalhe_os.html
+++ b/templates/ordens_servico/detalhe_os.html
@@ -26,6 +26,15 @@
         </div>
       </div>
 
+      {% if formulario_estrutura %}
+      <div class="card shadow-sm mb-4">
+        <div class="card-body">
+          {% set estrutura = formulario_estrutura %}
+          {% include 'ordens_servico/_formulario_vinculado_readonly.html' %}
+        </div>
+      </div>
+      {% endif %}
+
       {% if comentarios %}
       <div class="card shadow-sm mb-4">
         <div class="card-body">

--- a/templates/ordens_servico/nova_os.html
+++ b/templates/ordens_servico/nova_os.html
@@ -276,8 +276,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function showSection(idx) {
       sections.forEach((sec, i) => { sec.style.display = i === idx ? '' : 'none'; });
-      const title = sections[idx].querySelector('h4')?.textContent || `Seção ${idx + 1}`;
-      container.querySelector('#sectionTitle').textContent = title;
+      const titleEl = sections[idx].querySelector('h4');
+      const subtitleEl = sections[idx].querySelector('p.text-muted');
+      let title = titleEl?.textContent.trim();
+      let subtitle = subtitleEl?.textContent.trim();
+      let display = title || `Seção ${idx + 1}`;
+      if (subtitle) display += ` - ${subtitle}`;
+      container.querySelector('#sectionTitle').textContent = display;
       const pct = ((idx + 1) / sections.length) * 100;
       container.querySelector('#progressBar').style.width = pct + '%';
       const backBtn = container.querySelector('#backBtn');

--- a/templates/ordens_servico/os_modal.html
+++ b/templates/ordens_servico/os_modal.html
@@ -11,6 +11,12 @@
       {% if ordem.prioridade %}<p class="mb-1"><strong>Prioridade:</strong> {{ ordem.prioridade }}</p>{% endif %}
       {% if ordem.equipamento %}<p class="mb-1"><strong>Equipamento:</strong> {{ ordem.equipamento.nome }}</p>{% endif %}
       {% if ordem.sistema %}<p class="mb-1"><strong>Sistema:</strong> {{ ordem.sistema.nome }}</p>{% endif %}
+      {% if formulario_estrutura %}
+      <div class="mt-3">
+        {% set estrutura = formulario_estrutura %}
+        {% include 'ordens_servico/_formulario_vinculado_readonly.html' %}
+      </div>
+      {% endif %}
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Mostrar título e subtítulo das seções na barra de progresso
- Exibir títulos e campos dos formulários vinculados nas telas de detalhes da OS
- Adicionar template somente leitura para renderizar estrutura de formulários

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4b9ba5c9c832eb57966a235ee54e3