### PR TITLE
fix: ensure funcao seeds specify explicit ids

### DIFF
--- a/seeds/seed_funcoes.py
+++ b/seeds/seed_funcoes.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from sqlalchemy import func
 
 # Garante que o diretório raiz do projeto esteja no PYTHONPATH quando executado diretamente
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -30,9 +31,11 @@ def run():
     funcoes = [(p.value, p.value.replace("_", " ").capitalize()) for p in Permissao]
     funcoes.extend(EXTRA_FUNCOES)
     with app.app_context():
+        max_id = db.session.query(func.max(Funcao.id)).scalar() or 0
         for codigo, nome in funcoes:
             if not Funcao.query.filter_by(codigo=codigo).first():
-                db.session.add(Funcao(codigo=codigo, nome=nome))
+                max_id += 1
+                db.session.add(Funcao(id=max_id, codigo=codigo, nome=nome))
         db.session.commit()
         print("Funções criadas/atualizadas.")
 


### PR DESCRIPTION
## Summary
- avoid null ID errors by assigning incremental IDs when seeding `Funcao`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b766f2fce8832e977d6039f72ef35d