### PR TITLE
Corrige validação do cadastro de usuários e exibição de célula

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -601,6 +601,7 @@ def admin_usuarios():
         }
         for c in cargos
     }
+    admin_funcao = Funcao.query.filter_by(codigo='admin').first()
     return render_template(
         'admin/usuarios.html',
         usuarios=usuarios,
@@ -611,6 +612,7 @@ def admin_usuarios():
         celulas=celulas,
         funcoes=funcoes,
         cargo_defaults=json.dumps(cargo_defaults),
+        admin_funcao_id=admin_funcao.id if admin_funcao else None,
         manter_aba_cadastro=manter_aba_cadastro,
     )
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -338,13 +338,32 @@ document.addEventListener("DOMContentLoaded", function () {
     const username = document.getElementById('username');
     const email = document.getElementById('email');
     const cargo = document.getElementById('cargo_id');
+
+    const selectedCargoId = cargo?.value || null;
+    const cargoAdminFuncoes = selectedCargoId && cargoDefaults[selectedCargoId]
+      ? cargoDefaults[selectedCargoId].funcoes || []
+      : [];
+    const adminFuncaoId = Number(window.adminFuncaoId);
+    const hasAdminByCargo = Number.isInteger(adminFuncaoId)
+      ? cargoAdminFuncoes.includes(adminFuncaoId)
+      : false;
+    const hasAdminMarcadoManual = Number.isInteger(adminFuncaoId)
+      ? Array.from(document.querySelectorAll("input[name='funcao_ids']:checked"))
+          .some((input) => Number(input.value) === adminFuncaoId)
+      : false;
+
+    const exigeHierarquia = !(hasAdminByCargo || hasAdminMarcadoManual);
+    const hierarchyOk = !exigeHierarquia || (
+      hasCheckedInput("input[name='estabelecimento_id']:checked")
+      && hasCheckedInput("input[name='setor_ids']:checked")
+      && hasCheckedInput("input[name='celula_ids']:checked")
+    );
+
     const isValid = Boolean(
       username?.value.trim()
       && email?.value.trim()
       && cargo?.value
-      && hasCheckedInput("input[name='estabelecimento_id']:checked")
-      && hasCheckedInput("input[name='setor_ids']:checked")
-      && hasCheckedInput("input[name='celula_ids']:checked")
+      && hierarchyOk
     );
 
     submitBtn.disabled = !isValid;

--- a/templates/admin/celulas.html
+++ b/templates/admin/celulas.html
@@ -43,8 +43,8 @@
                                             {% for cel in celulas %}
                                             <tr class="{{ 'table-light text-muted' if not cel.ativo else '' }} clickable-row" data-href="{{ url_for('admin_celulas', edit_id=cel.id) }}">
                                                 <td>{{ cel.nome }}</td>
-                                                <td>{{ cel.estabelecimento.nome_fantasia }}</td>
                                                 <td>{{ cel.estabelecimento.instituicao.nome }}</td>
+                                                <td>{{ cel.estabelecimento.nome_fantasia }}</td>
                                                 <td>{{ cel.setor.nome if cel.setor else '--' }}</td>
                                                 <td>
                                                     {% if cel.ativo %}

--- a/templates/admin/usuarios.html
+++ b/templates/admin/usuarios.html
@@ -378,6 +378,7 @@
 {% block extra_js %}
 <script>
 window.cargoDefaults = {{ cargo_defaults|safe }};
+window.adminFuncaoId = {{ admin_funcao_id if admin_funcao_id else 'null' }};
 window.manterAbaCadastro = {{ 'true' if manter_aba_cadastro else 'false' }};
 </script>
 {% if user_editar %}


### PR DESCRIPTION
### Motivation
- Corrigir bloqueio indevido do botão “Adicionar Usuário” no front-end após alterações nas regras de funções, garantindo que a validação cliente reflita as mesmas exceções do servidor para usuários com permissão de admin.
- Corrigir a exibição trocada de instituição/estabelecimento na lista de Células, que passou a mostrar as colunas invertidas.

### Description
- Ajustei a validação em `static/js/main.js` para que a exigência de estabelecer Estabelecimento/Setor/Célula seja desabilitada quando o usuário alvo tiver permissão de `admin` (por cargo ou por função marcada manualmente) e para usar `window.adminFuncaoId` ao decidir essa exceção.
- Passei a expor `admin_funcao_id` no render do template em `blueprints/admin.py` para que o JavaScript saiba qual `Funcao` representa o admin.
- Atualizei `templates/admin/usuarios.html` para definir `window.adminFuncaoId` no `extra_js` e manter compatibilidade com a nova validação.
- Corrigi a ordem das colunas em `templates/admin/celulas.html` para que a coluna Instituição mostre a instituição e a coluna Estabelecimento mostre o estabelecimento.

### Testing
- Executei `pytest -q tests/test_admin_usuarios.py tests/test_celula.py` e todos os testes passaram (`17 passed`) com avisos de compatibilidade do SQLAlchemy (warnings, não falhas).
- Os testes automatizados relevantes para criação/edição de usuário e para a listagem/atualização de célula passaram, confirmando os comportamentos ajustados na UI e no backend.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92907dcac832eb5d3a0b6b5ffc40d)