### PR TITLE
docs: clarify flask bootstrap-admin behavior, BOOT* migration note, and production bootstrap guidance

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -26,13 +26,25 @@ Estes itens são os mesmos listados na seção de pré-requisitos do projeto【F
    source venv/bin/activate
    pip install -r requirements.txt
    ```
-3. **Aplique as migrações do banco**, execute o bootstrap do admin e (opcionalmente) rode os seeds:
+3. **Aplique as migrações do banco** e execute o bootstrap do admin:
    ```bash
    flask db upgrade
    flask bootstrap-admin
-   python -m seeds.seed  # opcional - inclui exemplo do processo de onboarding
    ```
    O comando `flask bootstrap-admin` é idempotente, não duplica o usuário admin e mantém `deve_trocar_senha=True` para forçar a troca imediata da senha inicial.
+   Quando já existir admin com mesmo `username` ou `email`, ele atualiza permissões/troca obrigatória sem recriar usuário.
+
+   **Antes x depois da mudança (`flask bootstrap-admin`):**
+   - **Antes:** a prática comum era usar `python -m seeds.seed` para preparar o ambiente, trazendo também dados de demonstração.
+   - **Depois:** o fluxo recomendado em produção é bootstrap mínimo e idempotente com `flask bootstrap-admin`.
+
+   **Recomendação operacional para produção (base limpa):**
+   - Use somente `flask db upgrade` + `flask bootstrap-admin`.
+   - Não execute `python -m seeds.seed` quando o objetivo for subir ambiente limpo sem dados de exemplo.
+
+   **Nota de migração para ambientes existentes (estrutura BOOT\*):**
+   - Ambientes que já possuem admin vinculado à estrutura `BOOT001` / `BOOT-EST` permanecem compatíveis.
+   - Se desejar descontinuar BOOT\*, reatribua admins para a estrutura organizacional definitiva e remova BOOT\* apenas após validar que não há vínculos remanescentes.
 
 ## 3. Configuração do `.env`
 Copie o arquivo `.env.example` para `.env` e defina os valores das variáveis `MAIL_PROVIDER`, `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_USE_TLS`, `MAIL_DEFAULT_SENDER`, `SECRET_KEY` e `DATABASE_URI`. Essas variáveis são obrigatórias para a aplicação【F:docs/GUIA_DE_INSTALACAO.md†L174-L188】【F:docs/GUIA_DE_INSTALACAO.md†L188-L230】. Um exemplo de `.env` pode ser visto abaixo:

--- a/docs/GUIA_DE_INSTALACAO.md
+++ b/docs/GUIA_DE_INSTALACAO.md
@@ -254,10 +254,15 @@ Use o comando oficial para criar (ou garantir) o administrador inicial:
 flask bootstrap-admin
 ```
 
-Comportamento do comando:
-- **Idempotente:** não cria usuário admin duplicado quando já existir.
+Comportamento do comando **depois da mudança**:
+- **Idempotente:** não cria usuário admin duplicado quando já existir (por `username` ou `email`).
 - **Senha inicial segura:** se `--password` não for enviada, uma senha temporária forte é gerada automaticamente e exibida no terminal.
 - **Troca obrigatória:** o usuário fica com `deve_trocar_senha=True` (equivalente a `must_change_password=True`).
+- **Atualização sem recriar:** se o admin já existir, o comando garante permissão administrativa e troca obrigatória, sem recriar usuário/estrutura.
+
+Comportamento **antes da mudança**:
+- Em muitos ambientes, a preparação inicial dependia principalmente de `python -m seeds.seed`.
+- Isso criava também dados de exemplo (incluindo estrutura organizacional e usuários de demonstração), em vez de focar no bootstrap mínimo do admin.
 
 Exemplo com senha definida manualmente:
 ```bash
@@ -270,11 +275,26 @@ flask bootstrap-admin --username admin --email admin@seudominio.com --password '
 > 3. O sistema redireciona para atualização de senha por `deve_trocar_senha=True`.
 > 4. Defina uma nova senha forte e exclusiva.
 
+> **Nota de migração para ambientes existentes (compatibilidade com BOOT\*):**
+> - Se o admin atual já estiver vinculado à estrutura `BOOT001` / `BOOT-EST` (e entidades derivadas), o ambiente continua compatível.
+> - Para migrar para a estrutura definitiva da empresa:
+>   1. Crie a nova estrutura organizacional.
+>   2. Reatribua os admins para `estabelecimento`, `setor` e `celula` finais.
+>   3. Garanta que a permissão/função `admin` permaneça no usuário.
+>   4. Remova a estrutura BOOT\* somente depois de validar ausência de vínculos.
+
 ## 13. (Opcional, mas Recomendado) Popular Dados de Exemplo
 Execute o script abaixo para criar funções, organização, usuários e artigos básicos:
 ```bash
 python -m seeds.seed
 ```
+
+> **Recomendação operacional (produção com base limpa):**
+> Quando o objetivo é subir um ambiente limpo, use apenas:
+> 1. `flask db upgrade`
+> 2. `flask bootstrap-admin`
+>
+> Nesse cenário, **não** execute `python -m seeds.seed`, pois ele insere dados de exemplo.
 
 ## 14. Rodar a Aplicação Flask
 Finalmente! Para rodar o servidor de desenvolvimento do Flask:

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,19 +95,38 @@ Consulte o passo a passo de instalação dessas dependências e a configuração
     ```bash
     flask bootstrap-admin
     ```
-    * O comando é **idempotente**: se o admin já existir, não cria duplicado.
-    * Se `--password` não for informada, uma senha temporária forte é gerada e exibida no terminal.
-    * O usuário é criado/atualizado com `deve_trocar_senha=True` (equivalente ao `must_change_password=True`), exigindo troca imediata no primeiro login.
+    * **Comportamento atual (depois da mudança):**
+      * O comando é **idempotente**: se o admin já existir (por `username` ou `email`), não cria duplicado.
+      * Se `--password` não for informada, uma senha temporária forte é gerada e exibida no terminal.
+      * O usuário é criado/atualizado com `deve_trocar_senha=True` (equivalente ao `must_change_password=True`), exigindo troca imediata no primeiro login.
+      * Quando o admin já existe, o comando apenas garante permissão administrativa e troca obrigatória de senha; **não recria** estrutura organizacional.
+    * **Comportamento anterior (antes da mudança):**
+      * A inicialização do ambiente era normalmente feita com `python -m seeds.seed`, que também popula dados de demonstração e outros usuários, além do admin.
+      * Em prática, a criação do admin ficava acoplada ao seed completo, em vez de um bootstrap mínimo e idempotente.
 
     Exemplo com credenciais explícitas:
     ```bash
     flask bootstrap-admin --username admin --email admin@seudominio.com --password 'TrocaImediata#2026'
     ```
 
+    > **Nota de migração (ambientes existentes com BOOT\*):**
+    > Se já existir admin vinculado à estrutura `BOOT001` / `BOOT-EST` (e seus Setor/Célula de bootstrap), **não é obrigatório migrar imediatamente**. O `flask bootstrap-admin` mantém compatibilidade e continuará funcionando.
+    >
+    > Quando quiser ajustar:
+    > 1. Crie/seleciona a estrutura organizacional definitiva.
+    > 2. Reatribua o admin para `estabelecimento`, `setor` e `celula` finais.
+    > 3. Mantenha a função/permissão administrativa (`admin`) no usuário.
+    > 4. Só remova a estrutura BOOT\* após confirmar que nenhum usuário depende dela.
+
 7.  **(Opcional) Popule dados de exemplo (funções, organização, usuários e artigos):**
     ```bash
     python -m seeds.seed
     ```
+    > **Recomendação operacional (produção/base limpa):**
+    > Para inicialização limpa, use **apenas**:
+    > 1) `flask db upgrade`  
+    > 2) `flask bootstrap-admin`  
+    > Evite `python -m seeds.seed` nesse cenário, pois ele insere dados de exemplo.
 
 8.  **Rode a aplicação Flask:**
     ```bash


### PR DESCRIPTION
### Motivation
- Clarify the exact behavior and intent of `flask bootstrap-admin` after a recent change, separate that from the full `seed` flow, and provide safe migration guidance for environments already using the BOOT* bootstrap structures.

### Description
- No skills used — the change is limited to documentation updates only because this is a docs-only change.
- Updated `docs/README.md`, `docs/DEPLOY.md` and `docs/GUIA_DE_INSTALACAO.md` to explicitly state the command behavior "before" and "after" the change, including idempotency and matching by `username`/`email` and that existing admin users are updated without recreating bootstrap structure.
- Added a migration note describing compatibility with existing `BOOT001` / `BOOT-EST` structures and recommended steps to reassign admins before removing BOOT* entities.
- Added a clear operational recommendation for production/clean installs to run only `flask db upgrade` followed by `flask bootstrap-admin` and to avoid `python -m seeds.seed` when the goal is a clean database.

### Testing
- Validated the changes by inspecting diffs and file previews with repository checks (`git diff`, `nl`, `sed`) to confirm the intended text was inserted into the three docs files.
- Confirmed the modified files are `docs/README.md`, `docs/DEPLOY.md`, and `docs/GUIA_DE_INSTALACAO.md` and that the new guidance is present in each.
- No unit or integration test suite was executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90d6a9100832eafc30a0e3ad54b3d)