### PR TITLE
Sincroniza seleção hierárquica de cargos no frontend

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -326,6 +326,128 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   }
 
+  function initCargoHierarchySync() {
+    const hierarchyForms = document.querySelectorAll('.js-cargo-hierarquia-form');
+    if (!hierarchyForms.length) return;
+
+    hierarchyForms.forEach((form) => {
+      const celulaCheckboxes = Array.from(form.querySelectorAll("input[type='checkbox'][name='celula_ids'][data-setor-id][data-estabelecimento-id][data-instituicao-id]"));
+      const setorCheckboxes = Array.from(form.querySelectorAll("input[type='checkbox'][name='setor_ids'][data-setor-id][data-estabelecimento-id][data-instituicao-id]"));
+      const estabelecimentoCheckboxes = Array.from(form.querySelectorAll("input[type='checkbox'][name='estabelecimento_ids'][data-estabelecimento-id][data-instituicao-id]"));
+      const instituicaoCheckboxes = Array.from(form.querySelectorAll("input[type='checkbox'][name='instituicao_ids'][data-instituicao-id]"));
+
+      const getByData = (list, key, value) => list.filter((checkbox) => checkbox.dataset[key] === String(value));
+      const anyChecked = (list) => list.some((checkbox) => checkbox.checked);
+      const setChecked = (list, checked) => {
+        list.forEach((checkbox) => {
+          checkbox.checked = checked;
+          checkbox.indeterminate = false;
+        });
+      };
+
+      const syncSetorByDescendants = (setorId) => {
+        const relatedSetores = getByData(setorCheckboxes, "setorId", setorId);
+        if (!relatedSetores.length) return;
+        const hasCheckedCelula = anyChecked(getByData(celulaCheckboxes, "setorId", setorId));
+        if (hasCheckedCelula) {
+          setChecked(relatedSetores, true);
+        }
+      };
+
+      const syncEstabelecimentoByDescendants = (estabelecimentoId) => {
+        const relatedEstabelecimentos = getByData(estabelecimentoCheckboxes, "estabelecimentoId", estabelecimentoId);
+        if (!relatedEstabelecimentos.length) return;
+        const hasCheckedSetor = anyChecked(getByData(setorCheckboxes, "estabelecimentoId", estabelecimentoId));
+        const hasCheckedCelula = anyChecked(getByData(celulaCheckboxes, "estabelecimentoId", estabelecimentoId));
+        setChecked(relatedEstabelecimentos, hasCheckedSetor || hasCheckedCelula);
+      };
+
+      const syncInstituicaoByDescendants = (instituicaoId) => {
+        const relatedInstituicoes = getByData(instituicaoCheckboxes, "instituicaoId", instituicaoId);
+        if (!relatedInstituicoes.length) return;
+        const hasCheckedEstabelecimento = anyChecked(getByData(estabelecimentoCheckboxes, "instituicaoId", instituicaoId));
+        const hasCheckedSetor = anyChecked(getByData(setorCheckboxes, "instituicaoId", instituicaoId));
+        const hasCheckedCelula = anyChecked(getByData(celulaCheckboxes, "instituicaoId", instituicaoId));
+        setChecked(relatedInstituicoes, hasCheckedEstabelecimento || hasCheckedSetor || hasCheckedCelula);
+      };
+
+      const syncAllParents = () => {
+        const setorIds = new Set(celulaCheckboxes.map((checkbox) => checkbox.dataset.setorId));
+        setorIds.forEach(syncSetorByDescendants);
+
+        const estabelecimentoIds = new Set([
+          ...celulaCheckboxes.map((checkbox) => checkbox.dataset.estabelecimentoId),
+          ...setorCheckboxes.map((checkbox) => checkbox.dataset.estabelecimentoId),
+        ]);
+        estabelecimentoIds.forEach(syncEstabelecimentoByDescendants);
+
+        const instituicaoIds = new Set([
+          ...celulaCheckboxes.map((checkbox) => checkbox.dataset.instituicaoId),
+          ...setorCheckboxes.map((checkbox) => checkbox.dataset.instituicaoId),
+          ...estabelecimentoCheckboxes.map((checkbox) => checkbox.dataset.instituicaoId),
+        ]);
+        instituicaoIds.forEach(syncInstituicaoByDescendants);
+      };
+
+      celulaCheckboxes.forEach((checkbox) => {
+        checkbox.addEventListener("change", () => {
+          const { setorId, estabelecimentoId, instituicaoId } = checkbox.dataset;
+          if (checkbox.checked) {
+            setChecked(getByData(setorCheckboxes, "setorId", setorId), true);
+            setChecked(getByData(estabelecimentoCheckboxes, "estabelecimentoId", estabelecimentoId), true);
+            setChecked(getByData(instituicaoCheckboxes, "instituicaoId", instituicaoId), true);
+            return;
+          }
+
+          syncSetorByDescendants(setorId);
+          syncEstabelecimentoByDescendants(estabelecimentoId);
+          syncInstituicaoByDescendants(instituicaoId);
+        });
+      });
+
+      setorCheckboxes.forEach((checkbox) => {
+        checkbox.addEventListener("change", () => {
+          const { setorId, estabelecimentoId, instituicaoId } = checkbox.dataset;
+          if (checkbox.checked) {
+            setChecked(getByData(estabelecimentoCheckboxes, "estabelecimentoId", estabelecimentoId), true);
+            setChecked(getByData(instituicaoCheckboxes, "instituicaoId", instituicaoId), true);
+            return;
+          }
+          syncSetorByDescendants(setorId);
+          syncEstabelecimentoByDescendants(estabelecimentoId);
+          syncInstituicaoByDescendants(instituicaoId);
+        });
+      });
+
+      estabelecimentoCheckboxes.forEach((checkbox) => {
+        checkbox.addEventListener("change", () => {
+          const { estabelecimentoId, instituicaoId } = checkbox.dataset;
+          if (checkbox.checked) {
+            setChecked(getByData(instituicaoCheckboxes, "instituicaoId", instituicaoId), true);
+            return;
+          }
+          syncEstabelecimentoByDescendants(estabelecimentoId);
+          syncInstituicaoByDescendants(instituicaoId);
+        });
+      });
+
+      instituicaoCheckboxes.forEach((checkbox) => {
+        checkbox.addEventListener("change", () => {
+          if (checkbox.checked) return;
+          syncInstituicaoByDescendants(checkbox.dataset.instituicaoId);
+        });
+      });
+
+      form.addEventListener("submit", () => {
+        syncAllParents();
+      });
+
+      syncAllParents();
+    });
+  }
+
+  initCargoHierarchySync();
+
   function getFieldIdentifier(field) {
     return field?.name || field?.id || "(sem-name-id)";
   }

--- a/templates/admin/cargos.html
+++ b/templates/admin/cargos.html
@@ -154,7 +154,7 @@
                         <i class="bi bi-plus-circle-fill me-2"></i>Adicionar Novo Cargo
                     </h5>
 
-                    <form method="POST" action="{{ url_for('admin_cargos') }}" novalidate class="compact-form">
+                    <form method="POST" action="{{ url_for('admin_cargos') }}" novalidate class="compact-form js-cargo-hierarquia-form">
                         <div class="row">
                             <div class="col-md-8 mb-1">
                                 <label for="nome" class="form-label">Nome <span class="text-danger">*</span></label>
@@ -178,25 +178,37 @@
                             <div class="card-header"><h6 class="mb-0">Hierarquia Padrão</h6></div>
                             <div class="card-body">
                                 {% for inst in estrutura %}
-                                    <div class="fw-bold mb-1">Instituição: {{ inst.obj.nome }}</div>
+                                    <div class="form-check mb-1">
+                                        <input
+                                            class="form-check-input"
+                                            type="checkbox"
+                                            id="c_inst{{ inst.obj.id }}"
+                                            name="instituicao_ids"
+                                            value="{{ inst.obj.id }}"
+                                            data-node-type="instituicao"
+                                            data-instituicao-id="{{ inst.obj.id }}"
+                                            {% if inst.obj.id|string in request.form.getlist('instituicao_ids') %}checked{% endif %}
+                                        >
+                                        <label class="form-check-label fw-bold" for="c_inst{{ inst.obj.id }}">Instituição: {{ inst.obj.nome }}</label>
+                                    </div>
                                     {% for est in inst.estabelecimentos %}
                                         <div class="ms-3">
                                             <div class="form-check">
-                                                <input class="form-check-input" type="checkbox" id="c_est{{ est.obj.id }}" name="estabelecimento_ids" value="{{ est.obj.id }}" {% if est.obj.id|string in request.form.getlist('estabelecimento_ids') %}checked{% endif %}>
+                                                <input class="form-check-input" type="checkbox" id="c_est{{ est.obj.id }}" name="estabelecimento_ids" value="{{ est.obj.id }}" data-node-type="estabelecimento" data-estabelecimento-id="{{ est.obj.id }}" data-instituicao-id="{{ inst.obj.id }}" {% if est.obj.id|string in request.form.getlist('estabelecimento_ids') %}checked{% endif %}>
                                                 <label class="form-check-label fw-bold" for="c_est{{ est.obj.id }}">Estabelecimento: {{ est.obj.nome_fantasia }}</label>
                                             </div>
                                             {% if est.setores %}
                                                 <div class="ms-4">
                                                     {% for st in est.setores %}
                                                         <div class="form-check">
-                                                            <input class="form-check-input" type="checkbox" id="c_setor{{ st.obj.id }}" name="setor_ids" value="{{ st.obj.id }}" {% if st.obj.id|string in request.form.getlist('setor_ids') %}checked{% endif %}>
+                                                            <input class="form-check-input" type="checkbox" id="c_setor{{ st.obj.id }}" name="setor_ids" value="{{ st.obj.id }}" data-node-type="setor" data-setor-id="{{ st.obj.id }}" data-estabelecimento-id="{{ est.obj.id }}" data-instituicao-id="{{ inst.obj.id }}" {% if st.obj.id|string in request.form.getlist('setor_ids') %}checked{% endif %}>
                                                             <label class="form-check-label" for="c_setor{{ st.obj.id }}">Setor: {{ st.obj.nome }}</label>
                                                         </div>
                                                         {% if st.celulas %}
                                                             <div class="ms-4 mb-2">
                                                                 {% for cel in st.celulas %}
                                                                     <div class="form-check">
-                                                                        <input class="form-check-input" type="checkbox" id="c_celula{{ cel.obj.id }}" name="celula_ids" value="{{ cel.obj.id }}" {% if cel.obj.id|string in request.form.getlist('celula_ids') %}checked{% endif %}>
+                                                                        <input class="form-check-input" type="checkbox" id="c_celula{{ cel.obj.id }}" name="celula_ids" value="{{ cel.obj.id }}" data-node-type="celula" data-setor-id="{{ st.obj.id }}" data-estabelecimento-id="{{ est.obj.id }}" data-instituicao-id="{{ inst.obj.id }}" {% if cel.obj.id|string in request.form.getlist('celula_ids') %}checked{% endif %}>
                                                                         <label class="form-check-label" for="c_celula{{ cel.obj.id }}">Célula: {{ cel.obj.nome }}</label>
                                                                     </div>
                                                                 {% endfor %}
@@ -322,7 +334,7 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
             </div>
             <div class="modal-body">
-                <form method="POST" action="{{ url_for('admin_cargos') }}" novalidate class="compact-form">
+                <form method="POST" action="{{ url_for('admin_cargos') }}" novalidate class="compact-form js-cargo-hierarquia-form">
                     <input type="hidden" name="id_para_atualizar" value="{{ cargo_editar.id }}">
                     <div class="row">
                         <div class="col-md-8 mb-1">
@@ -348,7 +360,7 @@
                         <div class="card-body">
                             {% for est in estabelecimentos %}
                                 <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="e_est{{ est.id }}" name="estabelecimento_ids" value="{{ est.id }}" {% if (request.form.getlist('estabelecimento_ids') and est.id|string in request.form.getlist('estabelecimento_ids')) or (not request.form.getlist('estabelecimento_ids') and (est in cargo_editar.default_estabelecimentos.all())) %}checked{% endif %}>
+                                    <input class="form-check-input" type="checkbox" id="e_est{{ est.id }}" name="estabelecimento_ids" value="{{ est.id }}" data-node-type="estabelecimento" data-estabelecimento-id="{{ est.id }}" data-instituicao-id="{{ est.instituicao_id }}" {% if (request.form.getlist('estabelecimento_ids') and est.id|string in request.form.getlist('estabelecimento_ids')) or (not request.form.getlist('estabelecimento_ids') and (est in cargo_editar.default_estabelecimentos.all())) %}checked{% endif %}>
                                     <label class="form-check-label fw-bold" for="e_est{{ est.id }}">{{ est.nome_fantasia }}</label>
                                 </div>
                                 {% set setores_est = est.setores.all() %}
@@ -356,7 +368,7 @@
                                     <div class="ms-4">
                                         {% for st in setores_est %}
                                             <div class="form-check">
-                                                <input class="form-check-input" type="checkbox" id="e_setor{{ st.id }}" name="setor_ids" value="{{ st.id }}" {% if (request.form.getlist('setor_ids') and st.id|string in request.form.getlist('setor_ids')) or (not request.form.getlist('setor_ids') and (st in cargo_editar.default_setores.all())) %}checked{% endif %}>
+                                                <input class="form-check-input" type="checkbox" id="e_setor{{ st.id }}" name="setor_ids" value="{{ st.id }}" data-node-type="setor" data-setor-id="{{ st.id }}" data-estabelecimento-id="{{ est.id }}" data-instituicao-id="{{ est.instituicao_id }}" {% if (request.form.getlist('setor_ids') and st.id|string in request.form.getlist('setor_ids')) or (not request.form.getlist('setor_ids') and (st in cargo_editar.default_setores.all())) %}checked{% endif %}>
                                                 <label class="form-check-label" for="e_setor{{ st.id }}">{{ st.nome }}</label>
                                             </div>
                                             {% set celulas_set = st.celulas.all() %}
@@ -364,7 +376,7 @@
                                                 <div class="ms-4 mb-2">
                                                     {% for cel in celulas_set %}
                                                         <div class="form-check">
-                                                            <input class="form-check-input" type="checkbox" id="e_celula{{ cel.id }}" name="celula_ids" value="{{ cel.id }}" {% if (request.form.getlist('celula_ids') and cel.id|string in request.form.getlist('celula_ids')) or (not request.form.getlist('celula_ids') and (cel in cargo_editar.default_celulas.all())) %}checked{% endif %}>
+                                                            <input class="form-check-input" type="checkbox" id="e_celula{{ cel.id }}" name="celula_ids" value="{{ cel.id }}" data-node-type="celula" data-setor-id="{{ st.id }}" data-estabelecimento-id="{{ est.id }}" data-instituicao-id="{{ est.instituicao_id }}" {% if (request.form.getlist('celula_ids') and cel.id|string in request.form.getlist('celula_ids')) or (not request.form.getlist('celula_ids') and (cel in cargo_editar.default_celulas.all())) %}checked{% endif %}>
                                                             <label class="form-check-label" for="e_celula{{ cel.id }}">{{ cel.nome }}</label>
                                                         </div>
                                                     {% endfor %}


### PR DESCRIPTION
### Motivation
- Tornar a seleção hierárquica (instituição → estabelecimento → setor → célula) consistente entre a interface e o payload submetido para evitar divergências UI/payload ao criar/editar cargos.

### Description
- Adiciona metadados nos checkboxes de hierarquia em `templates/admin/cargos.html` (`data-setor-id`, `data-estabelecimento-id`, `data-instituicao-id`) e marca os formulários de criação/edição com a classe `js-cargo-hierarquia-form` para escopo do script.
- Inclui um checkbox real de `instituição` no formulário de `Hierarquia Padrão` para refletir a seleção descendente visualmente sem cliques extras quando houver estabelecimentos/setores/células selecionados.
- Implementa em `static/js/main.js` a rotina `initCargoHierarchySync()` que: ao marcar uma célula marca automaticamente setor/estabelecimento/instituição; ao desmarcar reavalia se pais ainda têm descendentes marcados antes de desmarcar; e mantém coerência visual da instituição com base em descendentes.
- Garante que, no `submit` do formulário, a sincronização dos pais é aplicada (`syncAllParents`) para que os inputs `checked` enviados coincidam com o estado visual.

### Testing
- Executado `pytest -q tests/test_cargo.py` e os testes referentes a cargos passaram com sucesso (1 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2161db9c832ea20c52d204f9437e)