### PR TITLE
Corrige habilitação do botão "Adicionar Usuário" na tela de usuários

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -326,8 +326,8 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   }
 
-  function hasCheckedInput(selector) {
-    return document.querySelectorAll(selector).length > 0;
+  function hasCheckedInput(form, selector) {
+    return form.querySelectorAll(selector).length > 0;
   }
 
   function validateCreateUserForm() {
@@ -353,11 +353,13 @@ document.addEventListener("DOMContentLoaded", function () {
       : false;
 
     const exigeHierarquia = !(hasAdminByCargo || hasAdminMarcadoManual);
-    const hierarchyOk = !exigeHierarquia || (
-      hasCheckedInput("input[name='estabelecimento_id']:checked")
-      && hasCheckedInput("input[name='setor_ids']:checked")
-      && hasCheckedInput("input[name='celula_ids']:checked")
-    );
+    const hasSetor = hasCheckedInput(form, "input[name='setor_ids']:checked");
+    const hasCelula = hasCheckedInput(form, "input[name='celula_ids']:checked");
+
+    // Espelha a regra do backend:
+    // - setor e célula são obrigatórios para não-admin;
+    // - estabelecimento pode ser inferido a partir do setor/célula selecionados.
+    const hierarchyOk = !exigeHierarquia || (hasSetor && hasCelula);
 
     const isValid = Boolean(
       username?.value.trim()


### PR DESCRIPTION
### Motivation
- O botão "Adicionar Usuário" permanecia desabilitado mesmo quando os campos obrigatórios visíveis estavam preenchidos porque a checagem de caixas marcadas buscava inputs fora do formulário de criação (ex.: modal de edição), causando interferência na validação cliente.
- A lógica front-end exigia explicitamente o estabelecimento, enquanto o backend já permite inferi-lo a partir de setor/célula, gerando discrepância entre validação client/server.

### Description
- Atualizei `static/js/main.js` para que a função `hasCheckedInput` receba o formulário como escopo e passe a procurar checkboxes somente dentro de `#create-user-form`.
- Ajustei a regra de `validateCreateUserForm` para espelhar o backend: para usuários não-admin a validação exige `setor` e `célula` selecionados, sem forçar explicitamente o `estabelecimento` no front-end.
- Preservei o comportamento visual de desabilitar/habilitar o botão (`disabled` e classe `disabled`) e continuei vinculando `validateCreateUserForm` aos eventos `input` e `change` do formulário.

### Testing
- Executei `pytest -q tests/test_admin_usuarios.py` e todos os testes relacionados passaram (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93e9ebf00832eb1db85f5364c96d4)