### PR TITLE
fix: emulate auto increment for article on Oracle with sequence and trigger

### DIFF
--- a/migrations/versions/c4f9b8e3d7a1_add_article_id_sequence.py
+++ b/migrations/versions/c4f9b8e3d7a1_add_article_id_sequence.py
@@ -1,4 +1,9 @@
-"""convert article.id to identity for auto increment"""
+"""Provide auto increment for article.id on Oracle
+
+This migration replaces the attempt to convert the ``article.id`` column into an
+identity column – an operation that raises ``ORA-30673`` on populated tables –
+with the more compatible ``SEQUENCE`` + ``TRIGGER`` approach.
+"""
 
 from alembic import op
 import sqlalchemy as sa
@@ -14,21 +19,30 @@ def upgrade():
         start_id = bind.execute(
             sa.text("SELECT NVL(MAX(id), 0) + 1 FROM article")
         ).scalar()
+
         # Remove legacy default that referenced a sequence
         op.execute(sa.text("ALTER TABLE article MODIFY (id DEFAULT NULL)"))
 
-        # First convert the column into an identity. Using "GENERATED AS
-        # IDENTITY" avoids ORA-30673 when changing a populated column that was
-        # previously filled via a sequence or trigger.
-        op.execute(sa.text("ALTER TABLE article MODIFY (id GENERATED AS IDENTITY)"))
-
-
-        # Restart the identity sequence so that it continues after existing
-        # rows. This requires the column to already be an identity, so the
-        # previous statement must succeed before this runs.
+        # Create sequence starting after existing rows
         op.execute(
             sa.text(
-                f"ALTER TABLE article MODIFY (id RESTART START WITH {start_id})"
+                f"CREATE SEQUENCE article_seq START WITH {start_id} INCREMENT BY 1"
+            )
+        )
+
+        # Create trigger to populate id from the sequence when not provided
+        op.execute(
+            sa.text(
+                """
+                CREATE OR REPLACE TRIGGER article_before_insert
+                BEFORE INSERT ON article
+                FOR EACH ROW
+                BEGIN
+                  IF :new.id IS NULL THEN
+                    SELECT article_seq.NEXTVAL INTO :new.id FROM dual;
+                  END IF;
+                END;
+                """
             )
         )
 
@@ -36,6 +50,5 @@ def upgrade():
 def downgrade():
     bind = op.get_bind()
     if bind.dialect.name == 'oracle':
-        op.execute(
-            sa.text("ALTER TABLE article MODIFY (id DROP IDENTITY)")
-        )
+        op.execute(sa.text("DROP TRIGGER article_before_insert"))
+        op.execute(sa.text("DROP SEQUENCE article_seq"))


### PR DESCRIPTION
## Summary
- replace unsupported `GENERATED AS IDENTITY` conversion with explicit sequence and trigger for `article.id`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b89fa8a124832e92b4f067bc2fc600