### PR TITLE
fix: handle existing attachment table

### DIFF
--- a/migrations/versions/4c93f35865c8_add_attachment_table.py
+++ b/migrations/versions/4c93f35865c8_add_attachment_table.py
@@ -16,21 +16,25 @@ depends_on = None
 
 
 def upgrade():
-    # 1) Cria a tabela attachment
-    op.create_table(
-        'attachment',
-        sa.Column('id', sa.Integer(), primary_key=True),
-        sa.Column('article_id', sa.Integer(), sa.ForeignKey('article.id', ondelete='CASCADE'), nullable=False),
-        sa.Column('filename', sa.Text(), nullable=False),
-        sa.Column('mime_type', sa.Text(), nullable=False),
-        sa.Column('content', sa.Text(), nullable=True),
-        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
-    )
-    # 2) Índice para busca no content
     bind = op.get_bind()
-    if bind.dialect.name != 'oracle':
-        # Oracle não permite índice direto em colunas LOB
-        op.create_index('ix_attachment_content_fts', 'attachment', ['content'])
+    inspector = sa.inspect(bind)
+
+    # 1) Cria a tabela attachment somente se não existir
+    if not inspector.has_table('attachment'):
+        op.create_table(
+            'attachment',
+            sa.Column('id', sa.Integer(), primary_key=True),
+            sa.Column('article_id', sa.Integer(), sa.ForeignKey('article.id', ondelete='CASCADE'), nullable=False),
+            sa.Column('filename', sa.Text(), nullable=False),
+            sa.Column('mime_type', sa.Text(), nullable=False),
+            sa.Column('content', sa.Text(), nullable=True),
+            sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
+        )
+
+        # 2) Índice para busca no content
+        if bind.dialect.name != 'oracle':
+            # Oracle não permite índice direto em colunas LOB
+            op.create_index('ix_attachment_content_fts', 'attachment', ['content'])
 
     # Ajustes herdados da migração anterior
     with op.batch_alter_table('article', schema=None) as batch_op:
@@ -48,7 +52,6 @@ def upgrade():
             existing_server_default=sa.text("'rascunho'")
         )
 
-    inspector = sa.inspect(bind)
     columns = {col['name'] for col in inspector.get_columns('user')}
 
     with op.batch_alter_table('user', schema=None) as batch_op:
@@ -73,9 +76,11 @@ def upgrade():
 def downgrade():
     # 1) Remove índice e tabela attachment
     bind = op.get_bind()
-    if bind.dialect.name != 'oracle':
-        op.drop_index('ix_attachment_content_fts', table_name='attachment')
-    op.drop_table('attachment')
+    inspector = sa.inspect(bind)
+    if inspector.has_table('attachment'):
+        if bind.dialect.name != 'oracle':
+            op.drop_index('ix_attachment_content_fts', table_name='attachment')
+        op.drop_table('attachment')
 
     # 2) Reverte ajustes de user
     with op.batch_alter_table('user', schema=None) as batch_op:


### PR DESCRIPTION
## Summary
- skip creating attachment table if it already exists to avoid ORA-00955
- safely drop attachment table/index in downgrade only when present

## Testing
- `pytest -q` *(fails: command not found)*
- `pip install pytest` *(fails: externally-managed-environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fe40a888832e8110f667da64ff49