### PR TITLE
Handle existing tipo_os_id column

### DIFF
--- a/migrations/versions/52f02b1c789a_rename_cargo_os_flag.py
+++ b/migrations/versions/52f02b1c789a_rename_cargo_os_flag.py
@@ -8,6 +8,14 @@ Create Date: 2025-08-09 00:00:00
 from alembic import op
 import sqlalchemy as sa
 
+
+def _has_column(table: str, column: str) -> bool:
+    """Return True if the given table has the specified column."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"].lower() for c in inspector.get_columns(table)}
+    return column.lower() in cols
+
 # revision identifiers, used by Alembic.
 revision = '52f02b1c789a'
 down_revision = 'ab12cd34ef56'
@@ -16,10 +24,18 @@ depends_on = None
 
 
 def upgrade():
-    with op.batch_alter_table('cargo') as batch_op:
-        batch_op.alter_column('atende_ordem_servico', new_column_name='pode_atender_os')
+    if _has_column('cargo', 'atende_ordem_servico'):
+        if _has_column('cargo', 'pode_atender_os'):
+            op.drop_column('cargo', 'atende_ordem_servico')
+        else:
+            with op.batch_alter_table('cargo') as batch_op:
+                batch_op.alter_column('atende_ordem_servico', new_column_name='pode_atender_os')
 
 
 def downgrade():
-    with op.batch_alter_table('cargo') as batch_op:
-        batch_op.alter_column('pode_atender_os', new_column_name='atende_ordem_servico')
+    if _has_column('cargo', 'pode_atender_os'):
+        if _has_column('cargo', 'atende_ordem_servico'):
+            op.drop_column('cargo', 'pode_atender_os')
+        else:
+            with op.batch_alter_table('cargo') as batch_op:
+                batch_op.alter_column('pode_atender_os', new_column_name='atende_ordem_servico')

--- a/migrations/versions/ab12cd34ef56_restructure_ordem_servico.py
+++ b/migrations/versions/ab12cd34ef56_restructure_ordem_servico.py
@@ -8,6 +8,24 @@ Create Date: 2025-07-09 00:00:00.000000
 from alembic import op
 import sqlalchemy as sa
 
+
+def _has_column(table: str, column: str) -> bool:
+    """Check whether a given column exists in the specified table."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"].lower() for c in inspector.get_columns(table)}
+    return column.lower() in cols
+
+
+def _is_nullable(table: str, column: str) -> bool:
+    """Return True if the given column on the table is nullable."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    for col in inspector.get_columns(table):
+        if col["name"].lower() == column.lower():
+            return col.get("nullable", True)
+    return True
+
 # revision identifiers, used by Alembic.
 revision = 'ab12cd34ef56'
 down_revision = ('fa23b0c1c9d0', '7c8d9e0f1a2b')
@@ -25,8 +43,13 @@ def upgrade():
           END IF;
       END;
     """)
-    op.alter_column('ordem_servico', 'processo_id', new_column_name='tipo_os_id')
-    op.alter_column('ordem_servico', 'tipo_os_id', existing_type=sa.String(length=36), nullable=False)
+    if _has_column('ordem_servico', 'processo_id'):
+        if _has_column('ordem_servico', 'tipo_os_id'):
+            op.drop_column('ordem_servico', 'processo_id')
+        else:
+            op.alter_column('ordem_servico', 'processo_id', new_column_name='tipo_os_id')
+    if _has_column('ordem_servico', 'tipo_os_id') and _is_nullable('ordem_servico', 'tipo_os_id'):
+        op.alter_column('ordem_servico', 'tipo_os_id', existing_type=sa.String(length=36), nullable=False)
     op.alter_column(
         'ordem_servico',
         'status',
@@ -43,8 +66,10 @@ def upgrade():
     op.add_column('ordem_servico', sa.Column('prioridade', sa.String(length=10), nullable=True))
     op.add_column('ordem_servico', sa.Column('origem', sa.String(length=255), nullable=True))
     op.add_column('ordem_servico', sa.Column('observacoes', sa.Text(), nullable=True))
-    op.drop_column('ordem_servico', 'created_at')
-    op.drop_column('ordem_servico', 'updated_at')
+    if _has_column('ordem_servico', 'created_at'):
+        op.drop_column('ordem_servico', 'created_at')
+    if _has_column('ordem_servico', 'updated_at'):
+        op.drop_column('ordem_servico', 'updated_at')
 
     op.create_table(
         'ordem_servico_participante',
@@ -91,5 +116,6 @@ def downgrade():
     op.drop_column('ordem_servico', 'atribuido_para_id')
     op.drop_column('ordem_servico', 'criado_por_id')
     op.alter_column('ordem_servico', 'status', existing_type=sa.String(length=20), nullable=False, server_default='aberta')
-    op.alter_column('ordem_servico', 'tipo_os_id', new_column_name='processo_id', existing_type=sa.String(length=36), nullable=True)
+    if _has_column('ordem_servico', 'tipo_os_id'):
+        op.alter_column('ordem_servico', 'tipo_os_id', new_column_name='processo_id', existing_type=sa.String(length=36), nullable=True)
     op.alter_column('ordem_servico', 'descricao', existing_type=sa.Text(), nullable=True)

--- a/migrations/versions/ea3b24d8f6c7_add_tipo_os_and_cargo_processo_tables.py
+++ b/migrations/versions/ea3b24d8f6c7_add_tipo_os_and_cargo_processo_tables.py
@@ -10,48 +10,78 @@ branch_labels = None
 depends_on = None
 
 
+def _has_table(table: str) -> bool:
+    """Return True if the given table exists (case-insensitive)."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = {t.lower() for t in inspector.get_table_names()}
+    return table.lower() in tables
+
+
+def _has_fk(table: str, constraint: str) -> bool:
+    """Check whether the table has a foreign key with the given name."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if table.lower() not in {t.lower() for t in inspector.get_table_names()}:
+        return False
+    fks = {fk["name"].lower() for fk in inspector.get_foreign_keys(table)}
+    return constraint.lower() in fks
+
+
 def upgrade():
     # Rename etapa_processo to processo_etapa and update FK in campo_etapa
-    op.drop_constraint('campo_etapa_etapa_id_fkey', 'campo_etapa', type_='foreignkey')
-    op.rename_table('etapa_processo', 'processo_etapa')
-    op.create_foreign_key('campo_etapa_etapa_id_fkey', 'campo_etapa', 'processo_etapa', ['etapa_id'], ['id'])
+    if _has_fk('campo_etapa', 'campo_etapa_etapa_id_fkey'):
+        op.drop_constraint('campo_etapa_etapa_id_fkey', 'campo_etapa', type_='foreignkey')
+    if _has_table('etapa_processo'):
+        op.rename_table('etapa_processo', 'processo_etapa')
+    if not _has_fk('campo_etapa', 'campo_etapa_etapa_id_fkey'):
+        op.create_foreign_key('campo_etapa_etapa_id_fkey', 'campo_etapa', 'processo_etapa', ['etapa_id'], ['id'])
 
     # Create subprocesso table
-    op.create_table(
-        'subprocesso',
-        sa.Column('id', sa.Integer(), primary_key=True),
-        sa.Column('nome', sa.String(length=255), nullable=False),
-        sa.Column('processo_id', sa.String(length=36), sa.ForeignKey('processo.id'), nullable=False),
-    )
+    if not _has_table('subprocesso'):
+        op.create_table(
+            'subprocesso',
+            sa.Column('id', sa.Integer(), primary_key=True),
+            sa.Column('nome', sa.String(length=255), nullable=False),
+            sa.Column('processo_id', sa.String(length=36), sa.ForeignKey('processo.id'), nullable=False),
+        )
 
     # Create cargo_processo table
-    op.create_table(
-        'cargo_processo',
-        sa.Column('id', sa.Integer(), primary_key=True),
-        sa.Column('cargo_id', sa.Integer(), sa.ForeignKey('cargo.id'), nullable=False),
-        sa.Column('subprocesso_id', sa.Integer(), sa.ForeignKey('subprocesso.id'), nullable=False),
-    )
+    if not _has_table('cargo_processo'):
+        op.create_table(
+            'cargo_processo',
+            sa.Column('id', sa.Integer(), primary_key=True),
+            sa.Column('cargo_id', sa.Integer(), sa.ForeignKey('cargo.id'), nullable=False),
+            sa.Column('subprocesso_id', sa.Integer(), sa.ForeignKey('subprocesso.id'), nullable=False),
+        )
 
     # Create tipo_os table
-    op.create_table(
-        'tipo_os',
-        sa.Column('id', sa.Integer(), primary_key=True),
-        sa.Column('nome', sa.String(length=255), nullable=False),
-        sa.Column('descricao', sa.Text(), nullable=True),
-        sa.Column('subprocesso_id', sa.Integer(), sa.ForeignKey('subprocesso.id'), nullable=False),
-        sa.Column('equipe_responsavel_id', sa.Integer(), sa.ForeignKey('celula.id'), nullable=True),
-        sa.Column('formulario_vinculado_id', sa.Integer(), nullable=True),
-        sa.Column('obrigatorio_preenchimento', sa.Boolean(), nullable=False, server_default=sa.text('0')),
-    )
+    if not _has_table('tipo_os'):
+        op.create_table(
+            'tipo_os',
+            sa.Column('id', sa.Integer(), primary_key=True),
+            sa.Column('nome', sa.String(length=255), nullable=False),
+            sa.Column('descricao', sa.Text(), nullable=True),
+            sa.Column('subprocesso_id', sa.Integer(), sa.ForeignKey('subprocesso.id'), nullable=False),
+            sa.Column('equipe_responsavel_id', sa.Integer(), sa.ForeignKey('celula.id'), nullable=True),
+            sa.Column('formulario_vinculado_id', sa.Integer(), nullable=True),
+            sa.Column('obrigatorio_preenchimento', sa.Boolean(), nullable=False, server_default=sa.text('0')),
+        )
 
 
 def downgrade():
     # Drop newly created tables
-    op.drop_table('tipo_os')
-    op.drop_table('cargo_processo')
-    op.drop_table('subprocesso')
+    if _has_table('tipo_os'):
+        op.drop_table('tipo_os')
+    if _has_table('cargo_processo'):
+        op.drop_table('cargo_processo')
+    if _has_table('subprocesso'):
+        op.drop_table('subprocesso')
 
     # Rename processo_etapa back to etapa_processo and restore FK
-    op.drop_constraint('campo_etapa_etapa_id_fkey', 'campo_etapa', type_='foreignkey')
-    op.rename_table('processo_etapa', 'etapa_processo')
-    op.create_foreign_key('campo_etapa_etapa_id_fkey', 'campo_etapa', 'etapa_processo', ['etapa_id'], ['id'])
+    if _has_fk('campo_etapa', 'campo_etapa_etapa_id_fkey'):
+        op.drop_constraint('campo_etapa_etapa_id_fkey', 'campo_etapa', type_='foreignkey')
+    if _has_table('processo_etapa'):
+        op.rename_table('processo_etapa', 'etapa_processo')
+    if not _has_fk('campo_etapa', 'campo_etapa_etapa_id_fkey'):
+        op.create_foreign_key('campo_etapa_etapa_id_fkey', 'campo_etapa', 'etapa_processo', ['etapa_id'], ['id'])


### PR DESCRIPTION
## Summary
- avoid ORA-00957 by checking for existing columns before renaming processo_id to tipo_os_id
- skip redundant NOT NULL alteration on tipo_os_id when the column is already non-nullable
- make cargo flag rename idempotent if pode_atender_os already exists
- guard campo_etapa constraint and etapa_processo rename to prevent ORA-02443 errors
- add case-insensitive helpers and table-existence guards to avoid duplicate constraint/table errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b60a2336a0832eb798c5d94a7618e4