### PR TITLE
Exibir respostas de formulário em detalhes de OS

### DIFF
--- a/blueprints/ordens_servico.py
+++ b/blueprints/ordens_servico.py
@@ -103,6 +103,43 @@ def get_celulas_visiveis(usuario):
     return [c for c in set(celulas_ids) if c]
 
 
+def _get_formulario_estrutura_respostas(ordem):
+    """Recupera a estrutura e as respostas do formulário vinculado à OS."""
+    formulario_estrutura = None
+    formulario_respostas = None
+    if ordem.tipo_os and ordem.tipo_os.formulario_vinculado_id:
+        formulario = Formulario.query.get(ordem.tipo_os.formulario_vinculado_id)
+        if formulario and formulario.estrutura:
+            try:
+                formulario_estrutura = json.loads(formulario.estrutura)
+            except ValueError:
+                formulario_estrutura = []
+    if ordem.formulario_respostas_id:
+        fr = FormularioResposta.query.get(ordem.formulario_respostas_id)
+        if fr and fr.dados:
+            if isinstance(fr.dados, str):
+                try:
+                    dados = json.loads(fr.dados)
+                except ValueError:
+                    dados = None
+            else:
+                dados = fr.dados
+            if isinstance(dados, list):
+                respostas_dict = {}
+                for item in dados:
+                    if isinstance(item, dict):
+                        key = item.get('id') or item.get('campo_id') or item.get('campo')
+                        value = item.get('valor') if 'valor' in item else item.get('resposta')
+                        if key is not None and value is not None:
+                            respostas_dict[str(key)] = value
+                formulario_respostas = respostas_dict or None
+            elif isinstance(dados, dict):
+                formulario_respostas = {str(k): v for k, v in dados.items()}
+            else:
+                formulario_respostas = None
+    return formulario_estrutura, formulario_respostas
+
+
 @ordens_servico_bp.route('/admin/ordens_servico', methods=['GET', 'POST'])
 @os_admin_required
 def admin_ordens_servico():
@@ -510,19 +547,7 @@ def os_detalhar(ordem_id):
         abort(403)
     logs = OrdemServicoLog.query.filter_by(os_id=ordem.id).order_by(OrdemServicoLog.data_hora.asc()).all()
     comentarios = OrdemServicoComentario.query.filter_by(os_id=ordem.id).order_by(OrdemServicoComentario.data_hora.asc()).all()
-    formulario_estrutura = None
-    formulario_respostas = None
-    if ordem.tipo_os and ordem.tipo_os.formulario_vinculado_id:
-        formulario = Formulario.query.get(ordem.tipo_os.formulario_vinculado_id)
-        if formulario and formulario.estrutura:
-            try:
-                formulario_estrutura = json.loads(formulario.estrutura)
-            except ValueError:
-                formulario_estrutura = []
-    if ordem.formulario_respostas_id:
-        fr = FormularioResposta.query.get(ordem.formulario_respostas_id)
-        if fr and fr.dados:
-            formulario_respostas = fr.dados
+    formulario_estrutura, formulario_respostas = _get_formulario_estrutura_respostas(ordem)
     return render_template(
         'ordens_servico/detalhe_os.html',
         ordem=ordem,
@@ -543,19 +568,7 @@ def os_modal(ordem_id):
     usuario = User.query.get(session['user_id'])
     if not _usuario_pode_acessar_os(usuario, ordem):
         abort(403)
-    formulario_estrutura = None
-    formulario_respostas = None
-    if ordem.tipo_os and ordem.tipo_os.formulario_vinculado_id:
-        formulario = Formulario.query.get(ordem.tipo_os.formulario_vinculado_id)
-        if formulario and formulario.estrutura:
-            try:
-                formulario_estrutura = json.loads(formulario.estrutura)
-            except ValueError:
-                formulario_estrutura = []
-    if ordem.formulario_respostas_id:
-        fr = FormularioResposta.query.get(ordem.formulario_respostas_id)
-        if fr and fr.dados:
-            formulario_respostas = fr.dados
+    formulario_estrutura, formulario_respostas = _get_formulario_estrutura_respostas(ordem)
     return render_template(
         'ordens_servico/os_modal.html',
         ordem=ordem,
@@ -777,19 +790,7 @@ def os_atendimento_detalhar(ordem_id):
     if not _usuario_pode_acessar_os(usuario, ordem):
         abort(403)
     comentarios = OrdemServicoComentario.query.filter_by(os_id=ordem.id).order_by(OrdemServicoComentario.data_hora.asc()).all()
-    formulario_estrutura = None
-    formulario_respostas = None
-    if ordem.tipo_os and ordem.tipo_os.formulario_vinculado_id:
-        formulario = Formulario.query.get(ordem.tipo_os.formulario_vinculado_id)
-        if formulario and formulario.estrutura:
-            try:
-                formulario_estrutura = json.loads(formulario.estrutura)
-            except ValueError:
-                formulario_estrutura = []
-    if ordem.formulario_respostas_id:
-        fr = FormularioResposta.query.get(ordem.formulario_respostas_id)
-        if fr and fr.dados:
-            formulario_respostas = fr.dados
+    formulario_estrutura, formulario_respostas = _get_formulario_estrutura_respostas(ordem)
     return render_template(
         'ordens_servico/atendimento_detalhe.html',
         ordem=ordem,

--- a/templates/ordens_servico/atendimento_detalhe.html
+++ b/templates/ordens_servico/atendimento_detalhe.html
@@ -13,8 +13,9 @@
   {% if formulario_estrutura %}
   <div class="card shadow-sm mb-3">
     <div class="card-body">
-      {% set estrutura = formulario_estrutura %}
-      {% include 'ordens_servico/_formulario_vinculado_readonly.html' %}
+      {% with estrutura=formulario_estrutura, formulario_respostas=formulario_respostas %}
+        {% include 'ordens_servico/_formulario_vinculado_readonly.html' %}
+      {% endwith %}
     </div>
   </div>
   {% endif %}

--- a/templates/ordens_servico/detalhe_os.html
+++ b/templates/ordens_servico/detalhe_os.html
@@ -29,8 +29,9 @@
       {% if formulario_estrutura %}
       <div class="card shadow-sm mb-4">
         <div class="card-body">
-          {% set estrutura = formulario_estrutura %}
-          {% include 'ordens_servico/_formulario_vinculado_readonly.html' %}
+          {% with estrutura=formulario_estrutura, formulario_respostas=formulario_respostas %}
+            {% include 'ordens_servico/_formulario_vinculado_readonly.html' %}
+          {% endwith %}
         </div>
       </div>
       {% endif %}

--- a/templates/ordens_servico/os_modal.html
+++ b/templates/ordens_servico/os_modal.html
@@ -13,8 +13,9 @@
       {% if ordem.sistema %}<p class="mb-1"><strong>Sistema:</strong> {{ ordem.sistema.nome }}</p>{% endif %}
       {% if formulario_estrutura %}
       <div class="mt-3">
-        {% set estrutura = formulario_estrutura %}
-        {% include 'ordens_servico/_formulario_vinculado_readonly.html' %}
+        {% with estrutura=formulario_estrutura, formulario_respostas=formulario_respostas %}
+          {% include 'ordens_servico/_formulario_vinculado_readonly.html' %}
+        {% endwith %}
       </div>
       {% endif %}
     </div>

--- a/tests/test_ordem_servico.py
+++ b/tests/test_ordem_servico.py
@@ -301,6 +301,89 @@ def test_os_detalhar_exibe_respostas_formulario(client):
     assert 'Resposta' in html
 
 
+def test_os_detalhar_exibe_respostas_formulario_lista(client):
+    login_admin(client)
+    with app.app_context():
+        proc = Processo(nome='ProcRL')
+        etapa = ProcessoEtapa(nome='EtapaRL', ordem=1, processo=proc)
+        cel = Celula.query.first()
+        admin_user = User.query.filter_by(username='admin').first()
+        form = Formulario(
+            nome='FormRL',
+            estrutura='[{"tipo":"section","titulo":"Sec","campos":[{"id":1,"tipo":"text","label":"P1"}]}]',
+            criado_por_id=admin_user.id,
+            celula_id=cel.id,
+        )
+        respostas = FormularioResposta(dados=[{"id": 1, "resposta": "RespL"}])
+        db.session.add_all([proc, etapa, form, respostas])
+        db.session.commit()
+        tipo = TipoOS(
+            nome='TipoRL',
+            descricao='d',
+            equipe_responsavel_id=cel.id,
+            formulario_vinculado_id=form.id,
+        )
+        etapa.tipos_os.append(tipo)
+        os_obj = OrdemServico(
+            codigo=gerar_codigo_os(),
+            titulo='OSRL',
+            tipo_os=tipo,
+            status='rascunho',
+            criado_por_id=admin_user.id,
+            formulario_respostas_id=respostas.id,
+        )
+        db.session.add_all([tipo, os_obj])
+        db.session.commit()
+        os_id = os_obj.id
+    resp = client.get(f'/os/{os_id}')
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'RespL' in html
+
+
+def test_os_modal_e_atendimento_exibem_respostas_formulario(client):
+    login_admin(client)
+    with app.app_context():
+        proc = Processo(nome='ProcM')
+        etapa = ProcessoEtapa(nome='EtapaM', ordem=1, processo=proc)
+        cel = Celula.query.first()
+        admin_user = User.query.filter_by(username='admin').first()
+        form = Formulario(
+            nome='FormM',
+            estrutura='[{"tipo":"section","titulo":"Sec","campos":[{"id":1,"tipo":"text","label":"P1"}]}]',
+            criado_por_id=admin_user.id,
+            celula_id=cel.id,
+        )
+        respostas = FormularioResposta(dados={"1": "RespM"})
+        db.session.add_all([proc, etapa, form, respostas])
+        db.session.commit()
+        tipo = TipoOS(
+            nome='TipoM',
+            descricao='d',
+            equipe_responsavel_id=cel.id,
+            formulario_vinculado_id=form.id,
+        )
+        etapa.tipos_os.append(tipo)
+        os_obj = OrdemServico(
+            codigo=gerar_codigo_os(),
+            titulo='OSM',
+            tipo_os=tipo,
+            status='rascunho',
+            criado_por_id=admin_user.id,
+            formulario_respostas_id=respostas.id,
+        )
+        db.session.add_all([tipo, os_obj])
+        db.session.commit()
+        os_id = os_obj.id
+    resp = client.get(f'/os/{os_id}/modal')
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'RespM' in html
+    resp = client.get(f'/os/atendimento/{os_id}')
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'RespM' in html
+
 def test_os_nova_lista_tipos_para_usuario_sem_cargo(client):
     login_admin(client)
     with app.app_context():


### PR DESCRIPTION
## Resumo
- Passa explicitamente estrutura e respostas do formulário aos templates de detalhe, modal e atendimento, garantindo exibição dos valores preenchidos
- Adiciona teste cobrindo visualização das respostas nas rotas de modal e atendimento

## Testes
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4c326e600832e860e001e09370312