### PR TITLE
Corrige validação de campos organizacionais no cadastro de usuários

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -462,13 +462,18 @@ def admin_usuarios():
                 setor_ids = [s.id for s in cargo_padrao.default_setores]
             if not celula_ids:
                 celula_ids = [c.id for c in cargo_padrao.default_celulas]
-            if not estabelecimento_id:
-                if setor_ids:
-                    setor_obj = Setor.query.get(setor_ids[0])
-                    estabelecimento_id = setor_obj.estabelecimento_id
-                elif celula_ids:
-                    cel_obj = Celula.query.get(celula_ids[0])
-                    estabelecimento_id = cel_obj.estabelecimento_id
+
+        if celula_ids and not setor_ids:
+            celulas = Celula.query.filter(Celula.id.in_(celula_ids)).all()
+            setor_ids = list(dict.fromkeys(c.setor_id for c in celulas if c.setor_id))
+
+        if not estabelecimento_id:
+            if setor_ids:
+                setor_obj = Setor.query.get(setor_ids[0])
+                estabelecimento_id = setor_obj.estabelecimento_id if setor_obj else None
+            elif celula_ids:
+                cel_obj = Celula.query.get(celula_ids[0])
+                estabelecimento_id = cel_obj.estabelecimento_id if cel_obj else None
 
         data_nascimento = None
         if data_nascimento_str:

--- a/tests/test_admin_usuarios.py
+++ b/tests/test_admin_usuarios.py
@@ -209,6 +209,26 @@ def test_create_user_with_celula(client):
         assert usr.extra_celulas.filter_by(id=cel_id).count() == 1
 
 
+def test_create_user_infers_hierarchy_from_celula_when_missing_fields(client):
+    login_admin(client)
+    ids = client.base_ids
+
+    response = client.post('/admin/usuarios', data={
+        'username': 'celauto',
+        'email': 'celauto@example.com',
+        'ativo_check': 'on',
+        'celula_ids': [str(ids['cel'])]
+    }, follow_redirects=True)
+
+    assert response.status_code == 200
+    with app.app_context():
+        usr = User.query.filter_by(username='celauto').first()
+        assert usr is not None
+        assert usr.estabelecimento_id == ids['est']
+        assert usr.setor_id == ids['setor']
+        assert usr.celula_id == ids['cel']
+
+
 def test_user_defaults_from_cargo(client):
     login_admin(client)
     ids = client.base_ids


### PR DESCRIPTION
### Motivation
- O endpoint de criação/edição de usuários estava rejeitando payloads que forneciam apenas `celula_ids`, pois a validação exigia `estabelecimento_id`, `setor_ids` e `celula_ids` para usuários não-admin.  
- É desejável que o backend seja tolerante quando a hierarquia pode ser inferida a partir da célula enviada para não bloquear cadastros legítimos.

### Description
- Altera `blueprints/admin.py` para, quando houver `celula_ids` mas não `setor_ids`, buscar as `Celula` correspondentes e preencher `setor_ids` a partir de `celula.setor_id`.  
- Ajusta a inferência de `estabelecimento_id` para considerar primeiro `setor_ids` e, se ausente, usar `celula_ids`, com checagens para evitar `AttributeError` quando objetos não existirem.  
- Mantém a lógica existente de defaults vindos do `cargo` e combina essa inferência com os novos passos para cobrir payloads sem `estabelecimento_id`/`setor_ids`.  
- Adiciona o teste `test_create_user_infers_hierarchy_from_celula_when_missing_fields` em `tests/test_admin_usuarios.py` cobrindo criação com somente `celula_ids` e verificando que `estabelecimento_id`, `setor_id` e `celula_id` foram preenchidos corretamente.

### Testing
- Executei `pytest -q tests/test_admin_usuarios.py` e todos os testes do arquivo passaram com sucesso.  
- Resultado: `15 passed` (nenhum teste falhou) e sem regressões detectadas nos cenários cobertos por esses testes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93c2c9968832ea18e30cd92e05e5f)