### PR TITLE
Add Oracle connection test CLI

### DIFF
--- a/tests/test_test_oracle_cli.py
+++ b/tests/test_test_oracle_cli.py
@@ -1,0 +1,8 @@
+import os
+
+from tools import test_oracle
+
+
+def test_test_oracle_cli_success(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    assert test_oracle.main() == 0

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts for maintenance and development."""

--- a/tools/test_oracle.py
+++ b/tools/test_oracle.py
@@ -1,0 +1,41 @@
+"""CLI to validate Oracle database connectivity using SQLAlchemy.
+
+Run with ``python -m tools.test_oracle``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import SQLAlchemyError
+
+
+def main() -> int:
+    """Attempt to connect to the database and confirm permissions.
+
+    Reads the ``DATABASE_URL`` environment variable, establishes a connection
+    via SQLAlchemy and tries to create and drop a temporary table. Any failure
+    returns a non-zero exit status.
+    """
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        print("DATABASE_URL environment variable not set", file=sys.stderr)
+        return 1
+
+    engine = create_engine(db_url)
+
+    try:
+        with engine.begin() as connection:
+            connection.execute(text("CREATE TABLE TEST_ORACLE_CONNECTION (id NUMBER)"))
+            connection.execute(text("DROP TABLE TEST_ORACLE_CONNECTION"))
+        print("Database connection and permissions verified")
+        return 0
+    except SQLAlchemyError as exc:  # pragma: no cover - error handling
+        print(f"Database test failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - module execution
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a `python -m tools.test_oracle` helper that reads `DATABASE_URL`, connects with SQLAlchemy, and creates/drops a table to verify permissions
- cover the CLI with a unit test using an in-memory SQLite URL

## Testing
- `DATABASE_URL=sqlite:///:memory: python -m tools.test_oracle`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5dfd8e2bc832ea01943e1851535d0