### PR TITLE
Adicionar estabelecimentos padrão a Cargo e validação de hierarquia no admin

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -743,6 +743,7 @@ def admin_usuarios():
     funcoes = Funcao.query.order_by(Funcao.nome).all()
     cargo_defaults = {
         c.id: {
+            'estabelecimentos': [e.id for e in c.default_estabelecimentos],
             'setores': [s.id for s in c.default_setores],
             'celulas': [ce.id for ce in c.default_celulas],
             'funcoes': [f.id for f in c.permissoes],
@@ -973,6 +974,7 @@ def admin_cargos():
         nivel_hierarquico = request.form.get('nivel_hierarquico', type=int)
         ativo = request.form.get('ativo_check') == 'on'
         atende_os = request.form.get('pode_atender_os') == 'on'
+        estabelecimento_ids = list({int(e) for e in request.form.getlist('estabelecimento_ids') if e})
         setor_ids = list({int(s) for s in request.form.getlist('setor_ids') if s})
         celula_ids = list({int(c) for c in request.form.getlist('celula_ids') if c})
         funcao_ids = list({int(f) for f in request.form.getlist('funcao_ids') if f})
@@ -988,34 +990,77 @@ def admin_cargos():
             if nome_ja_existe:
                 flash(f'O nome de cargo "{nome}" já está em uso.', 'danger')
             else:
-                if id_para_atualizar:
-                    cargo = Cargo.query.get_or_404(id_para_atualizar)
-                    cargo.nome = nome
-                    cargo.descricao = descricao
-                    cargo.nivel_hierarquico = nivel_hierarquico
-                    cargo.ativo = ativo
-                    cargo.pode_atender_os = atende_os
-                    action_msg = 'atualizado'
+                setores_selecionados = Setor.query.filter(Setor.id.in_(setor_ids)).all() if setor_ids else []
+                celulas_selecionadas = Celula.query.filter(Celula.id.in_(celula_ids)).all() if celula_ids else []
+                estabelecimentos_ids_inferidos = set(estabelecimento_ids)
+                estabelecimentos_ids_inferidos.update(s.estabelecimento_id for s in setores_selecionados)
+                estabelecimentos_ids_inferidos.update(c.estabelecimento_id for c in celulas_selecionadas)
+                estabelecimentos_selecionados = (
+                    Estabelecimento.query.filter(Estabelecimento.id.in_(estabelecimentos_ids_inferidos)).all()
+                    if estabelecimentos_ids_inferidos else []
+                )
+
+                setor_ids_invalidos = set(setor_ids) - {s.id for s in setores_selecionados}
+                celula_ids_invalidos = set(celula_ids) - {c.id for c in celulas_selecionadas}
+                estabelecimento_ids_invalidos = set(estabelecimento_ids) - {e.id for e in estabelecimentos_selecionados}
+
+                erro_hierarquia = None
+                if estabelecimento_ids_invalidos or setor_ids_invalidos or celula_ids_invalidos:
+                    erro_hierarquia = 'Foram enviados itens de hierarquia inválidos. Atualize a página e tente novamente.'
                 else:
-                    cargo = Cargo(
-                        nome=nome,
-                        descricao=descricao,
-                        nivel_hierarquico=nivel_hierarquico,
-                        ativo=ativo,
-                        pode_atender_os=atende_os,
-                    )
-                    db.session.add(cargo)
-                    action_msg = 'criado'
-                cargo.default_setores = [Setor.query.get(sid) for sid in setor_ids]
-                cargo.default_celulas = [Celula.query.get(cid) for cid in celula_ids]
-                cargo.permissoes = [Funcao.query.get(fid) for fid in funcao_ids]
-                try:
-                    db.session.commit()
-                    flash(f'Cargo {action_msg} com sucesso!', 'success')
-                    return redirect(url_for('admin_bp.admin_cargos'))
-                except Exception as e:
-                    db.session.rollback()
-                    flash(f'Erro ao salvar cargo: {str(e)}', 'danger')
+                    setores_por_id = {s.id: s for s in setores_selecionados}
+                    estabelecimentos_set = {e.id for e in estabelecimentos_selecionados}
+                    for setor in setores_selecionados:
+                        if setor.estabelecimento_id not in estabelecimentos_set:
+                            erro_hierarquia = 'Cada setor selecionado deve pertencer a um estabelecimento selecionado.'
+                            break
+                    if not erro_hierarquia:
+                        for celula in celulas_selecionadas:
+                            setor_da_celula = setores_por_id.get(celula.setor_id)
+                            if not setor_da_celula:
+                                erro_hierarquia = 'Cada célula selecionada deve pertencer a um setor selecionado.'
+                                break
+                            if celula.estabelecimento_id != setor_da_celula.estabelecimento_id:
+                                erro_hierarquia = 'Inconsistência entre célula, setor e estabelecimento selecionados.'
+                                break
+                            if celula.estabelecimento_id not in estabelecimentos_set:
+                                erro_hierarquia = 'Cada célula selecionada deve pertencer a um estabelecimento selecionado.'
+                                break
+
+                if erro_hierarquia:
+                    flash(erro_hierarquia, 'danger')
+                    if id_para_atualizar:
+                        cargo_para_editar = Cargo.query.get(id_para_atualizar)
+                else:
+                    if id_para_atualizar:
+                        cargo = Cargo.query.get_or_404(id_para_atualizar)
+                        cargo.nome = nome
+                        cargo.descricao = descricao
+                        cargo.nivel_hierarquico = nivel_hierarquico
+                        cargo.ativo = ativo
+                        cargo.pode_atender_os = atende_os
+                        action_msg = 'atualizado'
+                    else:
+                        cargo = Cargo(
+                            nome=nome,
+                            descricao=descricao,
+                            nivel_hierarquico=nivel_hierarquico,
+                            ativo=ativo,
+                            pode_atender_os=atende_os,
+                        )
+                        db.session.add(cargo)
+                        action_msg = 'criado'
+                    cargo.default_estabelecimentos = estabelecimentos_selecionados
+                    cargo.default_setores = setores_selecionados
+                    cargo.default_celulas = celulas_selecionadas
+                    cargo.permissoes = [Funcao.query.get(fid) for fid in funcao_ids]
+                    try:
+                        db.session.commit()
+                        flash(f'Cargo {action_msg} com sucesso!', 'success')
+                        return redirect(url_for('admin_bp.admin_cargos'))
+                    except Exception as e:
+                        db.session.rollback()
+                        flash(f'Erro ao salvar cargo: {str(e)}', 'danger')
 
         if id_para_atualizar:
             cargo_para_editar = Cargo.query.get(id_para_atualizar)

--- a/core/models.py
+++ b/core/models.py
@@ -53,6 +53,12 @@ cargo_default_setores = db.Table(
     db.Column('setor_id', db.Integer, db.ForeignKey('setor.id'), primary_key=True),
 )
 
+cargo_default_estabelecimentos = db.Table(
+    'cargo_default_estabelecimentos',
+    db.Column('cargo_id', db.Integer, db.ForeignKey('cargo.id'), primary_key=True),
+    db.Column('estabelecimento_id', db.Integer, db.ForeignKey('estabelecimento.id'), primary_key=True),
+)
+
 # --- tabelas de permissões ---
 cargo_funcoes = db.Table(
     'cargo_funcoes',
@@ -221,6 +227,8 @@ class Cargo(db.Model):
     # Relacionamentos: Um Cargo pode ter vários Usuários
     usuarios = db.relationship('User', back_populates='cargo', lazy='dynamic')
     # Hierarquia padrão para usuários deste cargo
+    default_estabelecimentos = db.relationship(
+        'Estabelecimento', secondary=cargo_default_estabelecimentos, lazy='dynamic')
     default_setores = db.relationship(
         'Setor', secondary=cargo_default_setores, lazy='dynamic')
     default_celulas = db.relationship(

--- a/migrations/versions/5a7c9d1e2f34_add_cargo_default_estabelecimentos.py
+++ b/migrations/versions/5a7c9d1e2f34_add_cargo_default_estabelecimentos.py
@@ -1,0 +1,31 @@
+"""add cargo default estabelecimentos table
+
+Revision ID: 5a7c9d1e2f34
+Revises: 4d5e6f7a8b9c
+Create Date: 2026-04-23 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5a7c9d1e2f34'
+down_revision = '4d5e6f7a8b9c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'cargo_default_estabelecimentos',
+        sa.Column('cargo_id', sa.Integer(), nullable=False),
+        sa.Column('estabelecimento_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['cargo_id'], ['cargo.id']),
+        sa.ForeignKeyConstraint(['estabelecimento_id'], ['estabelecimento.id']),
+        sa.PrimaryKeyConstraint('cargo_id', 'estabelecimento_id'),
+    )
+
+
+def downgrade():
+    op.drop_table('cargo_default_estabelecimentos')

--- a/templates/admin/cargos.html
+++ b/templates/admin/cargos.html
@@ -182,7 +182,7 @@
                                     {% for est in inst.estabelecimentos %}
                                         <div class="ms-3">
                                             <div class="form-check">
-                                                <input class="form-check-input" type="checkbox" id="c_est{{ est.obj.id }}" value="{{ est.obj.id }}" disabled>
+                                                <input class="form-check-input" type="checkbox" id="c_est{{ est.obj.id }}" name="estabelecimento_ids" value="{{ est.obj.id }}" {% if est.obj.id|string in request.form.getlist('estabelecimento_ids') %}checked{% endif %}>
                                                 <label class="form-check-label fw-bold" for="c_est{{ est.obj.id }}">Estabelecimento: {{ est.obj.nome_fantasia }}</label>
                                             </div>
                                             {% if est.setores %}
@@ -348,7 +348,7 @@
                         <div class="card-body">
                             {% for est in estabelecimentos %}
                                 <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="e_est{{ est.id }}" value="{{ est.id }}" disabled>
+                                    <input class="form-check-input" type="checkbox" id="e_est{{ est.id }}" name="estabelecimento_ids" value="{{ est.id }}" {% if (request.form.getlist('estabelecimento_ids') and est.id|string in request.form.getlist('estabelecimento_ids')) or (not request.form.getlist('estabelecimento_ids') and (est in cargo_editar.default_estabelecimentos.all())) %}checked{% endif %}>
                                     <label class="form-check-label fw-bold" for="e_est{{ est.id }}">{{ est.nome_fantasia }}</label>
                                 </div>
                                 {% set setores_est = est.setores.all() %}


### PR DESCRIPTION
### Motivation
- Permitir selecionar estabelecimentos como parte da hierarquia padrão de um `Cargo` (antes os checkboxes de estabelecimento estavam desabilitados) e assegurar consistência entre estabelecimento → setor → célula ao salvar um cargo.

### Description
- Torna os checkboxes de estabelecimento no template de cargos acionáveis e com `name="estabelecimento_ids"`, preservando estado em criação/edição em `templates/admin/cargos.html`.
- Atualiza `admin_cargos` em `blueprints/admin.py` para ler `request.form.getlist('estabelecimento_ids')`, inferir estabelecimentos a partir de setores/células quando necessário, persistir `cargo.default_estabelecimentos` e salvar também `default_setores`/`default_celulas`/`permissoes`.
- Implementa validações no backend que rejeitam IDs inválidos e garantem que cada setor selecionado pertença a um estabelecimento selecionado e que cada célula pertença ao setor/estabelecimento correspondente.
- Adiciona suporte no modelo em `core/models.py` com a tabela de associação `cargo_default_estabelecimentos` e o relacionamento `default_estabelecimentos`, e inclui uma migration Alembic `migrations/versions/5a7c9d1e2f34_add_cargo_default_estabelecimentos.py`.
- Expande o JSON `cargo_defaults` retornado por `admin_usuarios` para incluir `estabelecimentos`, permitindo herança completa na UI de usuários.

### Testing
- Rodado `python -m compileall blueprints/admin.py core/models.py` com sucesso.
- Executado `pytest -q tests/test_cargo.py::test_create_cargo` e o teste passou (`1 passed`).
- Executado a suíte completa `pytest -q` e obteve sucesso final (`88 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1eb088e8832e8ac68a11493f2a63)