### PR TITLE
refactor: remove postgres-specific migrations

### DIFF
--- a/migrations/versions/0001_initial.py
+++ b/migrations/versions/0001_initial.py
@@ -2,7 +2,6 @@
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = '0001_initial'
@@ -12,19 +11,7 @@ depends_on = None
 
 
 def upgrade():
-    # 1) cria o ENUM article_status
-    op.execute("""
-        CREATE TYPE article_status AS ENUM (
-          'rascunho',
-          'pendente',
-          'em_revisao',
-          'em_ajuste',
-          'aprovado',
-          'rejeitado'
-        );
-    """)
-
-    # 2) cria a tabela user
+    # 1) cria a tabela user
     op.create_table(
         'user',
         sa.Column('id', sa.Integer(), primary_key=True),
@@ -35,35 +22,40 @@ def upgrade():
         sa.Column('foto', sa.String(255), nullable=True),
     )
 
-    # 3) cria a tabela article
+    # 2) cria a tabela article
     op.create_table(
         'article',
         sa.Column('id', sa.Integer(), primary_key=True),
         sa.Column('titulo', sa.String(200), nullable=False),
         sa.Column('texto', sa.Text(), nullable=False),
-        sa.Column('status', sa.Enum(
-            'rascunho','pendente','em_revisao','em_ajuste','aprovado','rejeitado',
-             name='article_status',
-             native_enum=False
-        ), nullable=False, server_default='rascunho'),
+        sa.Column(
+            'status',
+            sa.Enum(
+                'rascunho', 'pendente', 'em_revisao', 'em_ajuste', 'aprovado', 'rejeitado',
+                name='article_status',
+                native_enum=False,
+            ),
+            nullable=False,
+            server_default='rascunho',
+        ),
         sa.Column('user_id', sa.Integer(), sa.ForeignKey('user.id'), nullable=False),
         sa.Column('review_comment', sa.Text(), nullable=True),
         sa.Column('arquivos', sa.Text(), nullable=True),
-        sa.Column('created_at', postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text('now()')),
-        sa.Column('updated_at', postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text('now()')),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
     )
 
-    # 4) cria a tabela revision_request
+    # 3) cria a tabela revision_request
     op.create_table(
         'revision_request',
         sa.Column('id', sa.Integer(), primary_key=True),
         sa.Column('artigo_id', sa.Integer(), sa.ForeignKey('article.id'), nullable=False),
         sa.Column('user_id', sa.Integer(), sa.ForeignKey('user.id'), nullable=False),
         sa.Column('comentario', sa.Text(), nullable=False),
-        sa.Column('created_at', postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text('now()')),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
     )
 
-    # 5) cria a tabela notification
+    # 4) cria a tabela notification
     op.create_table(
         'notification',
         sa.Column('id', sa.Integer(), primary_key=True),
@@ -71,7 +63,7 @@ def upgrade():
         sa.Column('message', sa.String(255), nullable=False),
         sa.Column('url', sa.String(255), nullable=True),
         sa.Column('lido', sa.Boolean(), nullable=False, server_default=sa.false()),
-        sa.Column('created_at', postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text('now()')),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
     )
 
 
@@ -80,4 +72,4 @@ def downgrade():
     op.drop_table('revision_request')
     op.drop_table('article')
     op.drop_table('user')
-    op.execute('DROP TYPE article_status;')
+

--- a/migrations/versions/06df0a7c904d_fase1_estrutura_org_user_corrigida.py
+++ b/migrations/versions/06df0a7c904d_fase1_estrutura_org_user_corrigida.py
@@ -54,7 +54,7 @@ def upgrade():
     
     with op.batch_alter_table('attachment', schema=None) as batch_op:
         batch_op.add_column(sa.Column('original_filename', sa.Text(), nullable=True))
-        #batch_op.drop_index('ix_attachment_content_fts', postgresql_using='gin')
+        # batch_op.drop_index('ix_attachment_content_fts')
 
     with op.batch_alter_table('user', schema=None) as batch_op:
         batch_op.add_column(sa.Column('email', sa.String(length=120), nullable=False))
@@ -114,15 +114,15 @@ def downgrade():
         batch_op.drop_column('email')
 
     with op.batch_alter_table('attachment', schema=None) as batch_op:
-        batch_op.create_index('ix_attachment_content_fts', [sa.literal_column("to_tsvector('portuguese'::regconfig, content)")], unique=False, postgresql_using='gin')
+        batch_op.create_index('ix_attachment_content_fts', ['content'])
         batch_op.drop_column('original_filename')
 
     with op.batch_alter_table('article', schema=None) as batch_op:
         batch_op.alter_column('status',
-               existing_type=sa.Enum('rascunho', 'pendente', 'em_revisao', 'em_ajuste', 'aprovado', 'rejeitado', name='article_status'),
+               existing_type=sa.Enum('rascunho', 'pendente', 'em_revisao', 'em_ajuste', 'aprovado', 'rejeitado', name='article_status', native_enum=False),
                type_=sa.VARCHAR(length=10),
                existing_nullable=False,
-               existing_server_default=sa.text("'rascunho'::article_status"))
+               existing_server_default=sa.text("'rascunho'"))
 
     op.drop_table('setor')
     op.drop_table('centro_custo')

--- a/migrations/versions/09981b61c779_add_process_tables.py
+++ b/migrations/versions/09981b61c779_add_process_tables.py
@@ -56,7 +56,7 @@ def upgrade():
         sa.Column('campo_etapa_id', sa.String(length=36), sa.ForeignKey('campo_etapa.id'), nullable=False),
         sa.Column('valor', sa.Text(), nullable=True),
         sa.Column('preenchido_por', sa.Integer(), sa.ForeignKey('user.id'), nullable=False),
-        sa.Column('data_hora', sa.DateTime(timezone=True), nullable=False, server_default=sa.text('now()')),
+        sa.Column('data_hora', sa.DateTime(timezone=True), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
     )
 
 

--- a/migrations/versions/167292e80389_add_detailed_fields_to_estabelecimento_.py
+++ b/migrations/versions/167292e80389_add_detailed_fields_to_estabelecimento_.py
@@ -23,10 +23,10 @@ def upgrade():
     #           existing_type=sa.VARCHAR(length=10),
     #           type_=sa.Enum('rascunho', 'pendente', 'em_revisao', 'em_ajuste', 'aprovado', 'rejeitado', name='article_status'),
     #           existing_nullable=False,
-    #           existing_server_default=sa.text("'rascunho'::article_status"))
+    #           existing_server_default=sa.text("'rascunho'"))
 
     #with op.batch_alter_table('attachment', schema=None) as batch_op:
-        #batch_op.drop_index('ix_attachment_content_fts', postgresql_using='gin')
+    #    batch_op.drop_index('ix_attachment_content_fts')
 
     with op.batch_alter_table('cargo', schema=None) as batch_op:
         batch_op.add_column(sa.Column('ativo', sa.Boolean(), server_default=sa.text('1'), nullable=False))
@@ -55,8 +55,8 @@ def upgrade():
         batch_op.add_column(sa.Column('data_abertura', sa.Date(), nullable=True))
         batch_op.add_column(sa.Column('observacoes', sa.Text(), nullable=True))
         batch_op.add_column(sa.Column('ativo', sa.Boolean(), server_default=sa.text('1'), nullable=False))
-        batch_op.add_column(sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True))
-        batch_op.add_column(sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True))
+        batch_op.add_column(sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=True))
+        batch_op.add_column(sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=True))
         batch_op.create_unique_constraint(None, ['cnpj'])
         batch_op.drop_column('nome')
 
@@ -104,13 +104,13 @@ def downgrade():
         batch_op.drop_column('ativo')
 
     with op.batch_alter_table('attachment', schema=None) as batch_op:
-        batch_op.create_index('ix_attachment_content_fts', [sa.literal_column("to_tsvector('portuguese'::regconfig, content)")], unique=False, postgresql_using='gin')
+        batch_op.create_index('ix_attachment_content_fts', ['content'])
 
     #with op.batch_alter_table('article', schema=None) as batch_op:
     #    batch_op.alter_column('status',
     #           existing_type=sa.Enum('rascunho', 'pendente', 'em_revisao', 'em_ajuste', 'aprovado', 'rejeitado', name='article_status'),
     #           type_=sa.VARCHAR(length=10),
     #           existing_nullable=False,
-    #           existing_server_default=sa.text("'rascunho'::article_status"))
+    #           existing_server_default=sa.text("'rascunho'"))
 
     # ### end Alembic commands ###

--- a/migrations/versions/1a2b3c4d5e7f_add_ordem_servico_table.py
+++ b/migrations/versions/1a2b3c4d5e7f_add_ordem_servico_table.py
@@ -17,8 +17,8 @@ def upgrade():
         sa.Column('descricao', sa.Text(), nullable=True),
         sa.Column('processo_id', sa.String(length=36), nullable=True),
         sa.Column('status', sa.String(length=20), nullable=False, server_default='aberta'),
-        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
-        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'), onupdate=sa.text('CURRENT_TIMESTAMP'), nullable=False),
         sa.ForeignKeyConstraint(['processo_id'], ['processo.id']),
         sa.PrimaryKeyConstraint('id')
     )

--- a/migrations/versions/1b2c3d4e5f67_add_form_builder_tables.py
+++ b/migrations/versions/1b2c3d4e5f67_add_form_builder_tables.py
@@ -23,8 +23,8 @@ def upgrade():
         sa.Column('id', sa.Integer(), primary_key=True),
         sa.Column('nome', sa.String(length=200), nullable=False),
         sa.Column('estrutura', sa.Text(), nullable=True),
-        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
-        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
     )
 
     op.create_table(

--- a/migrations/versions/4c93f35865c8_add_attachment_table.py
+++ b/migrations/versions/4c93f35865c8_add_attachment_table.py
@@ -3,11 +3,10 @@
 Revision ID: 4c93f35865c8
 Revises: 67ef260f5a21
 Create Date: 2025-05-27 09:27:50.322986
-
 """
+
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = '4c93f35865c8'
@@ -25,27 +24,27 @@ def upgrade():
         sa.Column('filename', sa.Text(), nullable=False),
         sa.Column('mime_type', sa.Text(), nullable=False),
         sa.Column('content', sa.Text(), nullable=True),
-        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
     )
-    # 2) Índice GIN para busca full-text no content
-    op.execute(
-        "CREATE INDEX ix_attachment_content_fts "
-        "ON attachment USING GIN(to_tsvector('portuguese', content));"
-    )
+    # 2) Índice para busca no content
+    op.create_index('ix_attachment_content_fts', 'attachment', ['content'])
 
     # Ajustes herdados da migração anterior
     with op.batch_alter_table('article', schema=None) as batch_op:
-        batch_op.alter_column('status',
-               existing_type=postgresql.ENUM(
-                   'rascunho','pendente','em_revisao','em_ajuste','aprovado','rejeitado',
-                   name='article_status'),
-               type_=sa.Enum(
-                   'rascunho','pendente','em_revisao','em_ajuste','aprovado','rejeitado',
-                   name='article_status', native_enum=False),
-               existing_nullable=False,
-               existing_server_default=sa.text("'rascunho'::article_status")
+        batch_op.alter_column(
+            'status',
+            existing_type=sa.Enum(
+                'rascunho','pendente','em_revisao','em_ajuste','aprovado','rejeitado',
+                name='article_status', native_enum=False
+            ),
+            type_=sa.Enum(
+                'rascunho','pendente','em_revisao','em_ajuste','aprovado','rejeitado',
+                name='article_status', native_enum=False
+            ),
+            existing_nullable=False,
+            existing_server_default=sa.text("'rascunho'")
         )
-    
+
     bind = op.get_bind()
     inspector = sa.inspect(bind)
     columns = {col['name'] for col in inspector.get_columns('user')}
@@ -71,35 +70,39 @@ def upgrade():
 
 def downgrade():
     # 1) Remove índice e tabela attachment
-    op.execute("DROP INDEX ix_attachment_content_fts;")
+    op.drop_index('ix_attachment_content_fts', table_name='attachment')
     op.drop_table('attachment')
 
     # 2) Reverte ajustes de user
     with op.batch_alter_table('user', schema=None) as batch_op:
         batch_op.add_column(sa.Column('setor', sa.VARCHAR(length=80), nullable=True))
         batch_op.add_column(sa.Column('cargo', sa.VARCHAR(length=80), nullable=True))
-        batch_op.alter_column('foto',
-               existing_type=sa.String(length=255),
-               type_=sa.VARCHAR(length=200),
-               existing_nullable=True
+        batch_op.alter_column(
+            'foto',
+            existing_type=sa.String(length=255),
+            type_=sa.VARCHAR(length=200),
+            existing_nullable=True,
         )
-        batch_op.alter_column('nome_completo',
-               existing_type=sa.String(length=255),
-               type_=sa.VARCHAR(length=120),
-               existing_nullable=True
+        batch_op.alter_column(
+            'nome_completo',
+            existing_type=sa.String(length=255),
+            type_=sa.VARCHAR(length=120),
+            existing_nullable=True,
         )
 
     # 3) Reverte ajuste na article.status
     with op.batch_alter_table('article', schema=None) as batch_op:
-        batch_op.alter_column('status',
-               existing_type=sa.Enum(
-                   'rascunho','pendente','em_revisao','em_ajuste','aprovado','rejeitado',
-                   name='article_status', native_enum=False),
-               type_=postgresql.ENUM(
-                   'rascunho','pendente','em_revisao','em_ajuste','aprovado','rejeitado',
-                   name='article_status'),
-               existing_nullable=False,
-               existing_server_default=sa.text("'rascunho'::article_status")
+        batch_op.alter_column(
+            'status',
+            existing_type=sa.Enum(
+                'rascunho','pendente','em_revisao','em_ajuste','aprovado','rejeitado',
+                name='article_status', native_enum=False
+            ),
+            type_=sa.Enum(
+                'rascunho','pendente','em_revisao','em_ajuste','aprovado','rejeitado',
+                name='article_status', native_enum=False
+            ),
+            existing_nullable=False,
+            existing_server_default=sa.text("'rascunho'")
         )
 
-    # ### end Alembic commands ###

--- a/migrations/versions/67ef260f5a21_add_comment_table.py
+++ b/migrations/versions/67ef260f5a21_add_comment_table.py
@@ -4,9 +4,9 @@ Revision ID: 67ef260f5a21
 Revises: 0001_initial
 Create Date: 2025-05-22 17:07:52.415963
 """
+
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 revision = "67ef260f5a21"
 down_revision = "0001_initial"
@@ -25,35 +25,12 @@ def upgrade():
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
-            server_default=sa.text("now()"),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
             nullable=True,
         ),
     )
 
-    # 2) Corrige o tipo ENUM article_status para usar rótulos minúsculos
-    op.execute(
-        """
-        -- 2.1  Renomeia o enum atual (maiúsculo) para não colidir
-        ALTER TYPE article_status RENAME TO article_status_old;
-
-        -- 2.2  Cria o enum correto (minúsculo)
-        CREATE TYPE article_status AS ENUM
-          ('rascunho','pendente','em_revisao','em_ajuste','aprovado','rejeitado');
-
-        -- 2.3  Converte a coluna, normalizando valores para minúsculo
-        ALTER TABLE article
-          ALTER COLUMN status DROP DEFAULT,
-          ALTER COLUMN status TYPE article_status
-            USING lower(status)::article_status,
-          ALTER COLUMN status SET DEFAULT 'rascunho'::article_status;
-
-        -- 2.4  Remove o enum antigo
-        DROP TYPE article_status_old;
-        """
-    )
-
-
-    # 3) url em notification vira NOT NULL
+    # 2) url em notification vira NOT NULL
     with op.batch_alter_table("notification") as batch_op:
         batch_op.alter_column(
             "url",
@@ -61,13 +38,13 @@ def upgrade():
             nullable=False,
         )
 
-    # 4) created_at em revision_request deixa de ser NOT NULL
+    # 3) created_at em revision_request deixa de ser NOT NULL
     with op.batch_alter_table("revision_request") as batch_op:
         batch_op.alter_column(
             "created_at",
-            existing_type=postgresql.TIMESTAMP(timezone=True),
+            existing_type=sa.DateTime(timezone=True),
             nullable=True,
-            existing_server_default=sa.text("now()"),
+            existing_server_default=sa.text("CURRENT_TIMESTAMP"),
         )
 
 
@@ -76,9 +53,9 @@ def downgrade():
     with op.batch_alter_table("revision_request") as batch_op:
         batch_op.alter_column(
             "created_at",
-            existing_type=postgresql.TIMESTAMP(timezone=True),
+            existing_type=sa.DateTime(timezone=True),
             nullable=False,
-            existing_server_default=sa.text("now()"),
+            existing_server_default=sa.text("CURRENT_TIMESTAMP"),
         )
 
     # 2) url em notification volta a aceitar NULL
@@ -89,15 +66,6 @@ def downgrade():
             nullable=True,
         )
 
-    # 3) Converte enum → varchar
-    op.execute(
-        """
-        ALTER TABLE article
-          ALTER COLUMN status DROP DEFAULT,
-          ALTER COLUMN status TYPE varchar(10) USING status::varchar,
-          ALTER COLUMN status SET DEFAULT 'rascunho';
-        """
-    )
-
-    # 4) Remove a tabela comment
+    # 3) Remove a tabela comment
     op.drop_table("comment")
+

--- a/migrations/versions/6b6b76d9b5e5_fix_ordem_servico_tipo_os_fk.py
+++ b/migrations/versions/6b6b76d9b5e5_fix_ordem_servico_tipo_os_fk.py
@@ -19,7 +19,6 @@ def upgrade():
             existing_type=sa.String(length=36),
             type_=sa.Integer(),
             existing_nullable=False,
-            postgresql_using='tipo_os_id::integer'
         )
         # Create new FK to tipo_os
         batch_op.create_foreign_key(
@@ -34,7 +33,6 @@ def downgrade():
             existing_type=sa.Integer(),
             type_=sa.String(length=36),
             existing_nullable=False,
-            postgresql_using='tipo_os_id::text'
         )
         batch_op.create_foreign_key(
             'ordem_servico_processo_id_fkey', 'processo', ['tipo_os_id'], ['id']

--- a/migrations/versions/ab12cd34ef56_restructure_ordem_servico.py
+++ b/migrations/versions/ab12cd34ef56_restructure_ordem_servico.py
@@ -22,7 +22,7 @@ def upgrade():
     op.add_column('ordem_servico', sa.Column('criado_por_id', sa.Integer(), nullable=False))
     op.add_column('ordem_servico', sa.Column('atribuido_para_id', sa.Integer(), nullable=True))
     op.add_column('ordem_servico', sa.Column('equipe_responsavel_id', sa.Integer(), nullable=True))
-    op.add_column('ordem_servico', sa.Column('data_criacao', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False))
+    op.add_column('ordem_servico', sa.Column('data_criacao', sa.DateTime(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False))
     op.add_column('ordem_servico', sa.Column('data_conclusao', sa.DateTime(timezone=True), nullable=True))
     op.add_column('ordem_servico', sa.Column('formulario_respostas_id', sa.Integer(), nullable=True))
     op.add_column('ordem_servico', sa.Column('prioridade', sa.String(length=10), nullable=True))
@@ -41,7 +41,7 @@ def upgrade():
         'ordem_servico_log',
         sa.Column('id', sa.Integer(), primary_key=True),
         sa.Column('os_id', sa.String(length=36), sa.ForeignKey('ordem_servico.id'), nullable=False),
-        sa.Column('data_hora', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('data_hora', sa.DateTime(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
         sa.Column('usuario_id', sa.Integer(), sa.ForeignKey('user.id'), nullable=False),
         sa.Column('acao', sa.String(length=255), nullable=False),
         sa.Column('origem_status', sa.String(length=20)),
@@ -54,7 +54,7 @@ def upgrade():
         sa.Column('id', sa.Integer(), primary_key=True),
         sa.Column('os_id', sa.String(length=36), sa.ForeignKey('ordem_servico.id'), nullable=False),
         sa.Column('usuario_id', sa.Integer(), sa.ForeignKey('user.id'), nullable=False),
-        sa.Column('data_hora', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('data_hora', sa.DateTime(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
         sa.Column('mensagem', sa.Text(), nullable=False),
         sa.Column('anexo', sa.String(length=255))
     )
@@ -64,8 +64,8 @@ def downgrade():
     op.drop_table('ordem_servico_comentario')
     op.drop_table('ordem_servico_log')
     op.drop_table('ordem_servico_participante')
-    op.add_column('ordem_servico', sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False))
-    op.add_column('ordem_servico', sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False))
+    op.add_column('ordem_servico', sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False))
+    op.add_column('ordem_servico', sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False))
     op.drop_column('ordem_servico', 'observacoes')
     op.drop_column('ordem_servico', 'origem')
     op.drop_column('ordem_servico', 'prioridade')


### PR DESCRIPTION
## Summary
- replace Postgres-only types with generic SQLAlchemy types
- drop raw CREATE TYPE and GIN index usages
- remove `postgresql_using` casts for wider database compatibility

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5da26cb68832e8023bef490869204