### PR TITLE
Avoid redundant NOT NULL alteration in ordem_servico migration

### DIFF
--- a/migrations/versions/ab12cd34ef56_restructure_ordem_servico.py
+++ b/migrations/versions/ab12cd34ef56_restructure_ordem_servico.py
@@ -15,7 +15,13 @@ branch_labels = None
 depends_on = None
 
 def upgrade():
-    op.alter_column('ordem_servico', 'descricao', existing_type=sa.Text(), nullable=False)
+    op.alter_column(
+        'ordem_servico',
+        'descricao',
+        existing_type=sa.Text(),
+        existing_nullable=False,
+        nullable=False,
+    )
     op.alter_column('ordem_servico', 'processo_id', new_column_name='tipo_os_id')
     op.alter_column('ordem_servico', 'tipo_os_id', existing_type=sa.String(length=36), nullable=False)
     op.alter_column(


### PR DESCRIPTION
## Summary
- Skip altering `ordem_servico.descricao` if it's already NOT NULL

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6075220dc832eb87e69613ead0130