### PR TITLE
Use text columns with manual JSON serialization

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -14,6 +14,10 @@ try:
     from .enums import ArticleStatus, ArticleVisibility, OSStatus
 except ImportError:  # pragma: no cover - fallback for direct execution
     from core.enums import ArticleStatus, ArticleVisibility, OSStatus
+try:  # pragma: no cover - utils import
+    from .utils import serialize_json, deserialize_json
+except ImportError:  # pragma: no cover
+    from core.utils import serialize_json, deserialize_json
 
 # --- association tables for article visibility ---
 article_extra_celulas = db.Table(
@@ -529,13 +533,21 @@ class CampoEtapa(db.Model):
     nome = db.Column(db.String(255), nullable=False)
     tipo = db.Column(db.String(20), nullable=False)
     obrigatorio = db.Column(db.Boolean, nullable=False, default=False, server_default=sa.text('0'))
-    opcoes = db.Column(db.JSON, nullable=True)
+    _opcoes = db.Column('opcoes', db.Text, nullable=True)
     dica = db.Column(db.String(255), nullable=True)
 
     etapa = db.relationship('ProcessoEtapa', back_populates='campos')
 
     def __repr__(self):
         return f"<CampoEtapa {self.nome} ({self.tipo})>"
+
+    @property
+    def opcoes(self):
+        return deserialize_json(self._opcoes)
+
+    @opcoes.setter
+    def opcoes(self, value):
+        self._opcoes = serialize_json(value)
 
 
 # --- Novos modelos para Equipamento e Sistema ---
@@ -673,10 +685,18 @@ class FormularioResposta(db.Model):
     __tablename__ = 'formulario_respostas'
 
     id = db.Column(db.Integer, primary_key=True)
-    dados = db.Column(db.JSON, nullable=True)
+    _dados = db.Column('dados', db.Text, nullable=True)
 
     def __repr__(self):  # pragma: no cover
         return f"<FormularioResposta {self.id}>"
+
+    @property
+    def dados(self):
+        return deserialize_json(self._dados)
+
+    @dados.setter
+    def dados(self, value):
+        self._dados = serialize_json(value)
 
 
 class Formulario(db.Model):
@@ -722,7 +742,7 @@ class CampoFormulario(db.Model):
     usar_menu_suspenso = db.Column(db.Boolean, nullable=False, default=False, server_default=sa.text('0'))
     embaralhar_opcoes = db.Column(db.Boolean, nullable=False, default=False, server_default=sa.text('0'))
     tem_opcao_outra = db.Column(db.Boolean, nullable=False, default=False, server_default=sa.text('0'))
-    ramificacoes = db.Column(db.JSON, nullable=True)
+    _ramificacoes = db.Column('ramificacoes', db.Text, nullable=True)
     ordem = db.Column(db.Integer, nullable=False)
     opcoes = db.Column(db.Text, nullable=True)
     condicional = db.Column(db.Text, nullable=True)
@@ -741,6 +761,14 @@ class CampoFormulario(db.Model):
 
     def __repr__(self):
         return f"<CampoFormulario {self.label} ({self.tipo})>"
+
+    @property
+    def ramificacoes(self):
+        return deserialize_json(self._ramificacoes)
+
+    @ramificacoes.setter
+    def ramificacoes(self, value):
+        self._ramificacoes = serialize_json(value)
 
 
 class Secao(db.Model):

--- a/migrations/versions/09981b61c779_add_process_tables.py
+++ b/migrations/versions/09981b61c779_add_process_tables.py
@@ -6,7 +6,6 @@ Create Date: 2025-08-01 00:00:00
 """
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = '09981b61c779'
@@ -45,7 +44,7 @@ def upgrade():
         sa.Column('nome', sa.String(length=255), nullable=False),
         sa.Column('tipo', sa.String(length=20), nullable=False),
         sa.Column('obrigatorio', sa.Boolean(), nullable=False, server_default=sa.text('0')),
-        sa.Column('opcoes', postgresql.JSON(astext_type=sa.Text()), nullable=True),
+        sa.Column('opcoes', sa.Text(), nullable=True),
         sa.Column('dica', sa.String(length=255), nullable=True),
     )
 

--- a/migrations/versions/0b1c2d3e4f67_create_formulario_respostas_table.py
+++ b/migrations/versions/0b1c2d3e4f67_create_formulario_respostas_table.py
@@ -13,7 +13,7 @@ def upgrade():
     op.create_table(
         'formulario_respostas',
         sa.Column('id', sa.Integer(), primary_key=True),
-        sa.Column('dados', sa.JSON(), nullable=True),
+        sa.Column('dados', sa.Text(), nullable=True),
     )
     op.create_foreign_key(
         'ordem_servico_formulario_respostas_id_fkey',

--- a/migrations/versions/3e4f5g6h7i8j_add_fields_campo_formulario.py
+++ b/migrations/versions/3e4f5g6h7i8j_add_fields_campo_formulario.py
@@ -17,7 +17,7 @@ def upgrade():
     op.add_column('campo_formulario', sa.Column('usar_menu_suspenso', sa.Boolean(), nullable=False, server_default=sa.text('0')))
     op.add_column('campo_formulario', sa.Column('embaralhar_opcoes', sa.Boolean(), nullable=False, server_default=sa.text('0')))
     op.add_column('campo_formulario', sa.Column('tem_opcao_outra', sa.Boolean(), nullable=False, server_default=sa.text('0')))
-    op.add_column('campo_formulario', sa.Column('ramificacoes', sa.JSON(), nullable=True))
+    op.add_column('campo_formulario', sa.Column('ramificacoes', sa.Text(), nullable=True))
 
 
 def downgrade():


### PR DESCRIPTION
## Summary
- replace SQLAlchemy `JSON` columns with `Text` fields using custom serialization helpers
- add `serialize_json`/`deserialize_json` utilities for Oracle/Postgres compatibility
- adjust existing migrations to create text-based columns

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a692f7e0832ea91a8b218bf8d234