### PR TITLE
Handle Oracle LOB index constraint in migrations

### DIFF
--- a/migrations/versions/06df0a7c904d_fase1_estrutura_org_user_corrigida.py
+++ b/migrations/versions/06df0a7c904d_fase1_estrutura_org_user_corrigida.py
@@ -114,7 +114,9 @@ def downgrade():
         batch_op.drop_column('email')
 
     with op.batch_alter_table('attachment', schema=None) as batch_op:
-        batch_op.create_index('ix_attachment_content_fts', ['content'])
+        bind = op.get_bind()
+        if bind.dialect.name != 'oracle':
+            batch_op.create_index('ix_attachment_content_fts', ['content'])
         batch_op.drop_column('original_filename')
 
     with op.batch_alter_table('article', schema=None) as batch_op:

--- a/migrations/versions/167292e80389_add_detailed_fields_to_estabelecimento_.py
+++ b/migrations/versions/167292e80389_add_detailed_fields_to_estabelecimento_.py
@@ -104,7 +104,9 @@ def downgrade():
         batch_op.drop_column('ativo')
 
     with op.batch_alter_table('attachment', schema=None) as batch_op:
-        batch_op.create_index('ix_attachment_content_fts', ['content'])
+        bind = op.get_bind()
+        if bind.dialect.name != 'oracle':
+            batch_op.create_index('ix_attachment_content_fts', ['content'])
 
     #with op.batch_alter_table('article', schema=None) as batch_op:
     #    batch_op.alter_column('status',


### PR DESCRIPTION
## Summary
- Guard `attachment.content` index creation and removal for Oracle, where LOB columns cannot be indexed with B-tree indexes
- Protect later migrations' downgrade paths from creating the same index on Oracle

## Testing
- `pytest tests/test_migrations.py tests/test_test_oracle_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5e379c5d8832eb96b81ad9a72cfe7