### PR TITLE
Harden seed imports for package and script execution modes

### DIFF
--- a/seeds/bootstrap_admin.py
+++ b/seeds/bootstrap_admin.py
@@ -3,14 +3,14 @@ import string
 from dataclasses import dataclass
 
 try:
-    from .core.database import db
-except ImportError:  # pragma: no cover - fallback for direct execution
     from core.database import db
+except ImportError:  # pragma: no cover - fallback for package execution
+    from ..core.database import db
 
 try:
-    from .core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User
-except ImportError:  # pragma: no cover - fallback for direct execution
     from core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User
+except ImportError:  # pragma: no cover - fallback for package execution
+    from ..core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User
 
 
 @dataclass

--- a/seeds/seed_demonstration.py
+++ b/seeds/seed_demonstration.py
@@ -5,22 +5,11 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 try:
-    from .core.database import db
-except ImportError:  # pragma: no cover - fallback for direct execution
     from core.database import db
+except ImportError:  # pragma: no cover - fallback for package execution
+    from ..core.database import db
 
 try:
-    from .core.models import (
-        Instituicao,
-        Estabelecimento,
-        Setor,
-        Celula,
-        Cargo,
-        Funcao,
-        User,
-        Article,
-    )
-except ImportError:  # pragma: no cover - fallback for direct execution
     from core.models import (
         Instituicao,
         Estabelecimento,
@@ -31,11 +20,22 @@ except ImportError:  # pragma: no cover - fallback for direct execution
         User,
         Article,
     )
+except ImportError:  # pragma: no cover - fallback for package execution
+    from ..core.models import (
+        Instituicao,
+        Estabelecimento,
+        Setor,
+        Celula,
+        Cargo,
+        Funcao,
+        User,
+        Article,
+    )
 
 try:
-    from .core.enums import Permissao, ArticleVisibility, ArticleStatus
-except ImportError:  # pragma: no cover - fallback for direct execution
     from core.enums import Permissao, ArticleVisibility, ArticleStatus
+except ImportError:  # pragma: no cover - fallback for package execution
+    from ..core.enums import Permissao, ArticleVisibility, ArticleStatus
 
 from datetime import datetime, timezone
 from werkzeug.security import generate_password_hash

--- a/seeds/seed_funcoes.py
+++ b/seeds/seed_funcoes.py
@@ -5,18 +5,18 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 try:
-    from .core.database import db  # pragma: no cover
+    from core.database import db  # pragma: no cover
 except ImportError:
-    from core.database import db
+    from ..core.database import db
 try:
-    from .core.models import Funcao
-except ImportError:  # pragma: no cover - fallback for direct execução
     from core.models import Funcao
+except ImportError:  # pragma: no cover - fallback for package execution
+    from ..core.models import Funcao
 from app import app
 try:
-    from .core.enums import Permissao  # pragma: no cover
-except ImportError:  # pragma: no cover - fallback para execução direta
-    from core.enums import Permissao
+    from core.enums import Permissao  # pragma: no cover
+except ImportError:  # pragma: no cover - fallback para execução em pacote
+    from ..core.enums import Permissao
 
 # Permissões que não fazem parte do Enum Permissao
 EXTRA_FUNCOES = [

--- a/seeds/seed_organizacao.py
+++ b/seeds/seed_organizacao.py
@@ -1,11 +1,11 @@
 try:
-    from .core.database import db  # pragma: no cover
+    from core.database import db  # pragma: no cover
 except ImportError:
-    from core.database import db
+    from ..core.database import db
 try:
-    from .core.models import Instituicao, Estabelecimento, Setor, Celula
-except ImportError:  # pragma: no cover - fallback for direct execution
     from core.models import Instituicao, Estabelecimento, Setor, Celula
+except ImportError:  # pragma: no cover - fallback for package execution
+    from ..core.models import Instituicao, Estabelecimento, Setor, Celula
 from app import app
 
 

--- a/seeds/seed_processos.py
+++ b/seeds/seed_processos.py
@@ -1,12 +1,12 @@
 try:
-    from .core.database import db
-except ImportError:
     from core.database import db
+except ImportError:
+    from ..core.database import db
 
 try:
-    from .core.models import Processo, EtapaProcesso, CampoEtapa, Cargo, Setor
-except ImportError:
     from core.models import Processo, EtapaProcesso, CampoEtapa, Cargo, Setor
+except ImportError:
+    from ..core.models import Processo, EtapaProcesso, CampoEtapa, Cargo, Setor
 
 from app import app
 

--- a/tests/test_bootstrap_admin.py
+++ b/tests/test_bootstrap_admin.py
@@ -1,5 +1,9 @@
-from seeds.bootstrap_admin import ensure_initial_admin
-from core.models import User
+try:
+    from seeds.bootstrap_admin import ensure_initial_admin
+    from core.models import User
+except ImportError:  # pragma: no cover - fallback for package execution
+    from ..seeds.bootstrap_admin import ensure_initial_admin
+    from ..core.models import User
 
 
 def test_bootstrap_admin_is_idempotent_and_requires_password_change(app_ctx):


### PR DESCRIPTION
### Motivation
- Fix brittle `from .core...` patterns in seed modules that resolved to `seeds.core` and caused import errors in different execution contexts.
- Ensure `flask db upgrade` and CLI flows don't fail with `ModuleNotFoundError` due to seed import resolution differences between package and direct script execution.
- Keep test imports consistent with the resilient import strategy so unit tests run in both package and script contexts.

### Description
- Updated `seeds/bootstrap_admin.py` to import `core.*` first and fall back to package-relative `..core.*` to support both direct and package execution (`from core.database import db` then `except ImportError: from ..core.database import db`).
- Applied the same resilient import pattern to `seeds/seed_processos.py`, `seeds/seed_demonstration.py`, `seeds/seed_organizacao.py`, and `seeds/seed_funcoes.py` to eliminate `seeds.core` resolution issues.
- Adjusted `tests/test_bootstrap_admin.py` to try absolute imports first and fall back to package-relative imports in a `try/except` so tests work when run from different import contexts.
- Left `app.py` import strategy for `ensure_initial_admin` unchanged after validating its dual-mode fallback was already present and correct.

### Testing
- Ran a static import scan with `rg` over the modified files to verify occurrences of `from .core` were addressed, which completed successfully.
- Executed `pytest -q tests/test_bootstrap_admin.py` and the test suite passed (`1 passed`).
- Ran `flask db upgrade`, which advanced past the previous `ModuleNotFoundError` import stage but failed afterwards due to the local PostgreSQL service being unreachable (`psycopg2.OperationalError: connection to server at "localhost" port 5432 refused`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e902557884832e962a5d83b2583885)