### PR TITLE
Fix Article seeding to use user_id property

### DIFF
--- a/seeds/seed_demonstration.py
+++ b/seeds/seed_demonstration.py
@@ -113,14 +113,14 @@ def create_articles():
                 title = f"Artigo {vis.value.title()} - {usuario.username}"
                 with db.session.no_autoflush:
                     exists = Article.query.filter_by(
-                        titulo=title, usuario_id=usuario.id
+                        titulo=title, user_id=usuario.id
                     ).first()
                 if exists:
                     continue
                 data = {
                     "titulo": title,
                     "texto": f"Conteúdo visível por {vis.label}.",
-                    "usuario_id": usuario.id,
+                    "user_id": usuario.id,
                     "celula_id": usuario.celula_id,
                     "visibility": vis,
                     "status": ArticleStatus.APROVADO,


### PR DESCRIPTION
## Summary
- use `user_id` instead of `usuario_id` when creating sample articles

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b9da2e14c0832eb438b9f1b2c19655