### PR TITLE
Ajusta fluxo de senha inicial preservando obrigatoriedade/unicidade de e-mail

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -55,7 +55,6 @@ except ImportError:  # pragma: no cover
     from core.decorators import admin_required
 try:
     from ..core.utils import (
-        DEFAULT_NEW_USER_PASSWORD,
         send_email,
         generate_token,
         eligible_review_notification_users,
@@ -66,7 +65,6 @@ try:
     )
 except ImportError:  # pragma: no cover
     from core.utils import (
-        DEFAULT_NEW_USER_PASSWORD,
         send_email,
         generate_token,
         eligible_review_notification_users,
@@ -506,7 +504,7 @@ def admin_usuarios():
                     action_msg = 'atualizado'
                 else:
                     if not password:
-                        password = DEFAULT_NEW_USER_PASSWORD
+                        password = str(uuid.uuid4())
                     usr = User(
                         username=username,
                         email=email,

--- a/tests/test_admin_usuarios.py
+++ b/tests/test_admin_usuarios.py
@@ -2,7 +2,6 @@ import pytest
 
 from app import app, db
 from core.models import User, Instituicao, Estabelecimento, Setor, Celula, Cargo, Funcao
-from core.utils import DEFAULT_NEW_USER_PASSWORD
 
 @pytest.fixture
 def client(app_ctx):
@@ -64,7 +63,7 @@ def test_create_user(client):
         user = User.query.filter_by(username='newuser').first()
         assert user is not None
         assert user.email == 'new@example.com'
-        assert user.check_password(DEFAULT_NEW_USER_PASSWORD)
+        assert user.check_password('Mudanca123!') is False
         assert user.ativo is True
         assert user.celula_id == ids['cel']
         assert user.setor_id == ids['setor']
@@ -296,3 +295,52 @@ def test_edit_user_updates_relations(client):
         assert u.email == 'new@example.com'
         assert u.cargo_id == cargo_id
         assert {f.id for f in u.permissoes_personalizadas} == {func2_id}
+
+
+def test_admin_usuarios_form_keeps_email_required(client):
+    login_admin(client)
+    response = client.get('/admin/usuarios')
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert 'id="email"' in html
+    assert 'id="email" name="email"' in html
+    assert 'id="email" name="email" value="' in html
+    assert 'id="email" name="email" value="" required' in html
+
+
+def test_edit_user_duplicate_email_still_blocked(client):
+    login_admin(client)
+    ids = client.base_ids
+    with app.app_context():
+        u1 = User(
+            username='u-one',
+            email='u-one@example.com',
+            estabelecimento_id=ids['est'],
+            setor_id=ids['setor'],
+            celula_id=ids['cel'],
+        )
+        u1.set_password('x')
+        u2 = User(
+            username='u-two',
+            email='u-two@example.com',
+            estabelecimento_id=ids['est'],
+            setor_id=ids['setor'],
+            celula_id=ids['cel'],
+        )
+        u2.set_password('x')
+        db.session.add_all([u1, u2])
+        db.session.commit()
+        u2_id = u2.id
+
+    response = client.post('/admin/usuarios', data={
+        'id_para_atualizar': str(u2_id),
+        'username': 'u-two',
+        'email': 'u-one@example.com',
+        'ativo_check': 'on',
+        'estabelecimento_id': ids['est'],
+        'setor_ids': [str(ids['setor'])],
+        'celula_ids': [str(ids['cel'])],
+    }, follow_redirects=True)
+
+    assert response.status_code == 200
+    assert 'já está em uso' in response.get_data(as_text=True)


### PR DESCRIPTION
### Motivation
- Evitar uso de senha padrão fixa ao criar usuários pelo admin e reforçar o fluxo de definição de senha via link por e-mail.
- Não alterar constraints de banco nem validações existentes de e-mail.
- Garantir que a UI continue exibindo o `required` no campo de e-mail e que a unicidade de e-mail no backend permaneça ativa.

### Description
- Substitui o uso de `DEFAULT_NEW_USER_PASSWORD` no fluxo de criação de usuário por uma senha gerada aleatoriamente com `str(uuid.uuid4())` quando o admin não fornece uma senha (`blueprints/admin.py`).
- Remove a dependência de importação de `DEFAULT_NEW_USER_PASSWORD` no arquivo de rota de admin (`blueprints/admin.py`).
- Ajusta o teste de criação de usuário para não esperar mais a senha fixa antiga e adiciona `test_admin_usuarios_form_keeps_email_required` e `test_edit_user_duplicate_email_still_blocked` para cobrir que o campo de e-mail permanece `required` na UI e que a verificação de e-mail duplicado continua bloqueada no backend (`tests/test_admin_usuarios.py`).
- Não há mudanças em migrations, constraints de banco ou remoção de validações de e-mail no frontend.

### Testing
- Executei `pytest -q tests/test_admin_usuarios.py` e a suíte local passou com sucesso.
- Executei `pytest -q tests/test_admin_usuarios.py tests/test_password_reset.py` e ambos os conjuntos passaram (final: `14 passed`, warnings informativos sobre API legada do SQLAlchemy).
- Os novos/alterados testes confirmam que o campo de e-mail mantém `required` e que tentativa de duplicar e-mail é rejeitada pelo backend.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d817e1cc832e87e8a3ca97505b40)