### PR TITLE
Ajusta layout de solicitação de revisão de artigos

### DIFF
--- a/templates/artigos/solicitar_revisao.html
+++ b/templates/artigos/solicitar_revisao.html
@@ -1,29 +1,175 @@
 {% extends 'base.html' %}
+{% block title %}{{ artigo.titulo }}{% endblock %}
+
 {% block content %}
-<style>
-  .article-content {
-    scroll-margin-top: 6rem;
-  }
-</style>
-<div class="container-fluid">
-  <div class="sticky-top bg-white shadow-sm p-3 mb-4 rounded">
+<div class="container px-5">
+  <div class="sticky-top bg-white shadow-sm p-3 mb-4 rounded" style="z-index: 1020;">
     <h4>Solicitação de Revisão para o Artigo "{{ artigo.titulo }}"</h4>
     <form method="POST" action="{{ url_for('solicitar_revisao', artigo_id=artigo.id) }}">
-      <div class="form-group">
-        <label for="comentario">Comentário</label>
+      <div class="mb-3">
+        <label for="comentario" class="form-label">Comentário</label>
         <textarea class="form-control no-quill" name="comentario" rows="4" required></textarea>
       </div>
-      <div class="mt-3 text-end">
+      <div class="text-end">
         <button type="submit" class="btn btn-warning">Enviar pedido</button>
-        <a href="{{ url_for('pesquisar') }}" class="btn btn-secondary">Cancelar</a>
+        <a href="{{ url_for('artigo', artigo_id=artigo.id) }}" class="btn btn-secondary">Cancelar</a>
       </div>
     </form>
   </div>
 
-  <div class="card article-content">
-    <div class="card-body">
-      {{ artigo.texto | safe }}
-    </div>
-  </div>
+  <div class="row">
+    <div class="col-md-10 mx-auto">
+      <div class="card shadow-sm">
+        <div class="card-body position-relative">
+
+          {# Cabeçalho com título e status #}
+          <div class="d-flex justify-content-between align-items-start">
+            <div>
+              <h3>{{ artigo.titulo }}</h3>
+              <p class="text-muted mb-0">
+                <strong>Autor:</strong>
+                {{ artigo.author.nome_completo or artigo.author.username }}
+                <strong class="ms-2">Criado em:</strong>
+                {{ artigo.created_at.strftime('%d/%m/%Y %H:%M') }}
+                <strong class="ms-2">Visibilidade:</strong>
+                {{ artigo.visibility.label }}
+              </p>
+            </div>
+            {% set st = artigo.status %}
+            <span class="badge bg-{{ st.color }} text-{{ st.text_color }} fs-6 mt-1">
+              {{ st.label }}
+            </span>
+          </div>
+          <hr>
+
+          {# Conteúdo do artigo #}
+          <div>
+            {{ artigo.texto.replace('\n', '<br>')|safe }}
+          </div>
+          <hr>
+
+          {# Anexos com aviso para PDFs não pesquisáveis #}
+          {% if artigo.attachments %}
+          <h5 class="d-flex align-items-center">
+            Anexos
+            <i class="bi bi-info-circle ms-1 text-secondary" data-bs-toggle="tooltip" data-bs-placement="top"
+              title="PDFs escaneados (sem texto incorporado) não podem ser pesquisados">
+            </i>
+          </h5>
+          <div class="row g-3">
+            {% for att in artigo.attachments %}
+            {% set fname = att.filename %}
+            {% set ext = fname.split('.')[-1].lower() %}
+            <div class="col-auto" style="max-width: 130px;">
+              <a href="{{ url_for('uploaded_file', filename=fname) }}" class="text-decoration-none d-block"
+                target="_blank" title="{{ fname }}">
+                <div class="card h-100 shadow-sm">
+                  {% if ext in ['jpg','jpeg','png','gif','webp'] %}
+                  <img src="{{ url_for('uploaded_file', filename=fname) }}" class="card-img-top"
+                    style="width:100%; height:100px; object-fit:cover;" alt="{{ fname }}">
+                  {% else %}
+                  <div class="card-body d-flex align-items-center justify-content-center" style="height:100px;">
+                    <i class="bi bi-file-earmark-text display-4 text-secondary"></i>
+                  </div>
+                  {% endif %}
+                  <div class="card-footer text-center small text-truncate py-1">
+                    {{ fname }}
+                  </div>
+                </div>
+              </a>
+              {% if ext == 'pdf' and not att.content %}
+              <div style="position: relative; height: 0;">
+                <i class="bi bi-exclamation-circle-fill text-warning"
+                  style="position:absolute; bottom: 5px; right: 5px; z-index:5; font-size: 1.2rem; background-color: rgba(255,255,255,0.7); border-radius:50%;"
+                  data-bs-toggle="tooltip" data-bs-placement="top" title="Este PDF não contém texto pesquisável.">
+                </i>
+              </div>
+              {% endif %}
+            </div>
+            {% endfor %}
+          </div>
+          {% else %}
+          <p class="text-muted mt-3">Sem anexos.</p>
+          {% endif %}
+          <hr>
+
+          {# Histórico de Aprovação #}
+          {% if artigo.comments %}
+          <h5 class="mt-4">Histórico de Aprovação</h5>
+          <ul class="list-group mb-3">
+            {% for c in artigo.comments|sort(attribute='created_at') %}
+            {% set nome = c.autor.nome_completo if c.autor.nome_completo else c.autor.username %}
+            {% set parts = nome.split() %}
+            <li class="list-group-item">
+              <strong>{{ parts[0] }} {{ parts[-1] }}</strong>
+              <small class="text-muted">
+                {{ c.created_at.astimezone(ZoneInfo('America/Sao_Paulo')).strftime('%d/%m %H:%M') }}
+              </small><br>
+              {{ c.texto }}
+            </li>
+            {% endfor %}
+          </ul>
+          {% endif %}
+
+          {# Histórico de Solicitações de Revisão #}
+          {% if artigo.revision_requests %}
+          <h5 class="mt-4">Histórico de Solicitações de Revisão</h5>
+          <ul class="list-group mb-3">
+            {% for rr in artigo.revision_requests|sort(attribute='created_at') %}
+            {% set nome = rr.user.nome_completo if rr.user.nome_completo else rr.user.username %}
+            {% set p = nome.split() %}
+            <li class="list-group-item">
+              <strong>{{ p[0] }} {{ p[-1] }}</strong>
+              <small class="text-muted">
+                {{ rr.created_at.astimezone(ZoneInfo('America/Sao_Paulo')).strftime('%d/%m %H:%M') }}
+              </small><br>
+              {{ rr.comentario }}
+            </li>
+            {% endfor %}
+          </ul>
+          {% endif %}
+          <hr>
+
+          {# Botões de ação #}
+          <div class="mt-4">
+            {% if session.username
+            and artigo.author.username == session.username
+            and artigo.status in [
+            ArticleStatus.RASCUNHO,
+            ArticleStatus.EM_REVISAO,
+            ArticleStatus.EM_AJUSTE,
+            ArticleStatus.REJEITADO
+            ] %}
+            <a href="{{ url_for('editar_artigo', artigo_id=artigo.id) }}" class="btn btn-primary">
+              Editar
+            </a>
+            {% endif %}
+
+            {% if artigo.status == ArticleStatus.APROVADO %}
+            <i
+              class="bi bi-copy text-secondary copy-link-icon"
+              data-url="{{ url_for('artigo', artigo_id=artigo.id, _external=True) }}"
+              style="position:absolute; bottom:10px; right:10px; cursor:pointer; font-size:1.3rem;"
+            ></i>
+            {% endif %}
+          </div>
+
+        </div> {# .card-body #}
+      </div> {# .card #}
+    </div> {# .col #}
+  </div> {# .row #}
 </div>
+{% endblock %}
+{% block extra_js %}
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const currentPageUrl = "{{ url_for('artigo', artigo_id=artigo.id) }}";
+
+    if (typeof window.markNotificationAsReadMatchingUrl === 'function') {
+      window.markNotificationAsReadMatchingUrl(currentPageUrl);
+    } else {
+      console.warn('Função markNotificationAsReadMatchingUrl não encontrada em main.js.');
+    }
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replica visual de exibição de artigo na página de solicitação de revisão
- Adiciona área de comentário fixa no topo e remove botão duplicado de solicitação

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c03f62a25c832ebfc3826b86d5bb6a