### PR TITLE
Ensure Article IDs are auto-generated

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -338,7 +338,11 @@ class User(db.Model):
 
 class Article(db.Model):
     __tablename__ = 'article'
-    id = db.Column(db.Integer, primary_key=True)
+    id = db.Column(
+        db.Integer,
+        sa.Sequence('article_id_seq', optional=True),
+        primary_key=True
+    )
     titulo = db.Column(db.String(200), nullable=False)
     texto = db.Column(db.Text, nullable=False)
     status = db.Column(

--- a/migrations/versions/c4f9b8e3d7a1_add_article_id_sequence.py
+++ b/migrations/versions/c4f9b8e3d7a1_add_article_id_sequence.py
@@ -1,0 +1,22 @@
+"""add sequence for article id"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'c4f9b8e3d7a1'
+down_revision = '0b1c2d3e4f67'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    bind = op.get_bind()
+    if bind.dialect.name == 'oracle':
+        start_id = bind.execute(
+            sa.text("SELECT NVL(MAX(id), 0) + 1 FROM article")
+        ).scalar()
+        op.execute(sa.text(f"CREATE SEQUENCE article_id_seq START WITH {start_id}"))
+
+def downgrade():
+    bind = op.get_bind()
+    if bind.dialect.name == 'oracle':
+        op.execute(sa.text("DROP SEQUENCE article_id_seq"))


### PR DESCRIPTION
## Summary
- Assign Article.id from `article_id_seq` sequence to avoid null insert errors
- Add Alembic migration creating `article_id_seq`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b878706bd4832eaeeed29c48e344b2