### PR TITLE
Avoid invalid drops in migrations for Oracle

### DIFF
--- a/migrations/versions/b21bf94c6932_drop_centro_custo.py
+++ b/migrations/versions/b21bf94c6932_drop_centro_custo.py
@@ -10,17 +10,14 @@ depends_on = None
 
 
 def upgrade():
-    # Remove foreign key constraints and columns referencing centro_custo
+    """Remove columns referencing centro_custo and drop the table."""
     with op.batch_alter_table('user') as batch_op:
-        batch_op.drop_constraint('user_centro_custo_id_fkey', type_='foreignkey')
         batch_op.drop_column('centro_custo_id')
 
     with op.batch_alter_table('setor') as batch_op:
-        batch_op.drop_constraint('setor_centro_custo_id_fkey', type_='foreignkey')
         batch_op.drop_column('centro_custo_id')
 
     with op.batch_alter_table('celula') as batch_op:
-        batch_op.drop_constraint('celula_centro_custo_id_fkey', type_='foreignkey')
         batch_op.drop_column('centro_custo_id')
 
     op.drop_table('centro_custo')

--- a/migrations/versions/f5c6d7e8a9b0_drop_legacy_role_tables.py
+++ b/migrations/versions/f5c6d7e8a9b0_drop_legacy_role_tables.py
@@ -10,9 +10,13 @@ depends_on = None
 
 
 def upgrade():
-    # Remove tables from the old role-based display system if they exist
-    for table in ['legacy_role', 'legacy_role_permissions']:
-        op.execute(f'DROP TABLE IF EXISTS {table} CASCADE')
+    """Remove tables from the old role-based display system if they exist."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    # Drop child table first to avoid foreign key issues
+    for table in ['legacy_role_permissions', 'legacy_role']:
+        if inspector.has_table(table):
+            op.drop_table(table)
 
 
 def downgrade():


### PR DESCRIPTION
## Summary
- Remove explicit foreign key drops in `b21bf94c6932_drop_centro_custo` migration to accommodate Oracle's automatic constraint names
- Safely drop legacy role tables only if they exist to avoid unsupported `IF EXISTS` syntax on Oracle

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b600763bcc832e871b09c87e8b215b