### PR TITLE
Fortalece lifecycle e sincronização do catálogo de permissões

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -98,6 +98,7 @@ class Funcao(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     codigo = db.Column(db.String(100), unique=True, nullable=False)
     nome = db.Column(db.String(255), nullable=False)
+    managed_by_system = db.Column(db.Boolean, nullable=False, default=False, server_default='false')
 
     def __repr__(self):
         return f"<Funcao {self.codigo}>"

--- a/core/permission_catalog.py
+++ b/core/permission_catalog.py
@@ -33,3 +33,10 @@ CATALOG: tuple[PermissionCatalogItem, ...] = (
 )
 
 CATALOG_BY_CODE: dict[str, PermissionCatalogItem] = {item.codigo: item for item in CATALOG}
+
+# Migrações lógicas de código (de -> para) permitidas no sincronizador.
+CODE_ALIASES: dict[str, str] = {}
+
+# Códigos descontinuados do catálogo nativo que podem permanecer no banco
+# sem atualização automática até remoção por migração explícita.
+DEPRECATED_CODES: set[str] = set()

--- a/core/services/permission_sync.py
+++ b/core/services/permission_sync.py
@@ -10,10 +10,10 @@ from sqlalchemy.orm import Session
 
 try:
     from ..models import Funcao
-    from ..permission_catalog import CATALOG
+    from ..permission_catalog import CATALOG, CATALOG_BY_CODE, CODE_ALIASES, DEPRECATED_CODES
 except ImportError:  # pragma: no cover - fallback for direct execution
     from core.models import Funcao
-    from core.permission_catalog import CATALOG
+    from core.permission_catalog import CATALOG, CATALOG_BY_CODE, CODE_ALIASES, DEPRECATED_CODES
 
 logger = logging.getLogger(__name__)
 
@@ -29,24 +29,50 @@ def sync_permission_catalog(session: Session) -> PermissionSyncResult:
     """Sincroniza permissões por ``codigo`` com upsert idempotente.
 
     - Cria o registro quando ``codigo`` não existe.
+    - Atualiza somente registros gerenciados pelo sistema.
     - Atualiza somente campos gerenciados pelo catálogo (atualmente ``nome``).
     - Não remove registros extras já existentes no banco.
+    - Alterações de ``codigo`` só são aceitas via alias explícito em ``CODE_ALIASES``.
     """
+
+    _validate_catalog_rules()
 
     created = 0
     updated = 0
     unchanged = 0
 
+    _ensure_no_implicit_code_changes(session)
+
+    alias_to_canonical = CODE_ALIASES.copy()
+    aliases_by_canonical: dict[str, set[str]] = {}
+    for alias_code, canonical_code in alias_to_canonical.items():
+        aliases_by_canonical.setdefault(canonical_code, set()).add(alias_code)
+
     for item in CATALOG:
         existing = session.query(Funcao).filter_by(codigo=item.codigo).one_or_none()
 
         if existing is None:
-            session.add(Funcao(codigo=item.codigo, nome=item.nome))
+            existing = _resolve_alias_candidate(session, item.codigo, aliases_by_canonical.get(item.codigo, set()))
+
+        if existing is None:
+            session.add(Funcao(codigo=item.codigo, nome=item.nome, managed_by_system=True))
             created += 1
             continue
 
+        changed = False
+        if not existing.managed_by_system:
+            existing.managed_by_system = True
+            changed = True
+
+        if existing.codigo != item.codigo:
+            existing.codigo = item.codigo
+            changed = True
+
         if existing.nome != item.nome:
             existing.nome = item.nome
+            changed = True
+
+        if changed:
             updated += 1
         else:
             unchanged += 1
@@ -63,6 +89,42 @@ def sync_permission_catalog(session: Session) -> PermissionSyncResult:
         },
     )
     return result
+
+
+def _resolve_alias_candidate(session: Session, canonical_code: str, aliases: set[str]) -> Funcao | None:
+    if not aliases:
+        return None
+
+    for alias_code in aliases:
+        alias_row = session.query(Funcao).filter_by(codigo=alias_code, managed_by_system=True).one_or_none()
+        if alias_row is not None:
+            return alias_row
+
+    return None
+
+
+def _validate_catalog_rules() -> None:
+    for alias_code, canonical_code in CODE_ALIASES.items():
+        if canonical_code not in CATALOG_BY_CODE:
+            raise RuntimeError(
+                f"Alias '{alias_code}' aponta para código canônico inexistente '{canonical_code}'."
+            )
+
+
+def _ensure_no_implicit_code_changes(session: Session) -> None:
+    allowed_codes = set(CATALOG_BY_CODE) | set(CODE_ALIASES) | set(DEPRECATED_CODES)
+    unmanaged_customized = (
+        session.query(Funcao)
+        .filter(Funcao.managed_by_system.is_(True), Funcao.codigo.notin_(allowed_codes))
+        .all()
+    )
+
+    if unmanaged_customized:
+        invalid_codes = ", ".join(sorted(funcao.codigo for funcao in unmanaged_customized))
+        raise RuntimeError(
+            "Foram encontrados códigos gerenciados pelo sistema sem regra explícita de lifecycle "
+            f"(alias/deprecated): {invalid_codes}"
+        )
 
 
 def sync_permission_catalog_with_lock(session: Session) -> PermissionSyncResult | None:

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,26 @@ Orquetask é um sistema web integrado construído com Flask e Python. A base atu
 * **Temas Claro/Escuro e layout responsivo com sidebar.**
 * **Módulos em desenvolvimento:** Processos (modelos e telas administrativas já versionados, porém desativados por padrão) e Ordens de Serviço (modelos utilitários sem rotas ativas).
 
+## Catálogo de permissões: política de lifecycle
+
+O modelo `Funcao` possui o campo `managed_by_system` para separar permissões do
+catálogo nativo (`True`) de permissões customizadas (`False`).
+
+### Regras do sincronizador (`sync_permission_catalog`)
+
+* **Create/Update:** cria permissões canônicas ausentes e atualiza apenas
+  registros `managed_by_system=True`.
+* **Customizados preservados:** permissões `managed_by_system=False` não são
+  removidas nem alteradas pela sincronização.
+* **Renomeação de código:** só pode ocorrer via `CODE_ALIASES` (de/para)
+  definido em `core/permission_catalog.py`, preservando relacionamentos em
+  `cargo_funcoes` e `user_funcoes`.
+* **Bloqueio de mudança implícita de `codigo`:** se existir código gerenciado
+  pelo sistema fora das listas canônica, alias ou deprecated, a sincronização
+  falha com erro explícito.
+* **Deprecated:** códigos descontinuados devem ser listados em
+  `DEPRECATED_CODES` até a remoção por migração dedicada.
+
 ## Tecnologias Utilizadas
 
 * **Backend:** Python 3, Flask

--- a/migrations/versions/4d5e6f7a8b9c_add_managed_flag_to_funcao.py
+++ b/migrations/versions/4d5e6f7a8b9c_add_managed_flag_to_funcao.py
@@ -1,0 +1,27 @@
+"""add managed flag to funcao
+
+Revision ID: 4d5e6f7a8b9c
+Revises: 3c1d2e4f5a6b
+Create Date: 2026-04-22 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '4d5e6f7a8b9c'
+down_revision = '3c1d2e4f5a6b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'funcao',
+        sa.Column('managed_by_system', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+    )
+
+
+def downgrade():
+    op.drop_column('funcao', 'managed_by_system')

--- a/tests/test_permission_sync.py
+++ b/tests/test_permission_sync.py
@@ -2,11 +2,13 @@ try:
     from core.database import db
     from core.models import Funcao
     from core.permission_catalog import CATALOG
+    from core import permission_catalog
     from core.services.permission_sync import sync_permission_catalog, sync_permission_catalog_with_lock
 except ImportError:  # pragma: no cover - fallback for package execution
     from ..core.database import db
     from ..core.models import Funcao
     from ..core.permission_catalog import CATALOG
+    from ..core import permission_catalog
     from ..core.services.permission_sync import sync_permission_catalog, sync_permission_catalog_with_lock
 
 
@@ -35,6 +37,7 @@ def test_sync_permission_catalog_is_idempotent_and_updates_managed_fields(app_ct
     updated = Funcao.query.filter_by(codigo=item.codigo).first()
     assert updated is not None
     assert updated.nome == item.nome
+    assert updated.managed_by_system is True
 
 
 def test_sync_permission_catalog_with_lock_falls_back_for_non_postgres(app_ctx):
@@ -43,3 +46,51 @@ def test_sync_permission_catalog_with_lock_falls_back_for_non_postgres(app_ctx):
 
     assert result is not None
     assert result.created == len(CATALOG)
+
+
+def test_sync_permission_catalog_does_not_change_custom_permissions(app_ctx):
+    custom = Funcao(codigo="custom_exportar", nome="Exportar customizado", managed_by_system=False)
+    db.session.add(custom)
+    db.session.commit()
+
+    result = sync_permission_catalog(db.session)
+    db.session.commit()
+
+    assert result.created == len(CATALOG)
+
+    preserved = Funcao.query.filter_by(codigo="custom_exportar").one()
+    assert preserved.nome == "Exportar customizado"
+    assert preserved.managed_by_system is False
+
+
+def test_sync_permission_catalog_raises_for_implicit_code_changes(app_ctx):
+    orphan_managed = Funcao(codigo="codigo_antigo_sem_regra", nome="Legado", managed_by_system=True)
+    db.session.add(orphan_managed)
+    db.session.commit()
+
+    try:
+        sync_permission_catalog(db.session)
+    except RuntimeError as exc:
+        assert "sem regra explícita" in str(exc)
+    else:
+        raise AssertionError("Era esperado erro para código gerenciado sem alias/deprecated")
+
+
+def test_sync_permission_catalog_applies_alias_renaming(app_ctx):
+    item = CATALOG[0]
+    alias_code = f"legacy_{item.codigo}"
+    permission_catalog.CODE_ALIASES[alias_code] = item.codigo
+
+    try:
+        db.session.add(Funcao(codigo=alias_code, nome="Nome legado", managed_by_system=True))
+        db.session.commit()
+
+        result = sync_permission_catalog(db.session)
+        db.session.commit()
+
+        assert result.updated >= 1
+        migrated = Funcao.query.filter_by(codigo=item.codigo).one_or_none()
+        assert migrated is not None
+        assert migrated.nome == item.nome
+    finally:
+        permission_catalog.CODE_ALIASES.pop(alias_code, None)


### PR DESCRIPTION
### Motivation

- Evitar que a sincronização do catálogo sobrescreva ou remova permissões customizadas introduzidas no banco.
- Fornecer uma estratégia controlada para renomeação de `codigo` (alias de-para) sem quebrar relações em `cargo_funcoes` e `user_funcoes`.
- Bloquear mudanças implícitas de `codigo` no catálogo para forçar migrações ou regras explícitas de lifecycle.

### Description

- Adicionado o campo `managed_by_system` ao modelo `Funcao` e criada migração Alembic (`migrations/versions/4d5e6f7a8b9c_add_managed_flag_to_funcao.py`) para separar permissões nativas vs customizadas.
- Introduzidos `CODE_ALIASES` e `DEPRECATED_CODES` em `core/permission_catalog.py` para declarar renomeações permitidas e códigos descontinuados.
- Reescrito o sincronizador em `core/services/permission_sync.py` para validar regras de catálogo, aplicar aliases (reaproveitando linhas existentes), marcar novos itens com `managed_by_system=True`, preservar permissões customizadas (`managed_by_system=False`) e falhar caso existam códigos gerenciados sem regra explícita de lifecycle.
- Atualizados/expandidos testes em `tests/test_permission_sync.py` para cobrir preservação de customizados, erro em mudança implícita de `codigo` e aplicação de alias; adicionada documentação da política de lifecycle em `docs/README.md`.

### Testing

- Executado `pytest -q tests/test_permission_sync.py tests/test_migrations.py` e todos os testes passaram (`6 passed in 0.32s`).
- Novos e existentes testes de sincronização e migrações foram validados localmente com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91abc14a0832e863ed8396a3ec44d)