### PR TITLE
Melhora validação do cadastro de usuários e mantém tela em erros

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -396,6 +396,7 @@ def admin_toggle_ativo_estabelecimento(id):
 def admin_usuarios():
     """Lista, cria e edita usuários."""
     usuario_para_editar = None
+    manter_aba_cadastro = False
     if request.method == 'GET':
         edit_id = request.args.get('edit_id', type=int)
         if edit_id:
@@ -403,6 +404,7 @@ def admin_usuarios():
             app.logger.debug(f"Loading user {edit_id} for editing")
 
     if request.method == 'POST':
+        manter_aba_cadastro = True
         app.logger.debug(f"Received POST /admin/usuarios with data: {request.form}")
         id_para_atualizar = request.form.get('id_para_atualizar')
         username = request.form.get('username', '').strip()
@@ -475,14 +477,19 @@ def admin_usuarios():
         else:
             query_username = User.query.filter_by(username=username)
             query_email = User.query.filter_by(email=email)
+            query_cpf = User.query.filter_by(cpf=cpf) if cpf else None
             if id_para_atualizar:
                 query_username = query_username.filter(User.id != int(id_para_atualizar))
                 query_email = query_email.filter(User.id != int(id_para_atualizar))
+                if query_cpf is not None:
+                    query_cpf = query_cpf.filter(User.id != int(id_para_atualizar))
 
             if query_username.first():
                 flash(f'O nome de usuário "{username}" já está em uso.', 'danger')
             elif query_email.first():
                 flash(f'O email "{email}" já está em uso.', 'danger')
+            elif query_cpf is not None and query_cpf.first():
+                flash(f'O CPF "{cpf}" já está em uso.', 'danger')
             else:
                 if id_para_atualizar:
                     usr = User.query.get_or_404(id_para_atualizar)
@@ -564,6 +571,7 @@ def admin_usuarios():
                     flash('Ocorreu um erro ao salvar o usuário. Tente novamente em instantes.', 'danger')
                     app.logger.error(f"Erro DB User: {e}")
                 else:
+                    manter_aba_cadastro = False
                     if not id_para_atualizar:
                         origem_senha = 'informada pelo administrador' if not senha_gerada else 'gerada automaticamente'
                         flash(
@@ -603,6 +611,7 @@ def admin_usuarios():
         celulas=celulas,
         funcoes=funcoes,
         cargo_defaults=json.dumps(cargo_defaults),
+        manter_aba_cadastro=manter_aba_cadastro,
     )
 
 @admin_bp.route('/admin/usuarios/toggle_ativo/<int:id>', methods=['POST'])

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -683,3 +683,24 @@ body > .container {
 .os-card.prioridade-alta {
   border-left-color: var(--bs-danger);
 }
+
+.required-hint {
+  font-size: 0.85rem;
+}
+
+.required-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background-color: var(--bs-danger);
+  margin-right: 4px;
+}
+
+.required-field {
+  border-left: 3px solid rgba(var(--bs-danger-rgb), 0.5);
+}
+
+.required-field:focus {
+  border-left-color: var(--bs-danger);
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -307,8 +307,56 @@ document.addEventListener("DOMContentLoaded", function () {
     applyCargoDefaults('edit_', e.target.value);
   });
 
+  const selectedCargoCreate = document.getElementById('cargo_id')?.value;
+  if (selectedCargoCreate) {
+    applyCargoDefaults('', selectedCargoCreate);
+  }
+  const selectedCargoEdit = document.getElementById('edit_cargo_id')?.value;
+  if (selectedCargoEdit) {
+    applyCargoDefaults('edit_', selectedCargoEdit);
+  }
+
   // Expose helper for inline scripts
   window.setCargoFuncoesDisabled = setCargoFuncoesDisabled;
+
+  if (window.manterAbaCadastro) {
+    const cadastroTabBtn = document.getElementById('cadastro-tab');
+    if (cadastroTabBtn) {
+      bootstrap.Tab.getOrCreateInstance(cadastroTabBtn).show();
+    }
+  }
+
+  function hasCheckedInput(selector) {
+    return document.querySelectorAll(selector).length > 0;
+  }
+
+  function validateCreateUserForm() {
+    const form = document.getElementById('create-user-form');
+    const submitBtn = document.getElementById('submit-create-user');
+    if (!form || !submitBtn) return;
+
+    const username = document.getElementById('username');
+    const email = document.getElementById('email');
+    const cargo = document.getElementById('cargo_id');
+    const isValid = Boolean(
+      username?.value.trim()
+      && email?.value.trim()
+      && cargo?.value
+      && hasCheckedInput("input[name='estabelecimento_id']:checked")
+      && hasCheckedInput("input[name='setor_ids']:checked")
+      && hasCheckedInput("input[name='celula_ids']:checked")
+    );
+
+    submitBtn.disabled = !isValid;
+    submitBtn.classList.toggle('disabled', !isValid);
+  }
+
+  const createUserForm = document.getElementById('create-user-form');
+  if (createUserForm) {
+    createUserForm.addEventListener('input', validateCreateUserForm);
+    createUserForm.addEventListener('change', validateCreateUserForm);
+    validateCreateUserForm();
+  }
 
   // Mostra o campo de especificar apenas quando a opção "Outra" estiver selecionada
   document.querySelectorAll('select[data-outra-select]').forEach((select) => {

--- a/templates/admin/usuarios.html
+++ b/templates/admin/usuarios.html
@@ -84,19 +84,22 @@
                     <h5 class="mb-3">
                         <i class="bi bi-plus-circle-fill me-2"></i>Adicionar Novo Usuário
                     </h5>
+                    <p class="mb-2 text-muted required-hint">
+                        <span class="required-dot"></span> Campos com <span class="text-danger">*</span> são obrigatórios.
+                    </p>
 
-                    <form method="POST" action="{{ url_for('admin_usuarios') }}" novalidate class="compact-form">
+                    <form method="POST" action="{{ url_for('admin_usuarios') }}" novalidate class="compact-form" id="create-user-form">
                         <div class="card mb-3">
                             <div class="card-header"><h6 class="mb-0">Dados Cadastrais</h6></div>
                             <div class="card-body">
                                 <div class="row">
                                     <div class="col-md-4 mb-1">
                                         <label for="username" class="form-label">Usuário <span class="text-danger">*</span></label>
-                                        <input type="text" class="form-control form-control-sm" id="username" name="username" value="{{ request.form.get('username', '') }}" required maxlength="80">
+                                        <input type="text" class="form-control form-control-sm required-field" id="username" name="username" value="{{ request.form.get('username', '') }}" required maxlength="80">
                                     </div>
                                     <div class="col-md-4 mb-1">
                                         <label for="email" class="form-label">Email <span class="text-danger">*</span></label>
-                                        <input type="email" class="form-control form-control-sm" id="email" name="email" value="{{ request.form.get('email', '') }}" required maxlength="120">
+                                        <input type="email" class="form-control form-control-sm required-field" id="email" name="email" value="{{ request.form.get('email', '') }}" required maxlength="120">
                                     </div>
                                 </div>
                                 <div class="row">
@@ -151,14 +154,15 @@
                             <div class="card-header"><h6 class="mb-0">Hierarquia</h6></div>
                             <div class="card-body">
                                 <div class="mb-2">
-                                    <label for="cargo_id" class="form-label">Cargo</label>
-                                    <select class="form-select form-select-sm" id="cargo_id" name="cargo_id">
+                                    <label for="cargo_id" class="form-label">Cargo <span class="text-danger">*</span></label>
+                                    <select class="form-select form-select-sm required-field" id="cargo_id" name="cargo_id" required>
                                         <option value="">Selecione</option>
                                         {% for cg in cargos %}
                                             <option value="{{ cg.id }}" {% if request.form.get('cargo_id') == cg.id|string %}selected{% endif %}>{{ cg.nome }}</option>
                                         {% endfor %}
                                     </select>
                                 </div>
+                                <p class="small text-muted mb-2">Selecione ao menos um estabelecimento, setor e célula para habilitar o cadastro.</p>
                                 {% for est in estabelecimentos %}
                                     <div class="form-check">
                                         <input class="form-check-input estab-checkbox" type="checkbox" id="est{{ est.id }}" name="estabelecimento_id" value="{{ est.id }}" {% if request.form.get('estabelecimento_id') == est.id|string %}checked{% endif %}>
@@ -212,7 +216,7 @@
                             </div>
                         </div>
                         <div class="d-flex pt-2 border-top">
-                            <button type="submit" class="btn btn-primary">
+                            <button type="submit" class="btn btn-primary" id="submit-create-user">
                                 <i class="bi bi-check-lg me-1"></i> Adicionar Usuário
                             </button>
                         </div>
@@ -374,6 +378,7 @@
 {% block extra_js %}
 <script>
 window.cargoDefaults = {{ cargo_defaults|safe }};
+window.manterAbaCadastro = {{ 'true' if manter_aba_cadastro else 'false' }};
 </script>
 {% if user_editar %}
 <script>

--- a/tests/test_admin_usuarios.py
+++ b/tests/test_admin_usuarios.py
@@ -276,6 +276,24 @@ def test_create_user_with_custom_permissions(client):
         assert {f.id for f in u.permissoes_personalizadas} == {f2_id}
 
 
+def test_create_user_missing_email_keeps_cadastro_tab(client):
+    login_admin(client)
+    ids = client.base_ids
+    response = client.post('/admin/usuarios', data={
+        'username': 'sememail',
+        'email': '',
+        'ativo_check': 'on',
+        'estabelecimento_id': ids['est'],
+        'setor_ids': [str(ids['setor'])],
+        'celula_ids': [str(ids['cel'])]
+    }, follow_redirects=True)
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert 'Usuário e Email são obrigatórios.' in html
+    assert 'window.manterAbaCadastro = true;' in html
+
+
 def test_edit_user_updates_relations(client):
     login_admin(client)
     ids = client.base_ids


### PR DESCRIPTION
### Motivation
- Evitar que o usuário seja redirecionado para a aba de consulta quando há erro ao criar/editar usuário e garantir mensagens de erro claras e permanência na tela de cadastro.
- Corrigir o comportamento onde as permissões herdadas do `Cargo` não eram reaplicadas ao recarregar a página com um cargo já selecionado.
- Melhorar a UX visual e prevenir submissões inválidas do formulário de cadastro de usuário por falta de campos essenciais.

### Description
- Adiciona a flag `manter_aba_cadastro` em `admin_usuarios` e a envia ao template para manter a aba de cadastro ativa após falhas no `POST` (`blueprints/admin.py`).
- Reaplica defaults de `Cargo` ao carregar a página ao ler o valor inicial dos selects (`static/js/main.js`) e expõe `window.manterAbaCadastro` para ativar a aba de cadastro via JS.
- Implementa validação cliente que habilita o botão `Adicionar Usuário` somente quando `username`, `email`, `cargo` e pelo menos um `estabelecimento`, `setor` e `célula` estiverem selecionados (`static/js/main.js`, `templates/admin/usuarios.html`).
- Destaca visualmente campos obrigatórios com classes CSS (`static/css/custom.css`) e marca inputs obrigatórios no template (`templates/admin/usuarios.html`).
- Adiciona checagem de CPF duplicado no backend para retornar mensagem amigável antes do `commit` (`blueprints/admin.py`).
- Atualiza template `templates/admin/usuarios.html` para incluir marcação dos campos obrigatórios, `id` no formulário e exportar a flag JS; e adiciona/ajusta testes em `tests/test_admin_usuarios.py` para cobrir o comportamento de manter a aba de cadastro.

### Testing
- Executado `pytest -q tests/test_admin_usuarios.py` que retornou todos os testes passando (`14 passed`).
- Os testes verificam criação, validação, mensagens de erro amigáveis, reaplicação de defaults de `cargo`, comportamento de atualização de permissões e a preservação da aba de cadastro quando há erro.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e920397fd0832ea45fe652377306b9)