### PR TITLE
Handle existing tipo_os_id column

### DIFF
--- a/migrations/versions/52f02b1c789a_rename_cargo_os_flag.py
+++ b/migrations/versions/52f02b1c789a_rename_cargo_os_flag.py
@@ -8,6 +8,13 @@ Create Date: 2025-08-09 00:00:00
 from alembic import op
 import sqlalchemy as sa
 
+
+def _has_column(table: str, column: str) -> bool:
+    """Return True if the given table has the specified column."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return column in {c["name"] for c in inspector.get_columns(table)}
+
 # revision identifiers, used by Alembic.
 revision = '52f02b1c789a'
 down_revision = 'ab12cd34ef56'
@@ -16,10 +23,18 @@ depends_on = None
 
 
 def upgrade():
-    with op.batch_alter_table('cargo') as batch_op:
-        batch_op.alter_column('atende_ordem_servico', new_column_name='pode_atender_os')
+    if _has_column('cargo', 'atende_ordem_servico'):
+        if _has_column('cargo', 'pode_atender_os'):
+            op.drop_column('cargo', 'atende_ordem_servico')
+        else:
+            with op.batch_alter_table('cargo') as batch_op:
+                batch_op.alter_column('atende_ordem_servico', new_column_name='pode_atender_os')
 
 
 def downgrade():
-    with op.batch_alter_table('cargo') as batch_op:
-        batch_op.alter_column('pode_atender_os', new_column_name='atende_ordem_servico')
+    if _has_column('cargo', 'pode_atender_os'):
+        if _has_column('cargo', 'atende_ordem_servico'):
+            op.drop_column('cargo', 'pode_atender_os')
+        else:
+            with op.batch_alter_table('cargo') as batch_op:
+                batch_op.alter_column('pode_atender_os', new_column_name='atende_ordem_servico')


### PR DESCRIPTION
## Summary
- avoid ORA-00957 by checking for existing columns before renaming processo_id to tipo_os_id
- skip redundant NOT NULL alteration on tipo_os_id when the column is already non-nullable
- make cargo flag rename idempotent if pode_atender_os already exists

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b60a2336a0832eb798c5d94a7618e4