### PR TITLE
Fix Oracle GROUP BY error on approval page

### DIFF
--- a/tests/test_article_approval_review.py
+++ b/tests/test_article_approval_review.py
@@ -241,3 +241,53 @@ def test_aprovacao_requer_comentario(app_ctx, client):
         art_db = Article.query.get(art_id)
         assert art_db.status == ArticleStatus.PENDENTE
         assert Comment.query.count() == 0
+
+
+def test_aprovacao_revisados_listing(app_ctx, client):
+    """A rota /aprovacao deve listar artigos já revisados pelo usuário."""
+    with app.app_context():
+        inst = Instituicao(codigo='I2', nome='Inst2')
+        est = Estabelecimento(codigo='E2', nome_fantasia='Est2', instituicao=inst)
+        setor = Setor(nome='S2', estabelecimento=est)
+        cel = Celula(nome='C2', estabelecimento=est, setor=setor)
+        db.session.add_all([inst, est, setor, cel])
+        db.session.flush()
+
+        autor = User(username='autor2', email='a2@test', password_hash='x',
+                     estabelecimento=est, setor=setor, celula=cel)
+        revisor = User(username='rev2', email='r2@test', password_hash='x',
+                       estabelecimento=est, setor=setor, celula=cel)
+        db.session.add_all([autor, revisor])
+        db.session.flush()
+
+        art = Article(
+            titulo='Revisado',
+            texto='Conteudo',
+            status=ArticleStatus.EM_REVISAO,
+            user_id=autor.id,
+            celula_id=cel.id,
+            estabelecimento_id=est.id,
+            setor_id=setor.id,
+            instituicao_id=inst.id,
+            visibility=ArticleVisibility.CELULA,
+        )
+        db.session.add(art)
+        db.session.flush()
+
+        comentario = Comment(artigo_id=art.id, user_id=revisor.id, texto='ok')
+        db.session.add(comentario)
+
+        f = Funcao(codigo=Permissao.ARTIGO_REVISAR_CELULA.value, nome='rev')
+        db.session.add(f)
+        db.session.flush()
+        revisor.permissoes_personalizadas.append(f)
+        db.session.commit()
+
+        revisor_id = revisor.id
+
+    with client.session_transaction() as sess:
+        sess['user_id'] = revisor_id
+
+    resp = client.get('/aprovacao')
+    assert resp.status_code == 200
+    assert b'Revisado' in resp.data


### PR DESCRIPTION
## Summary
- Avoid Oracle GROUP BY error on approval page by using subquery for latest comment
- Test approval page listing of reviewed articles

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b876ca3738832ea5e91fcef49b1383