### PR TITLE
Unify article history into single tagged list

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -248,7 +248,31 @@ def artigo(artigo_id):
         return redirect(url_for('meus_artigos'))
 
     arquivos = json.loads(artigo.arquivos or '[]')
-    return render_template('artigos/artigo.html', artigo=artigo, arquivos=arquivos)
+
+    historicos = []
+    for c in artigo.comments.order_by(Comment.created_at.asc()).all():
+        dt = c.created_at or datetime.now(timezone.utc)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        historicos.append({
+            'tipo': c.tipo,
+            'texto': c.texto,
+            'autor': c.autor.nome_completo if c.autor.nome_completo else c.autor.username,
+            'created_at': dt,
+        })
+    for rr in artigo.revision_requests.order_by(RevisionRequest.created_at.asc()).all():
+        dt = rr.created_at or datetime.now(timezone.utc)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        historicos.append({
+            'tipo': 'Revisão',
+            'texto': rr.comentario,
+            'autor': rr.user.nome_completo if rr.user.nome_completo else rr.user.username,
+            'created_at': dt,
+        })
+    historicos.sort(key=lambda x: x['created_at'])
+
+    return render_template('artigos/artigo.html', artigo=artigo, arquivos=arquivos, historicos=historicos)
 
 @articles_bp.route("/artigo/<int:artigo_id>/editar", methods=["GET", "POST"], endpoint='editar_artigo')
 def editar_artigo(artigo_id):
@@ -512,7 +536,12 @@ def aprovacao_detail(artigo_id):
         novo_comment = Comment(
             artigo_id = artigo.id,
             user_id   = user.id,
-            texto     = comentario
+            texto     = comentario,
+            tipo     = {
+                'aprovar': 'Aprovação',
+                'ajustar': 'Solicitação de Ajuste',
+                'rejeitar': 'Rejeitado'
+            }.get(acao, 'Aprovação')
         )
         db.session.add(novo_comment)
         db.session.commit()

--- a/core/models.py
+++ b/core/models.py
@@ -420,6 +420,7 @@ class Comment(db.Model):
     artigo_id = db.Column(db.Integer, db.ForeignKey("article.id"), nullable=False)
     user_id = db.Column('usuario_id', db.Integer, db.ForeignKey("usuario.id"), nullable=False)  # Usuário responsável pelo comentário
     texto = db.Column(db.Text, nullable=False)
+    tipo = db.Column(db.String(30), nullable=False, default='Aprovação', server_default='Aprovação')
     created_at = db.Column(db.DateTime(timezone=True), server_default=func.now(), nullable=True) # Conforme migration
 
     autor = db.relationship('User', foreign_keys=[user_id], back_populates='comments')

--- a/templates/artigos/artigo.html
+++ b/templates/artigos/artigo.html
@@ -84,40 +84,27 @@
         {% endif %}
         <hr>
 
-        {# Histórico de Aprovação #}
-        {% if artigo.comments %}
-        <h5 class="mt-4">Histórico de Aprovação</h5>
-        <ul class="list-group mb-3">
-          {% for c in artigo.comments|sort(attribute='created_at') %}
-          {% set nome = c.autor.nome_completo if c.autor.nome_completo else c.autor.username %}
-          {% set parts = nome.split() %}
-          <li class="list-group-item">
-            <strong>{{ parts[0] }} {{ parts[-1] }}</strong>
-            <small class="text-muted">
-              {{ c.created_at.astimezone(ZoneInfo('America/Sao_Paulo')).strftime('%d/%m %H:%M') }}
-            </small><br>
-            {{ c.texto }}
-          </li>
+        {# Históricos unificados #}
+        {% if historicos %}
+        <h5 class="mt-4">Históricos</h5>
+        <div class="list-group mb-3">
+          {% for h in historicos %}
+          {% set p = h.autor.split() %}
+          {% set cores = {'Aprovação':'success','Solicitação de Ajuste':'warning','Rejeitado':'danger','Revisão':'info'} %}
+          <div class="list-group-item d-flex justify-content-between align-items-start">
+            <div class="ms-2 me-auto">
+              <div class="fw-bold">
+                {{ p[0] }} {{ p[-1] }}
+                <small class="text-muted">
+                  {{ h.created_at.astimezone(ZoneInfo('America/Sao_Paulo')).strftime('%d/%m %H:%M') }}
+                </small>
+              </div>
+              {{ h.texto }}
+            </div>
+            <span class="badge rounded-pill bg-{{ cores.get(h.tipo, 'secondary') }}">{{ h.tipo }}</span>
+          </div>
           {% endfor %}
-        </ul>
-        {% endif %}
-
-        {# Histórico de Solicitações de Revisão #}
-        {% if artigo.revision_requests %}
-        <h5 class="mt-4">Histórico de Solicitações de Revisão</h5>
-        <ul class="list-group mb-3">
-          {% for rr in artigo.revision_requests|sort(attribute='created_at') %}
-          {% set nome = rr.user.nome_completo if rr.user.nome_completo else rr.user.username %}
-          {% set p = nome.split() %}
-          <li class="list-group-item">
-            <strong>{{ p[0] }} {{ p[-1] }}</strong>
-            <small class="text-muted">
-              {{ rr.created_at.astimezone(ZoneInfo('America/Sao_Paulo')).strftime('%d/%m %H:%M') }}
-            </small><br>
-            {{ rr.comentario }}
-          </li>
-          {% endfor %}
-        </ul>
+        </div>
         {% endif %}
         <hr>
 


### PR DESCRIPTION
## Summary
- Track comment action type with new `tipo` field
- Aggregate comments and revision requests into a unified history list
- Display tagged history items in article page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c05ba9a3b8832eb2ee70c8012a9eb3