### PR TITLE
Centraliza catálogo de permissões e adiciona sincronização idempotente

### DIFF
--- a/app.py
+++ b/app.py
@@ -105,6 +105,12 @@ try:
 except ImportError:  # pragma: no cover - fallback for direct execution
     from seeds.bootstrap_admin import ensure_initial_admin
 
+
+try:
+    from .core.services.permission_sync import sync_permission_catalog_with_lock
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from core.services.permission_sync import sync_permission_catalog_with_lock
+
 from mimetypes import guess_type # Se for usar, descomente
 from werkzeug.utils import secure_filename # Útil para uploads, como na sua foto de perfil
 
@@ -187,6 +193,65 @@ for folder in (UPLOAD_FOLDER, PROFILE_PICS_FOLDER):
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 app.config['PROFILE_PICS_FOLDER'] = PROFILE_PICS_FOLDER
 
+
+
+@app.cli.command("bootstrap-permissions")
+def bootstrap_permissions_command() -> None:
+    """Sincroniza o catálogo centralizado de permissões (idempotente)."""
+    result = sync_permission_catalog_with_lock(db.session)
+    db.session.commit()
+
+    if result is None:
+        click.echo("ℹ️ Sincronização de permissões ignorada (lock não adquirido).")
+        return
+
+    click.echo(
+        "✅ Catálogo de permissões sincronizado. "
+        f"created={result.created} updated={result.updated} unchanged={result.unchanged}"
+    )
+
+
+def _should_run_startup_bootstrap() -> bool:
+    if app.config.get('TESTING'):
+        return False
+
+    enabled = str(os.getenv('RUN_STARTUP_BOOTSTRAP', '1')).strip().lower()
+    if enabled in {'0', 'false', 'no'}:
+        return False
+
+    if app.debug:
+        return os.environ.get('WERKZEUG_RUN_MAIN') == 'true'
+    return True
+
+
+@app.before_request
+def _run_startup_permission_bootstrap_once() -> None:
+    if app.config.get('_permission_bootstrap_done'):
+        return
+    if not _should_run_startup_bootstrap():
+        app.config['_permission_bootstrap_done'] = True
+        return
+
+    result = sync_permission_catalog_with_lock(db.session)
+    db.session.commit()
+
+    if result is None:
+        app.logger.info(
+            'permission_catalog_sync_skipped',
+            extra={'event': 'permission_catalog_sync_skipped', 'reason': 'lock_not_acquired'},
+        )
+    else:
+        app.logger.info(
+            'permission_catalog_sync_completed',
+            extra={
+                'event': 'permission_catalog_sync_completed',
+                'created_count': result.created,
+                'updated_count': result.updated,
+                'unchanged_count': result.unchanged,
+            },
+        )
+
+    app.config['_permission_bootstrap_done'] = True
 
 @app.cli.command("bootstrap-admin")
 @click.option("--username", default="admin", show_default=True, help="Username do admin inicial.")

--- a/core/permission_catalog.py
+++ b/core/permission_catalog.py
@@ -1,0 +1,35 @@
+"""Catálogo centralizado de permissões da aplicação."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+try:
+    from .enums import Permissao
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from core.enums import Permissao
+
+
+@dataclass(frozen=True)
+class PermissionCatalogItem:
+    """Entrada do catálogo de permissões."""
+
+    codigo: str
+    nome: str
+
+
+CATALOG: tuple[PermissionCatalogItem, ...] = (
+    *(
+        PermissionCatalogItem(
+            codigo=permission.value,
+            nome=permission.value.replace("_", " ").capitalize(),
+        )
+        for permission in Permissao
+    ),
+    PermissionCatalogItem(codigo="admin", nome="Administrador"),
+    PermissionCatalogItem(codigo="artigo_criar", nome="Criar artigo"),
+    PermissionCatalogItem(codigo="artigo_revisar", nome="Revisar artigo"),
+    PermissionCatalogItem(codigo="artigo_assumir_revisao", nome="Assumir revisão"),
+)
+
+CATALOG_BY_CODE: dict[str, PermissionCatalogItem] = {item.codigo: item for item in CATALOG}

--- a/core/services/__init__.py
+++ b/core/services/__init__.py
@@ -1,0 +1,1 @@
+"""Serviços de domínio da aplicação."""

--- a/core/services/permission_sync.py
+++ b/core/services/permission_sync.py
@@ -1,0 +1,101 @@
+"""Sincronização idempotente do catálogo de permissões."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+try:
+    from ..models import Funcao
+    from ..permission_catalog import CATALOG
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from core.models import Funcao
+    from core.permission_catalog import CATALOG
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PermissionSyncResult:
+    created: int = 0
+    updated: int = 0
+    unchanged: int = 0
+
+
+def sync_permission_catalog(session: Session) -> PermissionSyncResult:
+    """Sincroniza permissões por ``codigo`` com upsert idempotente.
+
+    - Cria o registro quando ``codigo`` não existe.
+    - Atualiza somente campos gerenciados pelo catálogo (atualmente ``nome``).
+    - Não remove registros extras já existentes no banco.
+    """
+
+    created = 0
+    updated = 0
+    unchanged = 0
+
+    for item in CATALOG:
+        existing = session.query(Funcao).filter_by(codigo=item.codigo).one_or_none()
+
+        if existing is None:
+            session.add(Funcao(codigo=item.codigo, nome=item.nome))
+            created += 1
+            continue
+
+        if existing.nome != item.nome:
+            existing.nome = item.nome
+            updated += 1
+        else:
+            unchanged += 1
+
+    result = PermissionSyncResult(created=created, updated=updated, unchanged=unchanged)
+    logger.info(
+        "permission_catalog_sync",
+        extra={
+            "event": "permission_catalog_sync",
+            "created_count": result.created,
+            "updated_count": result.updated,
+            "unchanged_count": result.unchanged,
+            "catalog_size": len(CATALOG),
+        },
+    )
+    return result
+
+
+def sync_permission_catalog_with_lock(session: Session) -> PermissionSyncResult | None:
+    """Executa sincronização sob lock advisory quando disponível.
+
+    Retorna ``None`` quando não for possível obter lock (outra instância já está sincronizando).
+    """
+
+    bind = session.get_bind()
+    if bind is None:
+        return sync_permission_catalog(session)
+
+    dialect = bind.dialect.name
+    if dialect != "postgresql":
+        return sync_permission_catalog(session)
+
+    lock_key = 918273645
+    lock_acquired = session.execute(
+        text("SELECT pg_try_advisory_lock(:lock_key)"),
+        {"lock_key": lock_key},
+    ).scalar()
+
+    if not lock_acquired:
+        logger.info(
+            "permission_catalog_sync_skipped",
+            extra={"event": "permission_catalog_sync_skipped", "reason": "lock_not_acquired"},
+        )
+        return None
+
+    try:
+        return sync_permission_catalog(session)
+    finally:
+        session.execute(
+            text("SELECT pg_advisory_unlock(:lock_key)"),
+            {"lock_key": lock_key},
+        )

--- a/seeds/seed_funcoes.py
+++ b/seeds/seed_funcoes.py
@@ -8,33 +8,23 @@ try:
     from core.database import db  # pragma: no cover
 except ImportError:
     from ..core.database import db
-try:
-    from core.models import Funcao
-except ImportError:  # pragma: no cover - fallback for package execution
-    from ..core.models import Funcao
 from app import app
-try:
-    from core.enums import Permissao  # pragma: no cover
-except ImportError:  # pragma: no cover - fallback para execução em pacote
-    from ..core.enums import Permissao
 
-# Permissões que não fazem parte do Enum Permissao
-EXTRA_FUNCOES = [
-    ("admin", "Administrador"),
-    ("artigo_criar", "Criar artigo"),
-    ("artigo_revisar", "Revisar artigo"),
-    ("artigo_assumir_revisao", "Assumir revisão"),
-]
+try:
+    from core.services.permission_sync import sync_permission_catalog
+except ImportError:  # pragma: no cover - fallback para execução em pacote
+    from ..core.services.permission_sync import sync_permission_catalog
+
 
 def run():
-    funcoes = [(p.value, p.value.replace("_", " ").capitalize()) for p in Permissao]
-    funcoes.extend(EXTRA_FUNCOES)
     with app.app_context():
-        for codigo, nome in funcoes:
-            if not Funcao.query.filter_by(codigo=codigo).first():
-                db.session.add(Funcao(codigo=codigo, nome=nome))
+        result = sync_permission_catalog(db.session)
         db.session.commit()
-        print("Funções criadas/atualizadas.")
+        print(
+            "Funções criadas/atualizadas. "
+            f"created={result.created} updated={result.updated} unchanged={result.unchanged}"
+        )
+
 
 if __name__ == "__main__":
     run()

--- a/tests/test_permission_sync.py
+++ b/tests/test_permission_sync.py
@@ -1,0 +1,45 @@
+try:
+    from core.database import db
+    from core.models import Funcao
+    from core.permission_catalog import CATALOG
+    from core.services.permission_sync import sync_permission_catalog, sync_permission_catalog_with_lock
+except ImportError:  # pragma: no cover - fallback for package execution
+    from ..core.database import db
+    from ..core.models import Funcao
+    from ..core.permission_catalog import CATALOG
+    from ..core.services.permission_sync import sync_permission_catalog, sync_permission_catalog_with_lock
+
+
+def test_sync_permission_catalog_is_idempotent_and_updates_managed_fields(app_ctx):
+    result_first = sync_permission_catalog(db.session)
+    db.session.commit()
+
+    assert result_first.created == len(CATALOG)
+    assert result_first.updated == 0
+    assert result_first.unchanged == 0
+
+    item = CATALOG[0]
+    func = Funcao.query.filter_by(codigo=item.codigo).first()
+    assert func is not None
+
+    func.nome = "Nome divergente"
+    db.session.commit()
+
+    result_second = sync_permission_catalog(db.session)
+    db.session.commit()
+
+    assert result_second.created == 0
+    assert result_second.updated == 1
+    assert result_second.unchanged == len(CATALOG) - 1
+
+    updated = Funcao.query.filter_by(codigo=item.codigo).first()
+    assert updated is not None
+    assert updated.nome == item.nome
+
+
+def test_sync_permission_catalog_with_lock_falls_back_for_non_postgres(app_ctx):
+    result = sync_permission_catalog_with_lock(db.session)
+    db.session.commit()
+
+    assert result is not None
+    assert result.created == len(CATALOG)


### PR DESCRIPTION
### Motivation
- Garantir um catálogo único e estável de permissões com identificador técnico (`codigo`) e metadados (`nome`) para evitar duplicação e dispersão das definições.
- Fornecer um mecanismo idempotente e seguro para propagar/atualizar essas permissões no banco de dados durante bootstrap/deploy, evitando concorrência entre workers.

### Description
- Adiciona o catálogo central em `core/permission_catalog.py` com entradas `PermissionCatalogItem(codigo, nome)` reunindo permissões do `Permissao` e extras operacionais.`
- Implementa `sync_permission_catalog(session)` em `core/services/permission_sync.py` que faz upsert idempotente por `codigo`, criando registros ausentes e atualizando apenas campos gerenciados pelo catálogo (`nome`).
- Implementa `sync_permission_catalog_with_lock(session)` que tenta usar advisory lock PostgreSQL (`pg_try_advisory_lock`) e retorna `None` quando não obtém o lock para evitar execuções concorrentes; em dialetos não-Postgres cai de volta para a sincronização simples.
- Registra logs estruturados do resultado com campos não-colidentes (`created_count`, `updated_count`, `unchanged_count`, `catalog_size`) para auditoria operacional.
- Expõe comando CLI `bootstrap-permissions` e adiciona um hook de inicialização controlado em `app.py` que executa a sincronização uma única vez por processo, com opt-out via variável `RUN_STARTUP_BOOTSTRAP` e respeito a `app.config['TESTING']` para não rodar em testes.
- Atualiza `seeds/seed_funcoes.py` para reutilizar o serviço de sincronização em vez de duplicar a lista de permissões.
- Adiciona testes em `tests/test_permission_sync.py` cobrindo idempotência e fallback para ambientes não-Postgres.

### Testing
- Executado `pytest -q tests/test_permission_sync.py tests/test_bootstrap_admin.py` e todos os testes passaram: `3 passed`.
- Os testes cobrem a criação inicial (`created`), atualização somente de campos gerenciados (`updated`) e comportamento de fallback do lock em ambientes não-Postgres (`sync_permission_catalog_with_lock`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e915019898832e83ffe2d3de43147f)