### PR TITLE
fix: handle Oracle-specific seeding issues

### DIFF
--- a/seeds/seed_demonstration.py
+++ b/seeds/seed_demonstration.py
@@ -39,6 +39,7 @@ except ImportError:  # pragma: no cover - fallback for direct execution
 
 from werkzeug.security import generate_password_hash
 from datetime import datetime, timezone
+from sqlalchemy import Text, func
 from app import app
 
 try:
@@ -47,12 +48,42 @@ except ImportError:  # pragma: no cover - fallback para execução direta
     import seed_funcoes
 
 
+id_counters = {}
+
+
 def get_or_create(model, defaults=None, **kwargs):
-    instance = model.query.filter_by(**kwargs).first()
+    """Fetches an existing row matching ``kwargs`` or creates one.
+
+    Columns of type ``Text`` are excluded from the lookup to avoid Oracle
+    ``CLOB`` comparison errors. Any excluded fields are instead applied only
+    when creating a new instance.
+
+    When creating a new row, a manual incremental ``id`` is assigned for
+    databases (like Oracle) that don't auto-generate integer primary keys.
+    """
+
+    params = defaults.copy() if defaults else {}
+    filter_kwargs = {}
+    for key, value in kwargs.items():
+        column = model.__table__.columns.get(key)
+        if column is not None and isinstance(column.type, Text):
+            params[key] = value
+        else:
+            filter_kwargs[key] = value
+
+    instance = model.query.filter_by(**filter_kwargs).first()
     if not instance:
-        params = defaults or {}
-        params.update(kwargs)
+        params.update(filter_kwargs)
         instance = model(**params)
+
+        if hasattr(model, "id") and getattr(instance, "id", None) is None:
+            current = id_counters.get(model)
+            if current is None:
+                current = db.session.query(func.max(model.id)).scalar() or 0
+            current += 1
+            id_counters[model] = current
+            instance.id = current
+
         db.session.add(instance)
     return instance
 

--- a/seeds/seed_funcoes.py
+++ b/seeds/seed_funcoes.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from sqlalchemy import func
 
 # Garante que o diretório raiz do projeto esteja no PYTHONPATH quando executado diretamente
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -30,9 +31,11 @@ def run():
     funcoes = [(p.value, p.value.replace("_", " ").capitalize()) for p in Permissao]
     funcoes.extend(EXTRA_FUNCOES)
     with app.app_context():
+        max_id = db.session.query(func.max(Funcao.id)).scalar() or 0
         for codigo, nome in funcoes:
             if not Funcao.query.filter_by(codigo=codigo).first():
-                db.session.add(Funcao(codigo=codigo, nome=nome))
+                max_id += 1
+                db.session.add(Funcao(id=max_id, codigo=codigo, nome=nome))
         db.session.commit()
         print("Funções criadas/atualizadas.")
 


### PR DESCRIPTION
## Summary
- avoid null ID errors by assigning incremental IDs when seeding `Funcao`
- skip `Text` columns during lookup in `get_or_create` to prevent Oracle CLOB comparison errors
- assign incremental IDs across all seeded models to prevent NULL ID violations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b766f2fce8832e977d6039f72ef35d