### PR TITLE
Add tests for initial-password onboarding and clarify SMTP optional in install guide

### DIFF
--- a/docs/GUIA_DE_INSTALACAO.md
+++ b/docs/GUIA_DE_INSTALACAO.md
@@ -180,7 +180,7 @@ pip install --force-reinstall lxml "numpy<2" opencv-python python-docx
 ## 10. Configurar Variáveis de Ambiente Essenciais (no Windows)
 Para que o Orquetask funcione corretamente e de forma segura, é crucial configurar algumas **variáveis de ambiente** no seu sistema Windows. Essas variáveis permitem que a aplicação acesse configurações importantes sem que elas precisem estar escritas diretamente no código.
 
-Antes de prosseguir, copie o arquivo `.env.example` que acompanha o projeto para `.env` e preencha os valores de `MAIL_PROVIDER`, `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_USE_TLS`, `MAIL_DEFAULT_SENDER`, `SECRET_KEY` e `DATABASE_URI` com suas próprias configurações. O Flask carregará essas variáveis automaticamente ao executar `flask run` se o arquivo `.env` estiver na raiz do projeto.
+Antes de prosseguir, copie o arquivo `.env.example` que acompanha o projeto para `.env` e preencha **obrigatoriamente** `SECRET_KEY` e `DATABASE_URI`. As variáveis de SMTP (`MAIL_PROVIDER`, `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_USE_TLS`, `MAIL_DEFAULT_SENDER`) são recomendadas para comunicações por e-mail, mas podem ser configuradas depois. O Flask carregará essas variáveis automaticamente ao executar `flask run` se o arquivo `.env` estiver na raiz do projeto.
 
 * **Por que usar Variáveis de Ambiente?**
     * **Segurança:** É a forma mais segura de gerenciar informações sensíveis como chaves secretas (`SECRET_KEY`) e credenciais de banco de dados (`DATABASE_URI`), mantendo-as fora do código-fonte que pode ser versionado no Git.
@@ -233,6 +233,11 @@ O arquivo `app.py` do Orquetask está programado para ler essas variáveis do se
     *(Opcionalmente, para testes rápidos, você pode definir variáveis temporariamente em uma sessão do PowerShell usando `$env:NOME_VARIAVEL = "VALOR"`, mas elas não persistirão).*
 
 Com essas variáveis corretamente configuradas, o Orquetask estará pronto para rodar usando configurações seguras e específicas do seu setup.
+
+> **Importante sobre cadastro e onboarding:**
+> - O campo **e-mail continua obrigatório** no cadastro de usuários.
+> - O **fluxo inicial de acesso não depende de envio de e-mail**: o admin define (ou recebe) uma senha inicial e o usuário é marcado para troca obrigatória no primeiro login.
+> - O **SMTP é opcional para onboarding inicial**, permanecendo útil/recomendado para comunicações futuras (como recuperação de senha e notificações).
 
 ## 11. Aplicar as Migrações do Banco de Dados
 Com o ambiente virtual ativo e as variáveis de ambiente configuradas (especialmente a `DATABASE_URI` correta):
@@ -301,9 +306,9 @@ Abra seu navegador de internet e acesse `http://127.0.0.1:5000/`. Você deverá 
 
 ---
 
-## 16. Configurar Envio de E-mails com SMTP Gmail
+## 16. Configurar Envio de E-mails com SMTP Gmail (Opcional para onboarding)
 
-Para que o Orquetask envie notificações por e-mail, configure o SMTP do Gmail.
+Para que o Orquetask envie notificações e fluxos de recuperação por e-mail, configure o SMTP do Gmail. Esta etapa é opcional para o onboarding inicial de usuários.
 
 1. **Use a conta de envio padrão do projeto:**
    * `orquetask.noreply@gmail.com`
@@ -320,7 +325,7 @@ Para que o Orquetask envie notificações por e-mail, configure o SMTP do Gmail.
    * `MAIL_DEFAULT_SENDER=orquetask.noreply@gmail.com`
 4. **Reinicie a aplicação** após alterar as variáveis para aplicar a nova configuração.
 
-Com essas configurações, o módulo central de e-mail continuará atendendo os envios de convite, redefinição de senha e notificações sem alterar as regras de negócio.
+Com essas configurações, o módulo central de e-mail atenderá os fluxos de redefinição de senha e notificações futuras sem alterar as regras de negócio.
 
 ## 17. Implantação em Produção
 

--- a/tests/test_admin_usuarios.py
+++ b/tests/test_admin_usuarios.py
@@ -70,7 +70,7 @@ def test_create_user(client):
         assert user.extra_celulas.filter_by(id=ids['cel']).count() == 1
 
 
-def test_create_user_does_not_send_password_email_and_shows_admin_password_feedback(client, monkeypatch):
+def test_create_user_shows_initial_password_and_marks_mandatory_change(client):
     login_admin(client)
     ids = client.base_ids
     response = client.post('/admin/usuarios', data={
@@ -84,11 +84,38 @@ def test_create_user_does_not_send_password_email_and_shows_admin_password_feedb
 
     assert response.status_code == 200
     html = response.get_data(as_text=True)
-    assert 'E-mail NÃO foi enviado' in html
+    assert 'Senha inicial (gerada automaticamente):' in html
+    assert 'Usuário marcado para trocar a senha no primeiro acesso.' in html
     with app.app_context():
         user = User.query.filter_by(email='emailuser@example.com').first()
         assert user is not None
         assert user.deve_trocar_senha is True
+        assert user.check_password('') is False
+
+
+def test_create_user_with_admin_password_marks_mandatory_change(client):
+    login_admin(client)
+    ids = client.base_ids
+    senha_inicial = 'Temp1234!'
+    response = client.post('/admin/usuarios', data={
+        'username': 'manualpassuser',
+        'email': 'manualpass@example.com',
+        'password': senha_inicial,
+        'ativo_check': 'on',
+        'estabelecimento_id': ids['est'],
+        'setor_ids': [str(ids['setor'])],
+        'celula_ids': [str(ids['cel'])]
+    }, follow_redirects=True)
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert 'Senha inicial (informada pelo administrador): Temp1234!' in html
+    assert 'Usuário marcado para trocar a senha no primeiro acesso.' in html
+    with app.app_context():
+        user = User.query.filter_by(email='manualpass@example.com').first()
+        assert user is not None
+        assert user.deve_trocar_senha is True
+        assert user.check_password(senha_inicial) is True
 
 
 

--- a/tests/test_security_controls.py
+++ b/tests/test_security_controls.py
@@ -171,6 +171,53 @@ def test_login_redirects_to_mandatory_password_change(client, app_ctx):
     assert "/troca-senha-obrigatoria" in resp.headers["Location"]
 
 
+def test_login_blocks_navigation_until_password_is_changed(client, app_ctx):
+    with app.app_context():
+        from core.models import Instituicao, Estabelecimento, Setor, Celula
+
+        inst = Instituicao(codigo="INST4B", nome="Inst4B")
+        est = Estabelecimento(codigo="E4B", nome_fantasia="Estab4B", instituicao=inst)
+        setor = Setor(nome="Setor4B", estabelecimento=est)
+        celula = Celula(nome="Cel4B", estabelecimento=est, setor=setor)
+        db.session.add_all([inst, est, setor, celula])
+        db.session.flush()
+
+        user = User(
+            username="must_change_login_block",
+            email="must_change_login_block@example.com",
+            estabelecimento=est,
+            setor=setor,
+            celula=celula,
+            deve_trocar_senha=True,
+        )
+        user.set_password("Secret1!")
+        db.session.add(user)
+        db.session.commit()
+
+    login = client.post(
+        "/login",
+        data={"username": "must_change_login_block", "password": "Secret1!"},
+        follow_redirects=False,
+    )
+    assert login.status_code == 302
+    assert "/troca-senha-obrigatoria" in login.headers["Location"]
+
+    blocked = client.get("/perfil", follow_redirects=False)
+    assert blocked.status_code == 302
+    assert "/troca-senha-obrigatoria" in blocked.headers["Location"]
+
+    changed = client.post(
+        "/troca-senha-obrigatoria",
+        data={"nova_senha": "NovaSenha1!", "confirmar_nova_senha": "NovaSenha1!"},
+        follow_redirects=False,
+    )
+    assert changed.status_code == 302
+    assert "/inicio" in changed.headers["Location"]
+
+    unblocked = client.get("/inicio")
+    assert unblocked.status_code == 200
+
+
 def test_mandatory_password_change_blocks_home_and_unblocks_after_change(client, app_ctx):
     user_id = None
     username = "must_change_block"


### PR DESCRIPTION
### Motivation
- Replace legacy test coupling to e-mail delivery with tests that assert the new onboarding flow based on an initial password and mandatory change on first login.
- Cover both automatically-generated initial passwords and admin-provided initial passwords so creation UX and stored password state are validated.
- Ensure the application blocks navigation while `deve_trocar_senha=True` and only unblocks after the user completes the required password change.
- Clarify installation docs so operators understand that e-mail remains required on user records but SMTP is optional for initial onboarding.

### Description
- Updated tests in `tests/test_admin_usuarios.py` to replace the old e-mail-sending assertion and add two scenarios: a user created with an automatically-generated initial password and a user created with an admin-specified password, both asserting `deve_trocar_senha is True` and the expected flash text.
- Added `test_login_blocks_navigation_until_password_is_changed` to `tests/test_security_controls.py` to assert that routes are redirected to `/troca-senha-obrigatoria` until the mandatory password change is completed and that normal access is restored afterwards.
- Edited `docs/GUIA_DE_INSTALACAO.md` to require `SECRET_KEY` and `DATABASE_URI` be set, state that the `e-mail` field remains mandatory on user creation, and mark SMTP configuration as optional for onboarding while still recommended for future communications (password recovery/notifications).

### Testing
- Ran `pytest -q tests/test_admin_usuarios.py tests/test_security_controls.py` which completed successfully with all tests passing (`22 passed`) and only warnings reported.
- No other automated tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e2fc6440832eac0d67fa8cf79588)