### PR TITLE
Fix article ID auto-increment

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -341,7 +341,7 @@ class Article(db.Model):
     __tablename__ = 'article'
     id = db.Column(
         db.Integer,
-        sa.Identity(start=1),
+        sa.Sequence('article_id_seq'),
         primary_key=True
     )
     titulo = db.Column(db.String(200), nullable=False)

--- a/migrations/versions/0002_add_article_id_sequence.py
+++ b/migrations/versions/0002_add_article_id_sequence.py
@@ -1,0 +1,23 @@
+"""Add sequence for article.id"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0002_add_article_id_sequence'
+down_revision = '0001_oracle_initial'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    max_id = conn.execute(sa.text('SELECT COALESCE(MAX(id), 0) FROM article')).scalar()
+    article_id_seq = sa.Sequence('article_id_seq', start=max_id + 1)
+    op.execute(sa.schema.CreateSequence(article_id_seq))
+    op.execute(sa.text('ALTER TABLE article MODIFY (id DEFAULT article_id_seq.NEXTVAL)'))
+
+
+def downgrade():
+    op.execute(sa.text('ALTER TABLE article MODIFY (id DEFAULT NULL)'))
+    op.execute(sa.schema.DropSequence(sa.Sequence('article_id_seq')))


### PR DESCRIPTION
## Summary
- Use an explicit sequence for `Article.id` to avoid Oracle primary key collisions
- Add migration creating `article_id_seq` and setting default value

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9dca2a648832e843950ac38e48c89