### PR TITLE
Allow initial admin without organizational links (nullable FKs + migration + bootstrap/test updates)

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -452,7 +452,25 @@ def admin_usuarios():
             except ValueError:
                 flash('Data de admissão inválida.', 'danger')
 
-        if not username or not email or not estabelecimento_id or not setor_ids or not celula_ids:
+        admin_funcao = Funcao.query.filter_by(codigo='admin').first()
+        selected_funcao_ids = set(funcao_ids)
+        cargo_funcao_ids = {f.id for f in cargo_padrao.permissoes} if cargo_padrao else set()
+        is_target_admin = bool(admin_funcao and admin_funcao.id in (selected_funcao_ids | cargo_funcao_ids))
+
+        if id_para_atualizar and not is_target_admin and admin_funcao:
+            usuario_existente = User.query.get_or_404(id_para_atualizar)
+            possui_admin_atual = usuario_existente.has_permissao('admin')
+            removendo_admin = (
+                possui_admin_atual
+                and admin_funcao.id not in selected_funcao_ids
+                and admin_funcao.id not in cargo_funcao_ids
+            )
+            if not removendo_admin:
+                is_target_admin = possui_admin_atual
+
+        if not username or not email:
+            flash('Usuário e Email são obrigatórios.', 'danger')
+        elif not is_target_admin and (not estabelecimento_id or not setor_ids or not celula_ids):
             flash('Usuário, Email, Estabelecimento, Setor e Célula são obrigatórios.', 'danger')
         else:
             query_username = User.query.filter_by(username=username)

--- a/core/models.py
+++ b/core/models.py
@@ -260,13 +260,13 @@ class User(db.Model):
     # Novas Chaves Estrangeiras e Relacionamentos (Fase 1)
     # Um usuário pertence a um estabelecimento, um setor e tem um cargo.
     # Nullable=True para flexibilidade inicial ou para usuários que não se encaixam perfeitamente.
-    estabelecimento_id = db.Column(db.Integer, db.ForeignKey('estabelecimento.id'), nullable=False)
+    estabelecimento_id = db.Column(db.Integer, db.ForeignKey('estabelecimento.id'), nullable=True)
     estabelecimento = db.relationship('Estabelecimento', back_populates='usuarios')
 
-    setor_id = db.Column(db.Integer, db.ForeignKey('setor.id'), nullable=False)
+    setor_id = db.Column(db.Integer, db.ForeignKey('setor.id'), nullable=True)
     setor = db.relationship('Setor', back_populates='usuarios')
 
-    celula_id = db.Column(db.Integer, db.ForeignKey('celula.id'), nullable=False)
+    celula_id = db.Column(db.Integer, db.ForeignKey('celula.id'), nullable=True)
     celula = db.relationship('Celula', back_populates='usuarios')
 
     cargo_id = db.Column(db.Integer, db.ForeignKey('cargo.id'), nullable=True)

--- a/migrations/versions/3c1d2e4f5a6b_make_user_org_links_nullable.py
+++ b/migrations/versions/3c1d2e4f5a6b_make_user_org_links_nullable.py
@@ -1,0 +1,28 @@
+"""make user organizational links nullable
+
+Revision ID: 3c1d2e4f5a6b
+Revises: 9f7a6b5c4d3e
+Create Date: 2026-04-22 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '3c1d2e4f5a6b'
+down_revision = '9f7a6b5c4d3e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('user', 'estabelecimento_id', existing_type=sa.Integer(), nullable=True)
+    op.alter_column('user', 'setor_id', existing_type=sa.Integer(), nullable=True)
+    op.alter_column('user', 'celula_id', existing_type=sa.Integer(), nullable=True)
+
+
+def downgrade():
+    op.alter_column('user', 'celula_id', existing_type=sa.Integer(), nullable=False)
+    op.alter_column('user', 'setor_id', existing_type=sa.Integer(), nullable=False)
+    op.alter_column('user', 'estabelecimento_id', existing_type=sa.Integer(), nullable=False)

--- a/seeds/bootstrap_admin.py
+++ b/seeds/bootstrap_admin.py
@@ -8,9 +8,9 @@ except ImportError:  # pragma: no cover - fallback for package execution
     from ..core.database import db
 
 try:
-    from core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User
+    from core.models import Funcao, User
 except ImportError:  # pragma: no cover - fallback for package execution
-    from ..core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User
+    from ..core.models import Funcao, User
 
 
 @dataclass
@@ -18,18 +18,6 @@ class BootstrapAdminResult:
     user: User
     created: bool
     generated_password: str | None
-
-
-def _get_or_create(model, defaults=None, **kwargs):
-    instance = model.query.filter_by(**kwargs).first()
-    if instance:
-        return instance
-    params = defaults or {}
-    params.update(kwargs)
-    instance = model(**params)
-    db.session.add(instance)
-    db.session.flush()
-    return instance
 
 
 def _generate_secure_password(length: int = 20) -> str:
@@ -73,29 +61,6 @@ def ensure_initial_admin(
         db.session.commit()
         return BootstrapAdminResult(user=existing_admin, created=False, generated_password=None)
 
-    instituicao = _get_or_create(
-        Instituicao,
-        codigo="BOOT001",
-        nome="Bootstrap Instituição",
-        defaults={"descricao": "Estrutura mínima para bootstrap do admin."},
-    )
-    estabelecimento = _get_or_create(
-        Estabelecimento,
-        codigo="BOOT-EST",
-        nome_fantasia="Bootstrap Estabelecimento",
-        defaults={"instituicao_id": instituicao.id},
-    )
-    setor = _get_or_create(
-        Setor,
-        nome="Bootstrap Setor",
-        defaults={"estabelecimento_id": estabelecimento.id},
-    )
-    celula = _get_or_create(
-        Celula,
-        nome="Bootstrap Célula",
-        defaults={"estabelecimento_id": estabelecimento.id, "setor_id": setor.id},
-    )
-
     generated_password = None
     password = initial_password
     if not password:
@@ -106,9 +71,6 @@ def ensure_initial_admin(
         username=username,
         email=email,
         nome_completo=nome_completo,
-        estabelecimento_id=estabelecimento.id,
-        setor_id=setor.id,
-        celula_id=celula.id,
         deve_trocar_senha=True,
     )
     admin.set_password(password)

--- a/tests/test_bootstrap_admin.py
+++ b/tests/test_bootstrap_admin.py
@@ -1,9 +1,9 @@
 try:
     from seeds.bootstrap_admin import ensure_initial_admin
-    from core.models import User
+    from core.models import User, Instituicao, Estabelecimento, Setor, Celula
 except ImportError:  # pragma: no cover - fallback for package execution
     from ..seeds.bootstrap_admin import ensure_initial_admin
-    from ..core.models import User
+    from ..core.models import User, Instituicao, Estabelecimento, Setor, Celula
 
 
 def test_bootstrap_admin_is_idempotent_and_requires_password_change(app_ctx):
@@ -15,6 +15,13 @@ def test_bootstrap_admin_is_idempotent_and_requires_password_change(app_ctx):
     assert first.created is True
     assert first.generated_password
     assert first.user.deve_trocar_senha is True
+    assert first.user.estabelecimento_id is None
+    assert first.user.setor_id is None
+    assert first.user.celula_id is None
+    assert Instituicao.query.count() == 0
+    assert Estabelecimento.query.count() == 0
+    assert Setor.query.count() == 0
+    assert Celula.query.count() == 0
 
     second = ensure_initial_admin(
         username='admin',
@@ -24,4 +31,7 @@ def test_bootstrap_admin_is_idempotent_and_requires_password_change(app_ctx):
     assert second.created is False
     assert second.generated_password is None
     assert second.user.deve_trocar_senha is True
+    assert second.user.estabelecimento_id is None
+    assert second.user.setor_id is None
+    assert second.user.celula_id is None
     assert User.query.filter_by(username='admin').count() == 1


### PR DESCRIPTION
### Motivation

- Permitir a criação do administrador inicial mesmo quando não existe estrutura organizacional disponível, evitando criar recursos artificiais durante bootstrap.
- Tornar os relacionamentos organizacionais de `User` flexíveis para acomodar usuários administrativos que não precisam de vínculo a `Estabelecimento`/`Setor`/`Célula`.

### Description

- Ajusta os campos do modelo `User` para `nullable=True` em `estabelecimento_id`, `setor_id` e `celula_id` no arquivo `core/models.py` (mantendo `cargo_id` inalterado). 
- Adiciona migration Alembic `migrations/versions/3c1d2e4f5a6b_make_user_org_links_nullable.py` que altera as colunas `user.estabelecimento_id`, `user.setor_id` e `user.celula_id` para aceitar `NULL` e provê o `downgrade` que restaura `nullable=False`.
- Remove a criação automática de `Instituicao`/`Estabelecimento`/`Setor`/`Celula` do bootstrap e passa a criar o admin inicial sem preencher esses FKs em `seeds/bootstrap_admin.py` (retira o uso de `_get_or_create`).
- Atualiza a validação de criação/edição em `blueprints/admin.py` para continuar exigindo vínculo organizacional para usuários não-admin, enquanto permite FKs nulos para usuários com a função `admin` (lógica que detecta seleção/remoção da função `admin`).
- Atualiza `tests/test_bootstrap_admin.py` para verificar que o admin inicial é criado com `estabelecimento_id`, `setor_id` e `celula_id` nulos e que nenhuma entidade organizacional foi criada.

### Testing

- Executei `pytest -q tests/test_bootstrap_admin.py tests/test_admin_usuarios.py` e ambos passaram sem falhas (`14 passed`, várias warnings relacionadas ao uso legado de `Query.get()`).
- Testes de integração cobriram criação idempotente do admin, marcação `deve_trocar_senha=True` e as validações administrativas para usuários normais.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90d57a4d0832e9a36fd4f09de6278)