### PR TITLE
Corrige horário de criação em páginas de artigo

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -297,6 +297,14 @@ def artigo(artigo_id):
             'created_at': dt,
         })
     historicos.sort(key=lambda x: x['created_at'])
+    dt = artigo.created_at or datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    artigo.local_created = dt.astimezone(ZoneInfo("America/Sao_Paulo"))
+    dt2 = artigo.updated_at or dt
+    if dt2.tzinfo is None:
+        dt2 = dt2.replace(tzinfo=timezone.utc)
+    artigo.local_updated = dt2.astimezone(ZoneInfo("America/Sao_Paulo"))
 
     return render_template('artigos/artigo.html', artigo=artigo, arquivos=arquivos, historicos=historicos)
 
@@ -414,6 +422,10 @@ def editar_artigo(artigo_id):
 
     # GET
     arquivos = json.loads(artigo.arquivos or "[]")
+    dt = artigo.created_at or datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    artigo.local_created = dt.astimezone(ZoneInfo("America/Sao_Paulo"))
     return render_template("artigos/editar_artigo.html", artigo=artigo, arquivos=arquivos)
 
 @articles_bp.route("/aprovacao", endpoint='aprovacao')
@@ -603,6 +615,10 @@ def aprovacao_detail(artigo_id):
 
     # GET → renderiza detalhes e histórico
     arquivos = json.loads(artigo.arquivos or '[]')
+    dt = artigo.created_at or datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    artigo.local_created = dt.astimezone(ZoneInfo("America/Sao_Paulo"))
     return render_template(
         'artigos/aprovacao_detail.html',
         artigo   = artigo,
@@ -646,6 +662,10 @@ def solicitar_revisao(artigo_id):
         flash('Pedido de revisão enviado!', 'success')
         return redirect(url_for('artigo', artigo_id=artigo.id))
 
+    dt = artigo.created_at or datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    artigo.local_created = dt.astimezone(ZoneInfo("America/Sao_Paulo"))
     return render_template('artigos/solicitar_revisao.html', artigo=artigo)
 
 @articles_bp.route('/pesquisar', endpoint='pesquisar')

--- a/templates/artigos/aprovacao_detail.html
+++ b/templates/artigos/aprovacao_detail.html
@@ -11,7 +11,7 @@
         <h3>{{ artigo.titulo }}</h3>
         <p class="text-muted">
           Autor: {{ artigo.author.nome_completo or artigo.author.username }} |
-          Criado em: {{ artigo.created_at.astimezone(ZoneInfo('America/Sao_Paulo')).strftime('%d/%m/%Y %H:%M') }} |
+          Criado em: {{ artigo.local_created.strftime('%d/%m/%Y %H:%M') }} |
           Visibilidade: {{ artigo.visibility.label }}
         </p>
         <hr>

--- a/templates/artigos/artigo.html
+++ b/templates/artigos/artigo.html
@@ -17,7 +17,7 @@
               <strong>Autor:</strong>
               {{ artigo.author.nome_completo or artigo.author.username }}
               <strong class="ms-2">Criado em:</strong>
-              {{ artigo.created_at.astimezone(ZoneInfo('America/Sao_Paulo')).strftime('%d/%m/%Y %H:%M') }}
+              {{ artigo.local_created.strftime('%d/%m/%Y %H:%M') }}
               <strong class="ms-2">Visibilidade:</strong>
               {{ artigo.visibility.label }}
             </p>

--- a/templates/artigos/editar_artigo.html
+++ b/templates/artigos/editar_artigo.html
@@ -13,7 +13,7 @@
       <div class="card-body">
         <h3>Editar Artigo</h3>
         <p class="text-muted">
-          Criado em: {{ artigo.created_at.astimezone(ZoneInfo('America/Sao_Paulo')).strftime('%d/%m/%Y %H:%M') }} |
+          Criado em: {{ artigo.local_created.strftime('%d/%m/%Y %H:%M') }} |
           Visibilidade: {{ artigo.visibility.label }}
         </p>
         <form method="POST" enctype="multipart/form-data">

--- a/templates/artigos/solicitar_revisao.html
+++ b/templates/artigos/solicitar_revisao.html
@@ -34,7 +34,7 @@
                 <strong>Autor:</strong>
                 {{ artigo.author.nome_completo or artigo.author.username }}
                 <strong class="ms-2">Criado em:</strong>
-                {{ artigo.created_at.astimezone(ZoneInfo('America/Sao_Paulo')).strftime('%d/%m/%Y %H:%M') }}
+                {{ artigo.local_created.strftime('%d/%m/%Y %H:%M') }}
                 <strong class="ms-2">Visibilidade:</strong>
                 {{ artigo.visibility.label }}
               </p>


### PR DESCRIPTION
## Summary
- ajusta rotas para calcular `local_created` com fuso de São Paulo
- exibe data local em páginas de artigo, aprovação, solicitação de revisão e edição

## Testing
- `pytest` *(falhou: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c076b8d84c832eb6d894cdd924d281