### PR TITLE
Add structured logging to /admin/usuarios and homologation logger tuning

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import json
 import time
 import uuid
 import re # Você já tinha, bom para futuras validações
+import sys
 from datetime import datetime, timezone # Adicionei datetime aqui se for usar em 'strptime' na rota de perfil
 from zoneinfo import ZoneInfo # Você já tinha
 
@@ -137,9 +138,38 @@ NOME_NIVEL_CARGO = {valor: nome for valor, nome in NIVEIS_HIERARQUICOS}
 # Configuração da Aplicação (Seu código existente)
 # -------------------------------------------------------------------------
 app = Flask(__name__)
-logging.basicConfig(level=logging.DEBUG)
-app.logger.setLevel(logging.DEBUG)
 app.config.from_object(Config)
+
+
+def _is_homologacao_environment() -> bool:
+    env_name = (
+        os.getenv('APP_ENV')
+        or os.getenv('FLASK_ENV')
+        or os.getenv('ENVIRONMENT')
+        or 'production'
+    ).strip().lower()
+    return env_name in {'homologacao', 'homolog', 'staging', 'development'}
+
+
+if _is_homologacao_environment():
+    log_level = logging.DEBUG
+    logging.basicConfig(
+        level=log_level,
+        stream=sys.stdout,
+        format='%(asctime)s %(name)s %(levelname)s %(message)s',
+    )
+    app.config['SQLALCHEMY_ECHO'] = os.getenv('SQLALCHEMY_ECHO', 'true').lower() == 'true'
+else:
+    log_level = logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        stream=sys.stdout,
+        format='%(asctime)s %(name)s %(levelname)s %(message)s',
+    )
+    app.config.setdefault('SQLALCHEMY_ECHO', os.getenv('SQLALCHEMY_ECHO', 'false').lower() == 'true')
+
+app.logger.setLevel(log_level)
+logging.getLogger('sqlalchemy.engine').setLevel(logging.DEBUG if _is_homologacao_environment() else logging.WARNING)
 
 app.secret_key = app.config['SECRET_KEY']
 app.logger.info(
@@ -414,4 +444,3 @@ def inject_zoneinfo():
 def inject_niveis_cargo():
     """Disponibiliza o mapeamento de níveis hierárquicos para todos os templates."""
     return dict(NOME_NIVEL_CARGO=NOME_NIVEL_CARGO, NIVEIS_HIERARQUICOS=NIVEIS_HIERARQUICOS)
-

--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -93,6 +93,16 @@ def _current_user():
     uid = session.get('user_id')
     return User.query.get(uid) if uid else None
 
+
+def _request_correlation_id():
+    return (
+        request.headers.get('X-Request-ID')
+        or request.headers.get('X-Correlation-ID')
+        or request.headers.get('X-Amzn-Trace-Id')
+        or request.environ.get('HTTP_X_REQUEST_ID')
+        or request.environ.get('HTTP_X_CORRELATION_ID')
+    )
+
 # ROTAS DE ADMINISTRAÇÃO (NOVA SEÇÃO - ADICIONE AS ROTAS DO ADMIN AQUI)
 # -------------------------------------------------------------------------
 @admin_bp.route('/admin/')
@@ -405,7 +415,27 @@ def admin_usuarios():
 
     if request.method == 'POST':
         manter_aba_cadastro = True
-        app.logger.debug(f"Received POST /admin/usuarios with data: {request.form}")
+        timestamp_utc = datetime.now(timezone.utc).isoformat()
+        correlation_id = _request_correlation_id()
+        actor = _current_user()
+        actor_id = getattr(actor, 'id', None) if actor else session.get('user_id')
+        actor_username = getattr(actor, 'username', None) if actor else None
+        sanitized_form = request.form.to_dict(flat=False)
+        if 'password' in sanitized_form:
+            sanitized_form['password'] = ['***REDACTED***']
+        app.logger.info(
+            "admin_usuarios_post_received",
+            extra={
+                'event': 'admin_usuarios_post_received',
+                'request_method': request.method,
+                'request_path': request.path,
+                'request_form': sanitized_form,
+                'actor_id': actor_id,
+                'actor_username': actor_username,
+                'timestamp_utc': timestamp_utc,
+                'correlation_id': correlation_id,
+            },
+        )
         id_para_atualizar = request.form.get('id_para_atualizar')
         username = request.form.get('username', '').strip()
         email = request.form.get('email', '').strip()
@@ -470,9 +500,54 @@ def admin_usuarios():
             if not removendo_admin:
                 is_target_admin = possui_admin_atual
 
+        app.logger.info(
+            "admin_usuarios_parsed_payload",
+            extra={
+                'event': 'admin_usuarios_parsed_payload',
+                'username': username,
+                'email': email,
+                'ativo': ativo,
+                'estabelecimento_id': estabelecimento_id,
+                'setor_ids': setor_ids,
+                'celula_ids': celula_ids,
+                'cargo_id': cargo_id,
+                'funcao_ids': funcao_ids,
+                'id_para_atualizar': id_para_atualizar,
+                'is_target_admin': is_target_admin,
+                'correlation_id': correlation_id,
+            },
+        )
+
         if not username or not email:
+            app.logger.warning(
+                "admin_usuarios_validation_failed_missing_username_or_email",
+                extra={
+                    'event': 'admin_usuarios_validation_failed',
+                    'reason': 'missing_username_or_email',
+                    'username': username,
+                    'email': email,
+                    'correlation_id': correlation_id,
+                },
+            )
             flash('Usuário e Email são obrigatórios.', 'danger')
         elif not is_target_admin and (not estabelecimento_id or not setor_ids or not celula_ids):
+            missing_fields = []
+            if not estabelecimento_id:
+                missing_fields.append('estabelecimento_id')
+            if not setor_ids:
+                missing_fields.append('setor_ids')
+            if not celula_ids:
+                missing_fields.append('celula_ids')
+            app.logger.warning(
+                "admin_usuarios_validation_failed_missing_required_org_fields",
+                extra={
+                    'event': 'admin_usuarios_validation_failed',
+                    'reason': 'missing_required_org_fields',
+                    'missing_fields': missing_fields,
+                    'is_target_admin': is_target_admin,
+                    'correlation_id': correlation_id,
+                },
+            )
             flash('Usuário, Email, Estabelecimento, Setor e Célula são obrigatórios.', 'danger')
         else:
             query_username = User.query.filter_by(username=username)
@@ -485,10 +560,37 @@ def admin_usuarios():
                     query_cpf = query_cpf.filter(User.id != int(id_para_atualizar))
 
             if query_username.first():
+                app.logger.warning(
+                    "admin_usuarios_validation_failed_duplicate_username",
+                    extra={
+                        'event': 'admin_usuarios_validation_failed',
+                        'reason': 'duplicate_username',
+                        'username': username,
+                        'correlation_id': correlation_id,
+                    },
+                )
                 flash(f'O nome de usuário "{username}" já está em uso.', 'danger')
             elif query_email.first():
+                app.logger.warning(
+                    "admin_usuarios_validation_failed_duplicate_email",
+                    extra={
+                        'event': 'admin_usuarios_validation_failed',
+                        'reason': 'duplicate_email',
+                        'email': email,
+                        'correlation_id': correlation_id,
+                    },
+                )
                 flash(f'O email "{email}" já está em uso.', 'danger')
             elif query_cpf is not None and query_cpf.first():
+                app.logger.warning(
+                    "admin_usuarios_validation_failed_duplicate_cpf",
+                    extra={
+                        'event': 'admin_usuarios_validation_failed',
+                        'reason': 'duplicate_cpf',
+                        'cpf': cpf,
+                        'correlation_id': correlation_id,
+                    },
+                )
                 flash(f'O CPF "{cpf}" já está em uso.', 'danger')
             else:
                 if id_para_atualizar:
@@ -560,16 +662,57 @@ def admin_usuarios():
                     action_msg = 'criado'
 
                 try:
+                    app.logger.info(
+                        "Tentando commit de usuário",
+                        extra={
+                            'event': 'admin_usuarios_commit_attempt',
+                            'action': action_msg,
+                            'user_id': getattr(usr, 'id', None),
+                            'username': usr.username,
+                            'email': usr.email,
+                            'is_update': bool(id_para_atualizar),
+                            'correlation_id': correlation_id,
+                        },
+                    )
                     db.session.commit()
-                    app.logger.info(f"Usuario {action_msg}: id={usr.id}")
+                    app.logger.info(
+                        "admin_usuarios_commit_success",
+                        extra={
+                            'event': 'admin_usuarios_commit_success',
+                            'action': action_msg,
+                            'user_id': usr.id,
+                            'username': usr.username,
+                            'correlation_id': correlation_id,
+                        },
+                    )
                 except IntegrityError as e:
                     db.session.rollback()
                     flash('Não foi possível salvar o usuário. Verifique os dados informados e tente novamente.', 'danger')
-                    app.logger.error(f"Erro de integridade ao salvar usuário: {e}")
+                    app.logger.error(
+                        "admin_usuarios_integrity_error",
+                        extra={
+                            'event': 'admin_usuarios_integrity_error',
+                            'error_repr': repr(e),
+                            'error_str': str(e),
+                            'error_orig': str(getattr(e, 'orig', None)),
+                            'username': username,
+                            'email': email,
+                            'correlation_id': correlation_id,
+                        },
+                    )
                 except Exception as e:
                     db.session.rollback()
                     flash('Ocorreu um erro ao salvar o usuário. Tente novamente em instantes.', 'danger')
-                    app.logger.error(f"Erro DB User: {e}")
+                    app.logger.exception(
+                        "admin_usuarios_unexpected_error",
+                        extra={
+                            'event': 'admin_usuarios_unexpected_error',
+                            'error_repr': repr(e),
+                            'username': username,
+                            'email': email,
+                            'correlation_id': correlation_id,
+                        },
+                    )
                 else:
                     manter_aba_cadastro = False
                     if not id_para_atualizar:

--- a/tests/test_admin_usuarios.py
+++ b/tests/test_admin_usuarios.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 
 from app import app, db
 from core.models import User, Instituicao, Estabelecimento, Setor, Celula, Cargo, Funcao
@@ -47,12 +48,14 @@ def login_admin(client):
         sess['user_id'] = uid
 
 
-def test_create_user(client):
+def test_create_user(client, caplog):
     login_admin(client)
     ids = client.base_ids
+    caplog.set_level(logging.INFO)
     response = client.post('/admin/usuarios', data={
         'username': 'newuser',
         'email': 'new@example.com',
+        'password': 'SuperSecreta!123',
         'ativo_check': 'on',
         'estabelecimento_id': ids['est'],
         'setor_ids': [str(ids['setor'])],
@@ -68,6 +71,14 @@ def test_create_user(client):
         assert user.celula_id == ids['cel']
         assert user.setor_id == ids['setor']
         assert user.extra_celulas.filter_by(id=ids['cel']).count() == 1
+    post_log = next((record for record in caplog.records if record.message == 'admin_usuarios_post_received'), None)
+    assert post_log is not None
+    assert post_log.request_method == 'POST'
+    assert post_log.request_path == '/admin/usuarios'
+    assert post_log.request_form['password'] == ['***REDACTED***']
+    assert 'SuperSecreta!123' not in caplog.text
+    assert any(record.message == 'Tentando commit de usuário' for record in caplog.records)
+    assert any(record.message == 'admin_usuarios_commit_success' for record in caplog.records)
 
 
 def test_create_user_shows_initial_password_and_marks_mandatory_change(client):
@@ -120,11 +131,12 @@ def test_create_user_with_admin_password_marks_mandatory_change(client):
 
 
 
-def test_create_user_integrity_error_shows_friendly_message(client, monkeypatch):
+def test_create_user_integrity_error_shows_friendly_message(client, monkeypatch, caplog):
     from sqlalchemy.exc import IntegrityError
 
     login_admin(client)
     ids = client.base_ids
+    caplog.set_level(logging.INFO)
 
     def raise_integrity_error():
         raise IntegrityError('INSERT', {'email': 'duplicado@example.com'}, Exception('duplicate key value violates unique constraint'))
@@ -144,6 +156,11 @@ def test_create_user_integrity_error_shows_friendly_message(client, monkeypatch)
     html = response.get_data(as_text=True)
     assert 'Não foi possível salvar o usuário. Verifique os dados informados e tente novamente.' in html
     assert 'duplicate key value violates unique constraint' not in html
+    error_log = next((record for record in caplog.records if record.message == 'admin_usuarios_integrity_error'), None)
+    assert error_log is not None
+    assert error_log.error_repr
+    assert error_log.error_str
+    assert 'duplicate key value violates unique constraint' in error_log.error_orig
 
 def test_toggle_user_active(client):
     ids = client.base_ids


### PR DESCRIPTION
### Motivation
- Improve observability and troubleshooting for the user creation/edit flow while preventing sensitive data leaks by redacting passwords from logs. 
- Provide actionable diagnostic context for DB integrity failures and unexpected errors to speed up incident analysis. 
- Make terminal logging useful in homologation/development environments and optionally enable SQL echo for easier debugging of DB interactions.

### Description
- Added structured request logging to `admin_usuarios` POST handling in `blueprints/admin.py`, logging method/path, sanitized `request.form` (password redacted), actor metadata, UTC timestamp and correlation/request identifiers via a new `_request_correlation_id` helper. 
- Logged parsed/normalized variables after form conversion (`username`, `email`, `ativo`, `estabelecimento_id`, `setor_ids`, `celula_ids`, `cargo_id`, `funcao_ids`, `id_para_atualizar`, `is_target_admin`) and added `warning` logs immediately before each validation path that triggers `flash(..., 'danger')`. 
- Around persistence: added a `Tentando commit de usuário` info log before `db.session.commit()`, a structured commit-success info log on success, richer `IntegrityError` logging that includes `repr(e)`, `str(e)` and `getattr(e, 'orig', None)`, and `logger.exception(...)` for unexpected exceptions to capture stack traces. 
- Updated `app.py` logging bootstrap to emit to `stdout` with a timestamp/logger/level/message format and to use `DEBUG` level for the app and `sqlalchemy.engine` when running in homologation/development-like environments, and to optionally enable `SQLALCHEMY_ECHO` there. 
- Added/updated tests in `tests/test_admin_usuarios.py` to assert that passwords are redacted from logs, that success flow emits start/commit logs, and that integrity errors produce diagnostic logs with error context.

### Testing
- Ran the modified unit tests with `pytest -q tests/test_admin_usuarios.py` and observed all tests passed (`14 passed`).
- Test run produced only expected deprecation/warning messages from SQLAlchemy; the new logging assertions in tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9384dc23c832ebc65775ffab40447)