### PR TITLE
feat: adicionar bootstrap idempotente do admin com CLI e senha inicial segura

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from flask import (
     session, send_from_directory, flash, jsonify # Adicionei jsonify se for usar em APIs futuras
 )
 import logging
+import click
 from flask_migrate import Migrate
 from werkzeug.security import check_password_hash, generate_password_hash # generate_password_hash se for resetar senha no admin
 from sqlalchemy import or_, func
@@ -99,6 +100,11 @@ except ImportError:  # pragma: no cover - fallback for direct execution
         user_can_review_article,
         eligible_review_notification_users,
     )
+try:
+    from .seeds.bootstrap_admin import ensure_initial_admin
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from seeds.bootstrap_admin import ensure_initial_admin
+
 from mimetypes import guess_type # Se for usar, descomente
 from werkzeug.utils import secure_filename # Útil para uploads, como na sua foto de perfil
 
@@ -180,6 +186,36 @@ for folder in (UPLOAD_FOLDER, PROFILE_PICS_FOLDER):
     os.makedirs(folder, exist_ok=True)
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 app.config['PROFILE_PICS_FOLDER'] = PROFILE_PICS_FOLDER
+
+
+@app.cli.command("bootstrap-admin")
+@click.option("--username", default="admin", show_default=True, help="Username do admin inicial.")
+@click.option("--email", default="admin@seudominio.com", show_default=True, help="E-mail do admin inicial.")
+@click.option("--password", default=None, help="Senha inicial. Se omitida, será gerada com segurança e exibida no terminal.")
+@click.option("--nome-completo", "nome_completo", default="Administrador Inicial", show_default=True, help="Nome completo do admin inicial.")
+def bootstrap_admin_command(username: str, email: str, password: str | None, nome_completo: str) -> None:
+    """Cria (ou garante) o usuário administrador inicial de forma idempotente."""
+    result = ensure_initial_admin(
+        username=username,
+        email=email,
+        initial_password=password,
+        nome_completo=nome_completo,
+    )
+
+    if result.created:
+        click.echo("✅ Admin inicial criado com sucesso.")
+        click.echo(f"- username: {result.user.username}")
+        click.echo(f"- email: {result.user.email}")
+        if result.generated_password:
+            click.echo(f"- senha temporária gerada: {result.generated_password}")
+        else:
+            click.echo("- senha temporária: [informada via --password]")
+        click.echo("- deve_trocar_senha: True")
+    else:
+        click.echo("ℹ️ Admin inicial já existe (idempotente, nenhum duplicado criado).")
+        click.echo(f"- username: {result.user.username}")
+        click.echo("- deve_trocar_senha: True")
+
 
 
 def _is_auth_local_flash_path(path: str) -> bool:

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -26,11 +26,13 @@ Estes itens são os mesmos listados na seção de pré-requisitos do projeto【F
    source venv/bin/activate
    pip install -r requirements.txt
    ```
-3. **Aplique as migrações do banco** e (opcionalmente) rode os seeds:
+3. **Aplique as migrações do banco**, execute o bootstrap do admin e (opcionalmente) rode os seeds:
    ```bash
    flask db upgrade
+   flask bootstrap-admin
    python -m seeds.seed  # opcional - inclui exemplo do processo de onboarding
    ```
+   O comando `flask bootstrap-admin` é idempotente, não duplica o usuário admin e mantém `deve_trocar_senha=True` para forçar a troca imediata da senha inicial.
 
 ## 3. Configuração do `.env`
 Copie o arquivo `.env.example` para `.env` e defina os valores das variáveis `MAIL_PROVIDER`, `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_USE_TLS`, `MAIL_DEFAULT_SENDER`, `SECRET_KEY` e `DATABASE_URI`. Essas variáveis são obrigatórias para a aplicação【F:docs/GUIA_DE_INSTALACAO.md†L174-L188】【F:docs/GUIA_DE_INSTALACAO.md†L188-L230】. Um exemplo de `.env` pode ser visto abaixo:

--- a/docs/GUIA_DE_INSTALACAO.md
+++ b/docs/GUIA_DE_INSTALACAO.md
@@ -243,13 +243,35 @@ Este comando executará todos os scripts de migração na pasta migrations/versi
 
 > **Observação:** se você adicionar uma nova coluna marcada como `nullable=True` em modelos existentes (como o `User`), remova previamente os registros ou deixe o campo temporariamente como `nullable=False` para rodar o `flask db upgrade`. Após a migração, altere o campo no banco para aceitar valores nulos, se desejar.
 
-## 12. (Opcional, mas Recomendado) Popular Dados de Exemplo
+## 12. Bootstrap Oficial do Admin Inicial (Recomendado)
+Use o comando oficial para criar (ou garantir) o administrador inicial:
+```bash
+flask bootstrap-admin
+```
+
+Comportamento do comando:
+- **Idempotente:** não cria usuário admin duplicado quando já existir.
+- **Senha inicial segura:** se `--password` não for enviada, uma senha temporária forte é gerada automaticamente e exibida no terminal.
+- **Troca obrigatória:** o usuário fica com `deve_trocar_senha=True` (equivalente a `must_change_password=True`).
+
+Exemplo com senha definida manualmente:
+```bash
+flask bootstrap-admin --username admin --email admin@seudominio.com --password 'TrocaImediata#2026'
+```
+
+> **Credenciais iniciais e troca imediata:**
+> 1. Guarde a senha temporária em local seguro.
+> 2. Faça login com o admin inicial.
+> 3. O sistema redireciona para atualização de senha por `deve_trocar_senha=True`.
+> 4. Defina uma nova senha forte e exclusiva.
+
+## 13. (Opcional, mas Recomendado) Popular Dados de Exemplo
 Execute o script abaixo para criar funções, organização, usuários e artigos básicos:
 ```bash
 python -m seeds.seed
 ```
 
-## 13. Rodar a Aplicação Flask
+## 14. Rodar a Aplicação Flask
 Finalmente! Para rodar o servidor de desenvolvimento do Flask:
 ```bash
 flask run (ou `python -m flask run`)
@@ -258,7 +280,7 @@ O terminal deverá exibir mensagens indicando que o servidor está rodando, gera
 
 Abra seu navegador de internet e acesse `http://127.0.0.1:5000/`. Você deverá ver a página de login do Orquetask ou ser redirecionado para ela.
 
-## 14. Solução de Problemas Comuns no Windows
+## 15. Solução de Problemas Comuns no Windows
 
 * **Comandos não encontrados (`python`, `pip`, `flask`, `git`):**
     * Verifique se o software correspondente foi adicionado ao **PATH** do sistema durante sua instalação.
@@ -279,7 +301,7 @@ Abra seu navegador de internet e acesse `http://127.0.0.1:5000/`. Você deverá 
 
 ---
 
-## 15. Configurar Envio de E-mails com SMTP Gmail
+## 16. Configurar Envio de E-mails com SMTP Gmail
 
 Para que o Orquetask envie notificações por e-mail, configure o SMTP do Gmail.
 
@@ -300,7 +322,7 @@ Para que o Orquetask envie notificações por e-mail, configure o SMTP do Gmail.
 
 Com essas configurações, o módulo central de e-mail continuará atendendo os envios de convite, redefinição de senha e notificações sem alterar as regras de negócio.
 
-## 16. Implantação em Produção
+## 17. Implantação em Produção
 
 Após concluir as etapas de instalação e configuração, consulte o
 [Guia de Implantação](./DEPLOY.md) para instruções detalhadas de como colocar o

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,12 +91,25 @@ Consulte o passo a passo de instalação dessas dependências e a configuração
     > em um repositório recém-clonado sem conflitos de cabeças.
     > Se suas migrações incluírem novas colunas com `nullable=True` em tabelas já existentes (ex.: `User`), remova os registros atuais ou defina o campo como `nullable=False` temporariamente para que a migração execute sem erros. Depois do `flask db upgrade`, ajuste o campo para permitir nulos, se for o caso.
 
-6.  **(Opcional) Popule dados de exemplo (funções, organização, usuários e artigos):**
+6.  **Bootstrap oficial do admin inicial (recomendado em qualquer ambiente):**
+    ```bash
+    flask bootstrap-admin
+    ```
+    * O comando é **idempotente**: se o admin já existir, não cria duplicado.
+    * Se `--password` não for informada, uma senha temporária forte é gerada e exibida no terminal.
+    * O usuário é criado/atualizado com `deve_trocar_senha=True` (equivalente ao `must_change_password=True`), exigindo troca imediata no primeiro login.
+
+    Exemplo com credenciais explícitas:
+    ```bash
+    flask bootstrap-admin --username admin --email admin@seudominio.com --password 'TrocaImediata#2026'
+    ```
+
+7.  **(Opcional) Popule dados de exemplo (funções, organização, usuários e artigos):**
     ```bash
     python -m seeds.seed
     ```
 
-7.  **Rode a aplicação Flask:**
+8.  **Rode a aplicação Flask:**
     ```bash
     flask run
     ```

--- a/seeds/bootstrap_admin.py
+++ b/seeds/bootstrap_admin.py
@@ -1,0 +1,120 @@
+import secrets
+import string
+from dataclasses import dataclass
+
+try:
+    from .core.database import db
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from core.database import db
+
+try:
+    from .core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User
+
+
+@dataclass
+class BootstrapAdminResult:
+    user: User
+    created: bool
+    generated_password: str | None
+
+
+def _get_or_create(model, defaults=None, **kwargs):
+    instance = model.query.filter_by(**kwargs).first()
+    if instance:
+        return instance
+    params = defaults or {}
+    params.update(kwargs)
+    instance = model(**params)
+    db.session.add(instance)
+    db.session.flush()
+    return instance
+
+
+def _generate_secure_password(length: int = 20) -> str:
+    if length < 12:
+        raise ValueError("O tamanho mínimo da senha inicial é 12 caracteres.")
+
+    alphabet = string.ascii_letters + string.digits + "!@#$%^&*()-_=+"
+    while True:
+        candidate = ''.join(secrets.choice(alphabet) for _ in range(length))
+        if (
+            any(char.islower() for char in candidate)
+            and any(char.isupper() for char in candidate)
+            and any(char.isdigit() for char in candidate)
+            and any(char in "!@#$%^&*()-_=+" for char in candidate)
+        ):
+            return candidate
+
+
+def ensure_initial_admin(
+    username: str = "admin",
+    email: str = "admin@seudominio.com",
+    initial_password: str | None = None,
+    nome_completo: str = "Administrador Inicial",
+) -> BootstrapAdminResult:
+    """Garante usuário administrador inicial de forma idempotente."""
+
+    admin_funcao = Funcao.query.filter_by(codigo="admin").first()
+    if not admin_funcao:
+        admin_funcao = Funcao(codigo="admin", nome="Administrador")
+        db.session.add(admin_funcao)
+        db.session.flush()
+
+    existing_admin = User.query.filter_by(username=username).first()
+    if not existing_admin:
+        existing_admin = User.query.filter_by(email=email).first()
+
+    if existing_admin:
+        if admin_funcao not in existing_admin.permissoes_personalizadas:
+            existing_admin.permissoes_personalizadas.append(admin_funcao)
+        existing_admin.deve_trocar_senha = True
+        db.session.commit()
+        return BootstrapAdminResult(user=existing_admin, created=False, generated_password=None)
+
+    instituicao = _get_or_create(
+        Instituicao,
+        codigo="BOOT001",
+        nome="Bootstrap Instituição",
+        defaults={"descricao": "Estrutura mínima para bootstrap do admin."},
+    )
+    estabelecimento = _get_or_create(
+        Estabelecimento,
+        codigo="BOOT-EST",
+        nome_fantasia="Bootstrap Estabelecimento",
+        defaults={"instituicao_id": instituicao.id},
+    )
+    setor = _get_or_create(
+        Setor,
+        nome="Bootstrap Setor",
+        defaults={"estabelecimento_id": estabelecimento.id},
+    )
+    celula = _get_or_create(
+        Celula,
+        nome="Bootstrap Célula",
+        defaults={"estabelecimento_id": estabelecimento.id, "setor_id": setor.id},
+    )
+
+    generated_password = None
+    password = initial_password
+    if not password:
+        generated_password = _generate_secure_password()
+        password = generated_password
+
+    admin = User(
+        username=username,
+        email=email,
+        nome_completo=nome_completo,
+        estabelecimento_id=estabelecimento.id,
+        setor_id=setor.id,
+        celula_id=celula.id,
+        deve_trocar_senha=True,
+    )
+    admin.set_password(password)
+    admin.permissoes_personalizadas.append(admin_funcao)
+
+    db.session.add(admin)
+    db.session.commit()
+
+    return BootstrapAdminResult(user=admin, created=True, generated_password=generated_password)

--- a/seeds/seed_demonstration.py
+++ b/seeds/seed_demonstration.py
@@ -37,14 +37,16 @@ try:
 except ImportError:  # pragma: no cover - fallback for direct execution
     from core.enums import Permissao, ArticleVisibility, ArticleStatus
 
-from werkzeug.security import generate_password_hash
 from datetime import datetime, timezone
+from werkzeug.security import generate_password_hash
 from app import app
 
 try:
     from . import seed_funcoes
+    from .bootstrap_admin import ensure_initial_admin
 except ImportError:  # pragma: no cover - fallback para execução direta
     import seed_funcoes
+    from bootstrap_admin import ensure_initial_admin
 
 
 def get_or_create(model, defaults=None, **kwargs):
@@ -379,25 +381,15 @@ def run():
                 )
                 db.session.add(user)
 
-        # Usuário administrador padrao
-        admin = User.query.filter_by(username="admin").first()
-        if not admin:
-            admin = User(
-                username="admin",
-                email="admin@seudominio.com",
-                password_hash=generate_password_hash("Senha123!"),
-                deve_trocar_senha=True,
-                nome_completo="Admin de Souza",
-                matricula="ADM001",
-                cpf="000.000.000-00",
-                estabelecimento_id=cel1.estabelecimento_id,
-                setor_id=cel1.setor_id,
-                celula_id=cel1.id,
+        bootstrap_result = ensure_initial_admin(
+            initial_password=os.getenv("INITIAL_ADMIN_PASSWORD"),
+        )
+        if bootstrap_result.created and bootstrap_result.generated_password:
+            print(
+                "Admin inicial criado pelo seed. "
+                f"username={bootstrap_result.user.username} "
+                f"senha_temporaria={bootstrap_result.generated_password}"
             )
-            func_admin = Funcao.query.filter_by(codigo="admin").first()
-            if func_admin:
-                admin.permissoes_personalizadas.append(func_admin)
-            db.session.add(admin)
 
         db.session.commit()
 

--- a/tests/test_bootstrap_admin.py
+++ b/tests/test_bootstrap_admin.py
@@ -1,0 +1,23 @@
+from seeds.bootstrap_admin import ensure_initial_admin
+from core.models import User
+
+
+def test_bootstrap_admin_is_idempotent_and_requires_password_change(app_ctx):
+    first = ensure_initial_admin(
+        username='admin',
+        email='admin@example.com',
+    )
+
+    assert first.created is True
+    assert first.generated_password
+    assert first.user.deve_trocar_senha is True
+
+    second = ensure_initial_admin(
+        username='admin',
+        email='admin@example.com',
+    )
+
+    assert second.created is False
+    assert second.generated_password is None
+    assert second.user.deve_trocar_senha is True
+    assert User.query.filter_by(username='admin').count() == 1


### PR DESCRIPTION
### Motivation
- Formalizar uma estratégia oficial para criar o administrador inicial com uma senha segura.
- Garantir que o admin inicial seja marcado para troca imediata de senha (`deve_trocar_senha=True`).
- Evitar criação duplicada do admin em execuções repetidas (idempotência).
- Documentar o procedimento de bootstrap e a troca imediata de credenciais para operadores.

### Description
- Adiciona `seeds/bootstrap_admin.py` com a função `ensure_initial_admin` que gera senha forte quando não informada, cria estrutura mínima (instituição/estabelecimento/setor/célula) para satisfazer FKs e marca o usuário com `deve_trocar_senha=True` garantindo idempotência.
- Registra o comando CLI `flask bootstrap-admin` em `app.py` com opções `--username`, `--email`, `--password` e `--nome-completo`, que chama `ensure_initial_admin` e exibe a senha temporária quando gerada.
- Integra o seed de demonstração (`seeds/seed_demonstration.py`) ao `ensure_initial_admin`, removendo a senha hardcoded anterior e respeitando a variável `INITIAL_ADMIN_PASSWORD` quando fornecida.
- Atualiza documentação (`docs/README.md`, `docs/GUIA_DE_INSTALACAO.md`, `docs/DEPLOY.md`) com os comandos e o procedimento de troca imediata, e adiciona teste `tests/test_bootstrap_admin.py` cobrindo idempotência e a flag de troca obrigatória.

### Testing
- Compilação estática dos módulos com `python -m compileall` foi realizada com sucesso para os arquivos alterados.
- `pytest -q tests/test_bootstrap_admin.py` passou (`1 passed`).
- `pytest -q tests/test_password_reset.py` passou (`3 passed`) e não foi afetado pelas mudanças.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e0b1d3b4832e8006f77403cae30b)