### PR TITLE
Escapa :new em trigger Oracle

### DIFF
--- a/migrations/versions/0001_oracle_initial.py
+++ b/migrations/versions/0001_oracle_initial.py
@@ -468,7 +468,7 @@ def upgrade():
     for table in tables:
         op.execute(f"CREATE SEQUENCE {table}_seq START WITH 1 INCREMENT BY 1")
         op.execute(
-            f"""
+            fr"""
 DECLARE
     dummy NUMBER;
 BEGIN
@@ -477,8 +477,8 @@ BEGIN
         BEFORE INSERT ON {table}
         FOR EACH ROW
         BEGIN
-            IF :new.id IS NULL THEN
-                SELECT {table}_seq.NEXTVAL INTO :new.id FROM dual;
+            IF \:new.id IS NULL THEN
+                SELECT {table}_seq.NEXTVAL INTO \:new.id FROM dual;
             END IF;
         END;
     ';


### PR DESCRIPTION
## Summary
- Escapa `:new` em SQL das migrações para impedir que o SQLAlchemy tente fazer bind

## Testing
- `pytest --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9cb93f2a8832e88661769ed694177