### PR TITLE
Add optional Oracle driver and document DATABASE_URI drivers

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -38,7 +38,9 @@ Copie o arquivo `.env.example` para `.env` e defina os valores das variáveis `S
 SENDGRID_API_KEY=seu_token_sendgrid
 EMAIL_FROM=notificacoes@exemplo.com
 SECRET_KEY=<sua_chave_aleatoria>
-DATABASE_URI=postgresql://usuario:senha@localhost:5432/repositorio_equipe_db
+DATABASE_URI=postgresql+psycopg2://usuario:senha@localhost:5432/repositorio_equipe_db
+# Para usar Oracle, instale o pacote opcional `oracledb` e utilize:
+# DATABASE_URI=oracle+oracledb://usuario:senha@host:1521/?service_name=ORCL
 ```
 Garanta também que `FLASK_APP=app.py` e `FLASK_DEBUG=0` estejam configurados para execução em produção.
 

--- a/docs/GUIA_DE_INSTALACAO.md
+++ b/docs/GUIA_DE_INSTALACAO.md
@@ -175,6 +175,8 @@ pip install -r requirements.txt
 # Se ocorrerem erros de compilação (lxml, numpy ou opencv),
 # execute a reinstalação a seguir para Python 3.11:
 pip install --force-reinstall lxml "numpy<2" opencv-python python-docx
+# Caso utilize Oracle, instale também o driver opcional:
+# pip install oracledb
 ```
 
 ## 10. Configurar Variáveis de Ambiente Essenciais (no Windows)
@@ -211,10 +213,11 @@ O arquivo `app.py` do Orquetask está programado para ler essas variáveis do se
         * Copie a longa string hexadecimal que for gerada. Este será o valor da sua variável `SECRET_KEY`.
 
     4.  **`DATABASE_URI`**:
-        * **Propósito:** A string de conexão com o seu banco de dados PostgreSQL.
+        * **Propósito:** A string de conexão com o banco de dados e o **driver** usado pelo SQLAlchemy.
         * **AÇÃO OBRIGATÓRIA:** Você **DEVE** definir esta variável de ambiente com as credenciais do **novo usuário seguro** que você criou no Passo 5 do guia de configuração do banco de dados. A aplicação Orquetask foi configurada para dar erro se esta variável não for encontrada no ambiente, garantindo que apenas conexões seguras e explicitamente configuradas sejam usadas.
-        * **Valor a Definir (exemplo de formato):**
-            `postgresql://SEU_NOVO_USUARIO_DO_BANCO:SUA_NOVA_SENHA_FORTE@localhost:5432/repositorio_equipe_db`
+        * **Valor a Definir (exemplos de formato):**
+            `postgresql+psycopg2://SEU_NOVO_USUARIO_DO_BANCO:SUA_NOVA_SENHA_FORTE@localhost:5432/repositorio_equipe_db`
+            `oracle+oracledb://usuario:senha@host:1521/?service_name=ORCL` *(requer o pacote opcional `oracledb`)*
             *(Substitua `SEU_NOVO_USUARIO_DO_BANCO` e `SUA_NOVA_SENHA_FORTE` pelos que você criou no Passo 5. Lembre-se de codificar caracteres especiais na senha se houver, como `!` que vira `%21`).*
 
 * **Como Definir as Variáveis de Ambiente Permanentemente no Windows (Recomendado):**

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ Orquetask é um sistema web integrado construído com Flask e Python, projetado 
 
 * **Backend:** Python 3, Flask
 * **Frontend:** HTML5, CSS3 (Bootstrap 5), JavaScript (Vanilla JS), Quill.js
-* **Banco de Dados:** PostgreSQL
+* **Banco de Dados:** PostgreSQL (padrão) / Oracle (opcional via `oracledb`)
 * **ORM / Migrations:** SQLAlchemy, Alembic (via Flask-SQLAlchemy, Flask-Migrate)
 * **Principais Bibliotecas:** Werkzeug, Jinja2, psycopg2-binary, python-docx, openpyxl, xlrd, odfpy, pdf2image, pytesseract, Pillow, opencv-python, Bleach, python-dotenv.
 
@@ -80,9 +80,12 @@ Consulte o passo a passo de instalação dessas dependências e a configuração
     pip install --force-reinstall lxml "numpy<2" opencv-python python-docx
     ```
 
-4.  **Configure o Banco de Dados PostgreSQL e Variáveis de Ambiente:**
+4.  **Configure o Banco de Dados e Variáveis de Ambiente:**
 
     * Siga as instruções detalhadas no nosso **[Guia de Instalação e Configuração](./GUIA_DE_INSTALACAO.md)** para criar o banco de dados, o usuário do banco com as permissões corretas, e para configurar as variáveis de ambiente essenciais (`FLASK_APP`, `FLASK_DEBUG`, `SECRET_KEY`, `DATABASE_URI`).
+    * A variável `DATABASE_URI` também define o **driver** do SQLAlchemy. Exemplos:
+        * `postgresql+psycopg2://usuario:senha@localhost:5432/repositorio_equipe_db` (padrão, já utiliza `psycopg2-binary`).
+        * `oracle+oracledb://usuario:senha@host:1521/?service_name=ORCL` (requer o pacote opcional `oracledb`).
     * Para habilitar o envio de e-mails, consulte a seção [Configurar Envio de E-mails com SendGrid](./GUIA_DE_INSTALACAO.md#14-configurar-envio-de-e-mails-com-sendgrid-opcional) e defina `SENDGRID_API_KEY` e `EMAIL_FROM` no seu ambiente.
 
 5.  **Aplique as migrações do banco de dados:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ tzdata==2025.2
 webencodings==0.5.1
 Werkzeug==3.1.3
 xlrd==2.0.1
+oracledb ; extra == "oracle"  # optional Oracle DB driver


### PR DESCRIPTION
## Summary
- add optional `oracledb` dependency for Oracle support
- document driver selection via `DATABASE_URI`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5dd0eb650832ea06af2299871b1fd