### PR TITLE
Fix funcao seeding for Oracle databases

### DIFF
--- a/migrations/versions/fa23b0c1c9d0_seed_article_permissions.py
+++ b/migrations/versions/fa23b0c1c9d0_seed_article_permissions.py
@@ -25,16 +25,25 @@ def upgrade():
         ("artigo_revisar", "Revisar artigo"),
         ("artigo_assumir_revisao", "Assumir revisão"),
     ]
+
+    # Determine the current max id once to generate new ids manually. This
+    # avoids relying on database-specific autoincrement behavior which may be
+    # absent (e.g. in Oracle).
+    next_id = connection.execute(
+        sa.text("SELECT COALESCE(MAX(id), 0) FROM funcao")
+    ).scalar()
+
     for codigo, nome in perms:
         res = connection.execute(
             sa.text("SELECT id FROM funcao WHERE codigo=:c"), {"c": codigo}
         ).first()
         if not res:
+            next_id += 1
             connection.execute(
                 sa.text(
-                    "INSERT INTO funcao (codigo, nome) VALUES (:c, :n)"
+                    "INSERT INTO funcao (id, codigo, nome) VALUES (:i, :c, :n)"
                 ),
-                {"c": codigo, "n": nome},
+                {"i": next_id, "c": codigo, "n": nome},
             )
 
 


### PR DESCRIPTION
## Summary
- manually generate `funcao` IDs during article permission seeds to support databases without auto-increment

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b603ba8660832eb77d0c97b1e04322