### PR TITLE
Use numeric server defaults for boolean fields

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -2,6 +2,7 @@
 from sqlalchemy.sql import func
 from sqlalchemy import Enum as SQLAEnum, Column, Text, ForeignKey, Date, Boolean, Integer, String, DateTime
 from sqlalchemy.orm import relationship, synonym
+import sqlalchemy as sa
 from werkzeug.security import generate_password_hash, check_password_hash # Mantendo seus imports de User
 import uuid
 
@@ -111,7 +112,7 @@ class Instituicao(db.Model):
     codigo = db.Column(db.String(7), unique=True, nullable=False)
     nome = db.Column(db.String(200), unique=True, nullable=False)
     descricao = db.Column(db.Text, nullable=True)
-    ativo = db.Column(db.Boolean, nullable=False, default=True, server_default='true')
+    ativo = db.Column(db.Boolean, nullable=False, default=True, server_default=sa.text('1'))
 
     estabelecimentos = db.relationship('Estabelecimento', back_populates='instituicao', lazy='dynamic')
 
@@ -156,7 +157,7 @@ class Estabelecimento(db.Model):
     observacoes = db.Column(db.Text, nullable=True)              # Campo para notas diversas
 
     # Status Ativo/Inativo (como discutimos)
-    ativo = db.Column(db.Boolean, nullable=False, default=True, server_default='true')
+    ativo = db.Column(db.Boolean, nullable=False, default=True, server_default=sa.text('1'))
     
     # Timestamps (opcional, mas útil)
     created_at = db.Column(db.DateTime(timezone=True), server_default=func.now())
@@ -176,7 +177,7 @@ class Setor(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     nome = db.Column(db.String(200), unique=True, nullable=False)
     descricao = db.Column(db.Text, nullable=True)
-    ativo = db.Column(db.Boolean, nullable=False, default=True, server_default='true')
+    ativo = db.Column(db.Boolean, nullable=False, default=True, server_default=sa.text('1'))
     
     estabelecimento_id = db.Column(db.Integer, db.ForeignKey('estabelecimento.id'), nullable=False)
     estabelecimento = db.relationship('Estabelecimento', back_populates='setores')
@@ -194,7 +195,7 @@ class Celula(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     nome = db.Column(db.String(200), unique=True, nullable=False)
-    ativo = db.Column(db.Boolean, nullable=False, default=True, server_default='true')
+    ativo = db.Column(db.Boolean, nullable=False, default=True, server_default=sa.text('1'))
 
     estabelecimento_id = db.Column(db.Integer, db.ForeignKey('estabelecimento.id'), nullable=False)
     estabelecimento = db.relationship('Estabelecimento', back_populates='celulas')
@@ -212,8 +213,8 @@ class Cargo(db.Model):
     nome = db.Column(db.String(200), unique=True, nullable=False)
     descricao = db.Column(db.Text, nullable=True)
     nivel_hierarquico = db.Column(db.Integer, nullable=True) # Para lógica de hierarquia (ex: 1=Alto, 10=Baixo)
-    ativo = db.Column(db.Boolean, nullable=False, default=True, server_default='true')
-    pode_atender_os = db.Column(db.Boolean, nullable=False, default=False, server_default='false')
+    ativo = db.Column(db.Boolean, nullable=False, default=True, server_default=sa.text('1'))
+    pode_atender_os = db.Column(db.Boolean, nullable=False, default=False, server_default=sa.text('0'))
     # Compatibilidade com nome antigo
     atende_ordem_servico = synonym('pode_atender_os')
 
@@ -254,7 +255,7 @@ class User(db.Model):
     data_nascimento = db.Column(db.Date, nullable=True)
     data_admissao = db.Column(db.Date, nullable=True)
     telefone_contato = db.Column(db.String(20), nullable=True) # Pode ser o celular ou outro contato
-    ativo = db.Column(db.Boolean, nullable=False, default=True, server_default='true')
+    ativo = db.Column(db.Boolean, nullable=False, default=True, server_default=sa.text('1'))
 
     # Novas Chaves Estrangeiras e Relacionamentos (Fase 1)
     # Um usuário pertence a um estabelecimento, um setor e tem um cargo.
@@ -442,7 +443,7 @@ class Notification(db.Model):
 
     tipo = db.Column(db.String(20), nullable=False, default='geral', server_default='geral')
 
-    lido = db.Column(db.Boolean, nullable=False, default=False, server_default='false')
+    lido = db.Column(db.Boolean, nullable=False, default=False, server_default=sa.text('0'))
     created_at = db.Column(db.DateTime(timezone=True), server_default=func.now(), nullable=False)
 
     user = db.relationship('User', back_populates='notifications')
@@ -458,7 +459,7 @@ class Processo(db.Model):
     id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     nome = db.Column(db.String(255), nullable=False)
     descricao = db.Column(db.Text, nullable=True)
-    ativo = db.Column(db.Boolean, nullable=False, default=True, server_default='true')
+    ativo = db.Column(db.Boolean, nullable=False, default=True, server_default=sa.text('1'))
 
     etapas = db.relationship('ProcessoEtapa', back_populates='processo', lazy='dynamic', cascade='all, delete-orphan')
 
@@ -474,7 +475,7 @@ class TipoOS(db.Model):
     descricao = db.Column(db.Text, nullable=True)
     equipe_responsavel_id = db.Column(db.Integer, db.ForeignKey('celula.id'), nullable=True)
     formulario_vinculado_id = db.Column(db.Integer, nullable=True)
-    obrigatorio_preenchimento = db.Column(db.Boolean, nullable=False, default=False, server_default='false')
+    obrigatorio_preenchimento = db.Column(db.Boolean, nullable=False, default=False, server_default=sa.text('0'))
     equipe_responsavel = db.relationship('Celula')
 
     etapas = db.relationship(
@@ -527,7 +528,7 @@ class CampoEtapa(db.Model):
     etapa_id = db.Column(db.String(36), db.ForeignKey('processo_etapa.id'), nullable=False)
     nome = db.Column(db.String(255), nullable=False)
     tipo = db.Column(db.String(20), nullable=False)
-    obrigatorio = db.Column(db.Boolean, nullable=False, default=False, server_default='false')
+    obrigatorio = db.Column(db.Boolean, nullable=False, default=False, server_default=sa.text('0'))
     opcoes = db.Column(db.JSON, nullable=True)
     dica = db.Column(db.String(255), nullable=True)
 
@@ -687,7 +688,7 @@ class Formulario(db.Model):
     estrutura = db.Column(db.Text, nullable=True)
     created_at = db.Column(db.DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = db.Column(db.DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
-    ativo = db.Column(db.Boolean, nullable=False, default=True, server_default='true')
+    ativo = db.Column(db.Boolean, nullable=False, default=True, server_default=sa.text('1'))
     criado_por_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     celula_id = db.Column(db.Integer, db.ForeignKey('celula.id'), nullable=False)
 
@@ -716,11 +717,11 @@ class CampoFormulario(db.Model):
     label = db.Column(db.String(200), nullable=False)
     subtitulo = db.Column(db.String(200), nullable=True)
     midia_url = db.Column(db.String(255), nullable=True)
-    obrigatoria = db.Column(db.Boolean, nullable=False, default=False, server_default='false')
-    permite_multipla_escolha = db.Column(db.Boolean, nullable=False, default=False, server_default='false')
-    usar_menu_suspenso = db.Column(db.Boolean, nullable=False, default=False, server_default='false')
-    embaralhar_opcoes = db.Column(db.Boolean, nullable=False, default=False, server_default='false')
-    tem_opcao_outra = db.Column(db.Boolean, nullable=False, default=False, server_default='false')
+    obrigatoria = db.Column(db.Boolean, nullable=False, default=False, server_default=sa.text('0'))
+    permite_multipla_escolha = db.Column(db.Boolean, nullable=False, default=False, server_default=sa.text('0'))
+    usar_menu_suspenso = db.Column(db.Boolean, nullable=False, default=False, server_default=sa.text('0'))
+    embaralhar_opcoes = db.Column(db.Boolean, nullable=False, default=False, server_default=sa.text('0'))
+    tem_opcao_outra = db.Column(db.Boolean, nullable=False, default=False, server_default=sa.text('0'))
     ramificacoes = db.Column(db.JSON, nullable=True)
     ordem = db.Column(db.Integer, nullable=False)
     opcoes = db.Column(db.Text, nullable=True)

--- a/migrations/versions/06df0a7c904d_fase1_estrutura_org_user_corrigida.py
+++ b/migrations/versions/06df0a7c904d_fase1_estrutura_org_user_corrigida.py
@@ -65,7 +65,7 @@ def upgrade():
         batch_op.add_column(sa.Column('data_nascimento', sa.Date(), nullable=True))
         batch_op.add_column(sa.Column('data_admissao', sa.Date(), nullable=True))
         batch_op.add_column(sa.Column('telefone_contato', sa.String(length=20), nullable=True))
-        batch_op.add_column(sa.Column('ativo', sa.Boolean(), server_default='true', nullable=False))
+        batch_op.add_column(sa.Column('ativo', sa.Boolean(), server_default=sa.text('1'), nullable=False))
         batch_op.add_column(sa.Column('estabelecimento_id', sa.Integer(), nullable=True))
         batch_op.add_column(sa.Column('centro_custo_id', sa.Integer(), nullable=True))
         batch_op.add_column(sa.Column('setor_id', sa.Integer(), nullable=True))

--- a/migrations/versions/09981b61c779_add_process_tables.py
+++ b/migrations/versions/09981b61c779_add_process_tables.py
@@ -22,7 +22,7 @@ def upgrade():
         sa.Column('id', sa.String(length=36), primary_key=True),
         sa.Column('nome', sa.String(length=255), nullable=False),
         sa.Column('descricao', sa.Text(), nullable=True),
-        sa.Column('ativo', sa.Boolean(), nullable=False, server_default='true'),
+        sa.Column('ativo', sa.Boolean(), nullable=False, server_default=sa.text('1')),
     )
 
     # 2) etapa_processo table
@@ -34,7 +34,7 @@ def upgrade():
         sa.Column('processo_id', sa.String(length=36), sa.ForeignKey('processo.id'), nullable=False),
         sa.Column('cargo_id', sa.Integer(), sa.ForeignKey('cargo.id'), nullable=True),
         sa.Column('setor_id', sa.Integer(), sa.ForeignKey('setor.id'), nullable=True),
-        sa.Column('obrigatoria', sa.Boolean(), nullable=False, server_default='true'),
+        sa.Column('obrigatoria', sa.Boolean(), nullable=False, server_default=sa.text('1')),
     )
 
     # 3) campo_etapa table
@@ -44,7 +44,7 @@ def upgrade():
         sa.Column('etapa_id', sa.String(length=36), sa.ForeignKey('etapa_processo.id'), nullable=False),
         sa.Column('nome', sa.String(length=255), nullable=False),
         sa.Column('tipo', sa.String(length=20), nullable=False),
-        sa.Column('obrigatorio', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('obrigatorio', sa.Boolean(), nullable=False, server_default=sa.text('0')),
         sa.Column('opcoes', postgresql.JSON(astext_type=sa.Text()), nullable=True),
         sa.Column('dica', sa.String(length=255), nullable=True),
     )

--- a/migrations/versions/167292e80389_add_detailed_fields_to_estabelecimento_.py
+++ b/migrations/versions/167292e80389_add_detailed_fields_to_estabelecimento_.py
@@ -29,10 +29,10 @@ def upgrade():
         #batch_op.drop_index('ix_attachment_content_fts', postgresql_using='gin')
 
     with op.batch_alter_table('cargo', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('ativo', sa.Boolean(), server_default='true', nullable=False))
+        batch_op.add_column(sa.Column('ativo', sa.Boolean(), server_default=sa.text('1'), nullable=False))
 
     with op.batch_alter_table('centro_custo', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('ativo', sa.Boolean(), server_default='true', nullable=False))
+        batch_op.add_column(sa.Column('ativo', sa.Boolean(), server_default=sa.text('1'), nullable=False))
 
     with op.batch_alter_table('estabelecimento', schema=None) as batch_op:
         batch_op.add_column(sa.Column('nome_fantasia', sa.String(length=200), nullable=False))
@@ -54,14 +54,14 @@ def upgrade():
         batch_op.add_column(sa.Column('email_contato', sa.String(length=120), nullable=True))
         batch_op.add_column(sa.Column('data_abertura', sa.Date(), nullable=True))
         batch_op.add_column(sa.Column('observacoes', sa.Text(), nullable=True))
-        batch_op.add_column(sa.Column('ativo', sa.Boolean(), server_default='true', nullable=False))
+        batch_op.add_column(sa.Column('ativo', sa.Boolean(), server_default=sa.text('1'), nullable=False))
         batch_op.add_column(sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True))
         batch_op.add_column(sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True))
         batch_op.create_unique_constraint(None, ['cnpj'])
         batch_op.drop_column('nome')
 
     with op.batch_alter_table('setor', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('ativo', sa.Boolean(), server_default='true', nullable=False))
+        batch_op.add_column(sa.Column('ativo', sa.Boolean(), server_default=sa.text('1'), nullable=False))
 
     # ### end Alembic commands ###
 

--- a/migrations/versions/1b2c3d4e5f67_add_form_builder_tables.py
+++ b/migrations/versions/1b2c3d4e5f67_add_form_builder_tables.py
@@ -16,7 +16,7 @@ depends_on = None
 
 def upgrade():
     with op.batch_alter_table('cargo', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('pode_atender_os', sa.Boolean(), nullable=False, server_default='false'))
+        batch_op.add_column(sa.Column('pode_atender_os', sa.Boolean(), nullable=False, server_default=sa.text('0')))
 
     op.create_table(
         'formulario',
@@ -33,7 +33,7 @@ def upgrade():
         sa.Column('formulario_id', sa.Integer(), sa.ForeignKey('formulario.id'), nullable=False),
         sa.Column('tipo', sa.String(length=50), nullable=False),
         sa.Column('label', sa.String(length=200), nullable=False),
-        sa.Column('obrigatorio', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('obrigatorio', sa.Boolean(), nullable=False, server_default=sa.text('0')),
         sa.Column('ordem', sa.Integer(), nullable=False),
         sa.Column('opcoes', sa.Text(), nullable=True),
         sa.Column('condicional', sa.Text(), nullable=True),

--- a/migrations/versions/3e4f5g6h7i8j_add_fields_campo_formulario.py
+++ b/migrations/versions/3e4f5g6h7i8j_add_fields_campo_formulario.py
@@ -13,10 +13,10 @@ def upgrade():
     op.alter_column('campo_formulario', 'obrigatorio', new_column_name='obrigatoria')
     op.add_column('campo_formulario', sa.Column('subtitulo', sa.String(length=200), nullable=True))
     op.add_column('campo_formulario', sa.Column('midia_url', sa.String(length=255), nullable=True))
-    op.add_column('campo_formulario', sa.Column('permite_multipla_escolha', sa.Boolean(), nullable=False, server_default='false'))
-    op.add_column('campo_formulario', sa.Column('usar_menu_suspenso', sa.Boolean(), nullable=False, server_default='false'))
-    op.add_column('campo_formulario', sa.Column('embaralhar_opcoes', sa.Boolean(), nullable=False, server_default='false'))
-    op.add_column('campo_formulario', sa.Column('tem_opcao_outra', sa.Boolean(), nullable=False, server_default='false'))
+    op.add_column('campo_formulario', sa.Column('permite_multipla_escolha', sa.Boolean(), nullable=False, server_default=sa.text('0')))
+    op.add_column('campo_formulario', sa.Column('usar_menu_suspenso', sa.Boolean(), nullable=False, server_default=sa.text('0')))
+    op.add_column('campo_formulario', sa.Column('embaralhar_opcoes', sa.Boolean(), nullable=False, server_default=sa.text('0')))
+    op.add_column('campo_formulario', sa.Column('tem_opcao_outra', sa.Boolean(), nullable=False, server_default=sa.text('0')))
     op.add_column('campo_formulario', sa.Column('ramificacoes', sa.JSON(), nullable=True))
 
 

--- a/migrations/versions/7c8d9e0f1a2b_add_ativo_to_formulario.py
+++ b/migrations/versions/7c8d9e0f1a2b_add_ativo_to_formulario.py
@@ -17,7 +17,7 @@ depends_on = None
 
 def upgrade():
     with op.batch_alter_table('formulario', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('ativo', sa.Boolean(), nullable=False, server_default='true'))
+        batch_op.add_column(sa.Column('ativo', sa.Boolean(), nullable=False, server_default=sa.text('1')))
 
 
 def downgrade():

--- a/migrations/versions/8f36375399a9_add_instituicao_and_celula.py
+++ b/migrations/versions/8f36375399a9_add_instituicao_and_celula.py
@@ -38,7 +38,7 @@ def upgrade():
         'celula',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('nome', sa.String(length=200), nullable=False),
-        sa.Column('ativo', sa.Boolean(), server_default='true', nullable=False),
+        sa.Column('ativo', sa.Boolean(), server_default=sa.text('1'), nullable=False),
         sa.Column('estabelecimento_id', sa.Integer(), nullable=False),
         sa.Column('setor_id', sa.Integer(), nullable=True),
         sa.Column('centro_custo_id', sa.Integer(), nullable=False),

--- a/migrations/versions/9e9642d233f1_add_ativo_to_instituicao.py
+++ b/migrations/versions/9e9642d233f1_add_ativo_to_instituicao.py
@@ -17,7 +17,7 @@ depends_on = None
 
 def upgrade():
     with op.batch_alter_table('instituicao', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('ativo', sa.Boolean(), nullable=False, server_default='true'))
+        batch_op.add_column(sa.Column('ativo', sa.Boolean(), nullable=False, server_default=sa.text('1')))
 
 
 def downgrade():

--- a/migrations/versions/ea3b24d8f6c7_add_tipo_os_and_cargo_processo_tables.py
+++ b/migrations/versions/ea3b24d8f6c7_add_tipo_os_and_cargo_processo_tables.py
@@ -41,7 +41,7 @@ def upgrade():
         sa.Column('subprocesso_id', sa.Integer(), sa.ForeignKey('subprocesso.id'), nullable=False),
         sa.Column('equipe_responsavel_id', sa.Integer(), sa.ForeignKey('celula.id'), nullable=True),
         sa.Column('formulario_vinculado_id', sa.Integer(), nullable=True),
-        sa.Column('obrigatorio_preenchimento', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('obrigatorio_preenchimento', sa.Boolean(), nullable=False, server_default=sa.text('0')),
     )
 
 


### PR DESCRIPTION
## Summary
- Replace `'true'`/`'false'` server defaults with `sa.text('1')`/`sa.text('0')` across models and migrations
- Import `sqlalchemy as sa` to support new `sa.text` usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a13cb0ec832eb45aa1503a1c6eb1