### PR TITLE
Add signed login-avatar cookie and endpoint to show remembered avatar on login page

### DIFF
--- a/blueprints/auth.py
+++ b/blueprints/auth.py
@@ -2,6 +2,7 @@ import os
 import re
 import uuid
 from datetime import datetime
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 
 from flask import Blueprint, render_template, request, redirect, url_for, flash, session, current_app as app, send_from_directory, abort
 from werkzeug.utils import secure_filename
@@ -33,6 +34,33 @@ def send_password_email(user, action):
     send_email(user.email, 'Definição de Senha', html)
 
 auth_bp = Blueprint('auth_bp', __name__)
+LOGIN_AVATAR_COOKIE = 'login_avatar_token'
+LOGIN_AVATAR_TOKEN_SALT = 'login-avatar'
+LOGIN_AVATAR_MAX_AGE_SECONDS = 60 * 60 * 24 * 30
+
+
+def _login_avatar_serializer():
+    return URLSafeTimedSerializer(app.config['SECRET_KEY'], salt=LOGIN_AVATAR_TOKEN_SALT)
+
+
+def _build_login_avatar_token(user):
+    return _login_avatar_serializer().dumps({'uid': user.id})
+
+
+def _get_remembered_user_from_cookie():
+    token = request.cookies.get(LOGIN_AVATAR_COOKIE)
+    if not token:
+        return None
+
+    try:
+        payload = _login_avatar_serializer().loads(token, max_age=LOGIN_AVATAR_MAX_AGE_SECONDS)
+        user_id = payload.get('uid')
+    except (BadSignature, SignatureExpired):
+        return None
+
+    if not user_id:
+        return None
+    return User.query.get(user_id)
 
 # ROTAS PRINCIPAIS
 # -------------------------------------------------------------------------
@@ -59,7 +87,7 @@ def login():
         # Validação simples de campos vazios no backend
         if not username or not password:
             flash("Nome de usuário e senha são obrigatórios.", "danger")
-            return render_template("auth/login.html", users_json={})
+            return render_template("auth/login.html", remembered_user=_get_remembered_user_from_cookie())
 
         user = User.query.filter_by(username=username).first()
 
@@ -75,16 +103,33 @@ def login():
 
             # Redireciona para a página de destino após o login
             next_url = request.args.get('next')
+            response = redirect(next_url) if next_url else redirect(url_for("pagina_inicial"))
+            response.set_cookie(
+                LOGIN_AVATAR_COOKIE,
+                _build_login_avatar_token(user),
+                max_age=LOGIN_AVATAR_MAX_AGE_SECONDS,
+                secure=app.config.get('SESSION_COOKIE_SECURE', True),
+                httponly=True,
+                samesite=app.config.get('SESSION_COOKIE_SAMESITE', 'Lax'),
+            )
             if next_url:
-                return redirect(next_url)
-            return redirect(url_for("pagina_inicial")) # Redireciona para a página inicial do usuário
+                return response
+            return response # Redireciona para a página inicial do usuário
         else:
             # Credenciais inválidas
             flash("Usuário ou senha inválidos!", "danger")
-            return render_template("auth/login.html", users_json={})
+            return render_template("auth/login.html", remembered_user=_get_remembered_user_from_cookie())
 
     # Para requisições GET (primeiro acesso à página de login)
-    return render_template("auth/login.html", users_json={})
+    return render_template("auth/login.html", remembered_user=_get_remembered_user_from_cookie())
+
+
+@auth_bp.route('/login-avatar', endpoint='login_avatar')
+def login_avatar():
+    remembered_user = _get_remembered_user_from_cookie()
+    if not remembered_user or not remembered_user.foto:
+        return abort(404)
+    return send_from_directory(app.config['PROFILE_PICS_FOLDER'], remembered_user.foto)
 
 
 @auth_bp.route('/esqueci-senha', methods=['GET', 'POST'], endpoint='forgot_password')
@@ -305,5 +350,6 @@ def perfil():
 @auth_bp.route('/logout', endpoint='logout')
 def logout():
     session.clear()
-    return redirect(url_for('login'))
-
+    response = redirect(url_for('login'))
+    response.delete_cookie(LOGIN_AVATAR_COOKIE)
+    return response

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 
-{% block body_attrs %}{% endblock %}
+{% block body_attrs %}
+data-login-avatar-url="{{ url_for('login_avatar') }}"
+data-remembered-username="{{ remembered_user.username if remembered_user else '' }}"
+{% endblock %}
 
 {% block title %}Login{% endblock %}
 
@@ -95,8 +98,8 @@
       flashContainer.remove();
     }
 
-    const dataUsers  = document.body.dataset.users;
-    const users      = dataUsers ? JSON.parse(dataUsers) : {};
+    const loginAvatarUrl = document.body.dataset.loginAvatarUrl || "";
+    const rememberedUsername = (document.body.dataset.rememberedUsername || "").trim();
     const input      = document.getElementById("username");
     const photo      = document.getElementById("user-photo");
     const loginForm  = document.querySelector("form");
@@ -112,9 +115,9 @@
     /* ------------------------------------------------------------------
        2) Renderiza o avatar                                              */
     function render(username) {
-      if (users[username] && users[username].foto) {
+      if (rememberedUsername && loginAvatarUrl && username === rememberedUsername) {
         photo.innerHTML = `
-          <img src="/profile_pics/${users[username].foto}"
+          <img src="${loginAvatarUrl}"
                class="rounded-circle"
                style="width:60px; height:60px;"
                alt="${username}">

--- a/tests/test_security_controls.py
+++ b/tests/test_security_controls.py
@@ -46,6 +46,80 @@ def test_profile_pic_requires_auth(app_ctx, tmp_path):
     assert resp.status_code == 401
 
 
+def test_login_avatar_requires_signed_cookie(app_ctx):
+    with app.app_context():
+        from core.models import Instituicao, Estabelecimento, Setor, Celula
+
+        inst = Instituicao(codigo="INST2", nome="Inst2")
+        est = Estabelecimento(codigo="E2", nome_fantasia="Estab2", instituicao=inst)
+        setor = Setor(nome="Setor2", estabelecimento=est)
+        celula = Celula(nome="Cel2", estabelecimento=est, setor=setor)
+        db.session.add_all([inst, est, setor, celula])
+        db.session.flush()
+
+        user = User(
+            username="avatar_user",
+            email="avatar@example.com",
+            estabelecimento=est,
+            setor=setor,
+            celula=celula,
+            foto="avatar_login.jpg",
+        )
+        user.set_password("Secret1!")
+        db.session.add(user)
+        db.session.commit()
+
+    folder = app.config["PROFILE_PICS_FOLDER"]
+    os.makedirs(folder, exist_ok=True)
+    with open(os.path.join(folder, "avatar_login.jpg"), "wb") as f:
+        f.write(b"avatar-bytes")
+
+    client = app.test_client()
+    resp_without_cookie = client.get("/login-avatar")
+    assert resp_without_cookie.status_code == 404
+
+    client.post("/login", data={"username": "avatar_user", "password": "Secret1!"})
+    resp_with_cookie = client.get("/login-avatar")
+    assert resp_with_cookie.status_code == 200
+    assert resp_with_cookie.data == b"avatar-bytes"
+
+
+def test_logout_clears_login_avatar_cookie(app_ctx):
+    with app.app_context():
+        from core.models import Instituicao, Estabelecimento, Setor, Celula
+
+        inst = Instituicao(codigo="INST3", nome="Inst3")
+        est = Estabelecimento(codigo="E3", nome_fantasia="Estab3", instituicao=inst)
+        setor = Setor(nome="Setor3", estabelecimento=est)
+        celula = Celula(nome="Cel3", estabelecimento=est, setor=setor)
+        db.session.add_all([inst, est, setor, celula])
+        db.session.flush()
+
+        user = User(
+            username="logout_avatar",
+            email="logout_avatar@example.com",
+            estabelecimento=est,
+            setor=setor,
+            celula=celula,
+            foto="logout_avatar.jpg",
+        )
+        user.set_password("Secret1!")
+        db.session.add(user)
+        db.session.commit()
+
+    folder = app.config["PROFILE_PICS_FOLDER"]
+    os.makedirs(folder, exist_ok=True)
+    with open(os.path.join(folder, "logout_avatar.jpg"), "wb") as f:
+        f.write(b"logout-avatar")
+
+    client = app.test_client()
+    client.post("/login", data={"username": "logout_avatar", "password": "Secret1!"})
+    assert client.get("/login-avatar").status_code == 200
+
+    client.get("/logout")
+    assert client.get("/login-avatar").status_code == 404
+
+
 def test_secure_cookie_flags_present(app_ctx):
     assert app.config["SESSION_COOKIE_SECURE"] is True
     assert app.config["SESSION_COOKIE_HTTPONLY"] is True


### PR DESCRIPTION
### Motivation

- Remember and display a user's profile avatar on the login page after a successful sign-in while preserving privacy and integrity. 
- Ensure the remembered-avatar data is tamper-proof, time-limited and removed on logout.

### Description

- Introduces a signed, timed cookie flow with constants `LOGIN_AVATAR_COOKIE`, `LOGIN_AVATAR_TOKEN_SALT`, and `LOGIN_AVATAR_MAX_AGE_SECONDS` and a `URLSafeTimedSerializer` for token generation and validation. 
- Adds helper functions `_build_login_avatar_token` and `_get_remembered_user_from_cookie`, sets the signed cookie on successful `login` and deletes it on `logout`, and uses secure/httponly/samesite flags based on app config. 
- Adds a new endpoint `login_avatar` (`/login-avatar`) that serves the user's photo from `PROFILE_PICS_FOLDER` only when the signed cookie is valid and the user has a `foto`. 
- Updates the login template to expose `data-login-avatar-url` and `data-remembered-username` and updates client-side JS to render the avatar from the signed-cookie-backed endpoint instead of embedding user metadata in the page.

### Testing

- Added and ran `tests/test_security_controls.py::test_login_avatar_requires_signed_cookie`, which verifies the avatar endpoint is 404 without a valid cookie and returns the image after login, and it passed. 
- Added and ran `tests/test_security_controls.py::test_logout_clears_login_avatar_cookie`, which verifies the cookie is cleared on logout and the avatar endpoint returns 404 afterward, and it passed. 
- Ran existing security-related tests including `test_secure_cookie_flags_present` and `test_login_page_hides_user_metadata`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab1f396310832eb346698d1b173eec)