### PR TITLE
Deixar campos organizacionais como visual somente e sincronizar payload herdado do cargo

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -458,10 +458,31 @@ def admin_usuarios():
 
         cargo_padrao = Cargo.query.get(cargo_id) if cargo_id else None
         if cargo_padrao:
-            if not setor_ids:
-                setor_ids = [s.id for s in cargo_padrao.default_setores]
-            if not celula_ids:
-                celula_ids = [c.id for c in cargo_padrao.default_celulas]
+            payload_org_original = {
+                'estabelecimento_id': estabelecimento_id,
+                'setor_ids': setor_ids[:],
+                'celula_ids': celula_ids[:],
+            }
+            setor_ids = [s.id for s in cargo_padrao.default_setores]
+            celula_ids = [c.id for c in cargo_padrao.default_celulas]
+            cargo_estabelecimentos = [e.id for e in cargo_padrao.default_estabelecimentos]
+            estabelecimento_id = cargo_estabelecimentos[0] if cargo_estabelecimentos else None
+
+            if payload_org_original['estabelecimento_id'] != estabelecimento_id or payload_org_original['setor_ids'] != setor_ids or payload_org_original['celula_ids'] != celula_ids:
+                app.logger.warning(
+                    "admin_usuarios_payload_org_reconciled_with_cargo_defaults",
+                    extra={
+                        'event': 'admin_usuarios_payload_org_reconciled_with_cargo_defaults',
+                        'cargo_id': cargo_id,
+                        'payload_original': payload_org_original,
+                        'payload_reconciled': {
+                            'estabelecimento_id': estabelecimento_id,
+                            'setor_ids': setor_ids,
+                            'celula_ids': celula_ids,
+                        },
+                        'correlation_id': correlation_id,
+                    },
+                )
 
         if celula_ids and not setor_ids:
             celulas = Celula.query.filter(Celula.id.in_(celula_ids)).all()

--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -463,10 +463,19 @@ def admin_usuarios():
                 'setor_ids': setor_ids[:],
                 'celula_ids': celula_ids[:],
             }
-            setor_ids = [s.id for s in cargo_padrao.default_setores]
-            celula_ids = [c.id for c in cargo_padrao.default_celulas]
             cargo_estabelecimentos = [e.id for e in cargo_padrao.default_estabelecimentos]
-            estabelecimento_id = cargo_estabelecimentos[0] if cargo_estabelecimentos else None
+            cargo_setor_ids = [s.id for s in cargo_padrao.default_setores]
+            cargo_celula_ids = [c.id for c in cargo_padrao.default_celulas]
+
+            # Reconciliação determinística:
+            # - quando o cargo define defaults organizacionais, eles prevalecem;
+            # - quando não define, preserva o payload manual recebido.
+            if cargo_setor_ids:
+                setor_ids = cargo_setor_ids
+            if cargo_celula_ids:
+                celula_ids = cargo_celula_ids
+            if cargo_estabelecimentos:
+                estabelecimento_id = cargo_estabelecimentos[0]
 
             if payload_org_original['estabelecimento_id'] != estabelecimento_id or payload_org_original['setor_ids'] != setor_ids or payload_org_original['celula_ids'] != celula_ids:
                 app.logger.warning(

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -264,18 +264,6 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 
   // --------------------------------------------------------------
-  // Auxiliar: permite apenas um estabelecimento selecionado
-  document.querySelectorAll('input[name="estabelecimento_id"]').forEach((chk) => {
-    chk.addEventListener('change', () => {
-      if (chk.checked) {
-        document.querySelectorAll('input[name="estabelecimento_id"]').forEach((o) => {
-          if (o !== chk) o.checked = false;
-        });
-      }
-    });
-  });
-
-
   const cargoDefaults = window.cargoDefaults || {};
 
   function setCargoFuncoesDisabled(prefix, cargoId) {
@@ -286,7 +274,41 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   function applyCargoDefaults(prefix, cargoId) {
-    const defs = cargoDefaults[cargoId] || { setores: [], celulas: [], funcoes: [] };
+    const defs = cargoDefaults[cargoId] || { estabelecimentos: [], setores: [], celulas: [], funcoes: [] };
+    const form = prefix === 'edit_' ? document.getElementById('edit_cargo_id')?.closest('form') : document.getElementById('create-user-form');
+    const hiddenEstabelecimento = document.getElementById(`${prefix}hidden_estabelecimento_id`);
+    const hiddenSetorContainer = document.getElementById(`${prefix}hidden_setor_ids_container`);
+    const hiddenCelulaContainer = document.getElementById(`${prefix}hidden_celula_ids_container`);
+
+    const clearAndAppendMultiHidden = (container, name, values) => {
+      if (!container) return;
+      container.innerHTML = '';
+      values.forEach((value) => {
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = name;
+        input.value = value;
+        container.appendChild(input);
+      });
+    };
+
+    const estabelecimentoPadrao = defs.estabelecimentos?.length ? defs.estabelecimentos[0] : '';
+    if (hiddenEstabelecimento) {
+      hiddenEstabelecimento.value = estabelecimentoPadrao ? String(estabelecimentoPadrao) : '';
+    }
+    clearAndAppendMultiHidden(hiddenSetorContainer, 'setor_ids', defs.setores || []);
+    clearAndAppendMultiHidden(hiddenCelulaContainer, 'celula_ids', defs.celulas || []);
+
+    const instituicaoDisplay = form?.querySelector("input[name='instituicao_nome_herdada']");
+    if (instituicaoDisplay) {
+      const estabelecimentoMarcado = form?.querySelector(`input[id^='${prefix}est'][value='${estabelecimentoPadrao}']`);
+      const instituicaoLabel = estabelecimentoMarcado?.closest('.form-check')?.querySelector('small')?.textContent || '';
+      instituicaoDisplay.value = instituicaoLabel.replace('(Instituição:', '').replace(')', '').trim();
+    }
+
+    document.querySelectorAll(`input[id^='${prefix}est']`).forEach((chk) => {
+      chk.checked = defs.estabelecimentos.includes(parseInt(chk.value));
+    });
     document.querySelectorAll(`input[id^='${prefix}setor']`).forEach((chk) => {
       chk.checked = defs.setores.includes(parseInt(chk.value));
     });
@@ -539,8 +561,8 @@ document.addEventListener("DOMContentLoaded", function () {
       };
     });
 
-    const setorChecked = form.querySelectorAll("input[name='setor_ids']:checked");
-    const celulaChecked = form.querySelectorAll("input[name='celula_ids']:checked");
+    const setorChecked = form.querySelectorAll("input[id^='setor']:checked");
+    const celulaChecked = form.querySelectorAll("input[id^='celula']:checked");
     const hasSetor = setorChecked.length > 0;
     const hasCelula = celulaChecked.length > 0;
 

--- a/templates/admin/usuarios.html
+++ b/templates/admin/usuarios.html
@@ -162,18 +162,34 @@
                                         {% endfor %}
                                     </select>
                                 </div>
-                                <p class="small text-muted mb-2">Selecione ao menos um estabelecimento, setor e célula para habilitar o cadastro.</p>
+                                <p class="small text-muted mb-2">
+                                    Campos de instituição/estabelecimento/setor/célula são herdados do cargo selecionado e exibidos apenas para consulta.
+                                </p>
+                                <input type="hidden" name="estabelecimento_id" id="hidden_estabelecimento_id" value="{{ request.form.get('estabelecimento_id', '') }}">
+                                <div id="hidden_setor_ids_container">
+                                    {% for setor_id in request.form.getlist('setor_ids') %}
+                                        <input type="hidden" name="setor_ids" value="{{ setor_id }}">
+                                    {% endfor %}
+                                </div>
+                                <div id="hidden_celula_ids_container">
+                                    {% for celula_id in request.form.getlist('celula_ids') %}
+                                        <input type="hidden" name="celula_ids" value="{{ celula_id }}">
+                                    {% endfor %}
+                                </div>
                                 {% for est in estabelecimentos %}
                                     <div class="form-check">
-                                        <input class="form-check-input estab-checkbox" type="checkbox" id="est{{ est.id }}" name="estabelecimento_id" value="{{ est.id }}" {% if request.form.get('estabelecimento_id') == est.id|string %}checked{% endif %}>
-                                        <label class="form-check-label fw-bold" for="est{{ est.id }}">{{ est.nome_fantasia }}</label>
+                                        <input class="form-check-input estab-checkbox" type="checkbox" id="est{{ est.id }}" name="estabelecimento_id_visual" value="{{ est.id }}" {% if request.form.get('estabelecimento_id') == est.id|string %}checked{% endif %} disabled>
+                                        <label class="form-check-label fw-bold" for="est{{ est.id }}">
+                                            {{ est.nome_fantasia }}
+                                            <small class="text-muted">(Instituição: {{ est.instituicao.nome if est.instituicao else 'N/D' }})</small>
+                                        </label>
                                     </div>
                                     {% set setores_est = est.setores.all() %}
                                     {% if setores_est %}
                                         <div class="ms-4">
                                             {% for st in setores_est %}
                                                 <div class="form-check">
-                                                    <input class="form-check-input" type="checkbox" id="setor{{ st.id }}" name="setor_ids" value="{{ st.id }}" {% if st.id|string in request.form.getlist('setor_ids') %}checked{% endif %}>
+                                                    <input class="form-check-input" type="checkbox" id="setor{{ st.id }}" name="setor_ids_visual" value="{{ st.id }}" {% if st.id|string in request.form.getlist('setor_ids') %}checked{% endif %} disabled>
                                                     <label class="form-check-label" for="setor{{ st.id }}">{{ st.nome }}</label>
                                                 </div>
                                                 {% set celulas_set = st.celulas.all() %}
@@ -181,7 +197,7 @@
                                                     <div class="ms-4 mb-2">
                                                         {% for cel in celulas_set %}
                                                             <div class="form-check">
-                                                                <input class="form-check-input" type="checkbox" id="celula{{ cel.id }}" name="celula_ids" value="{{ cel.id }}" {% if cel.id|string in request.form.getlist('celula_ids') %}checked{% endif %}>
+                                                                <input class="form-check-input" type="checkbox" id="celula{{ cel.id }}" name="celula_ids_visual" value="{{ cel.id }}" {% if cel.id|string in request.form.getlist('celula_ids') %}checked{% endif %} disabled>
                                                                 <label class="form-check-label" for="celula{{ cel.id }}">{{ cel.nome }}</label>
                                                             </div>
                                                         {% endfor %}
@@ -305,17 +321,52 @@
                                     {% endfor %}
                                 </select>
                             </div>
+                            <p class="small text-muted mb-2">
+                                Campos de instituição/estabelecimento/setor/célula são herdados do cargo selecionado e exibidos apenas para consulta.
+                            </p>
+                            <input type="hidden" name="estabelecimento_id" id="edit_hidden_estabelecimento_id" value="{{ request.form.get('estabelecimento_id', user_editar.estabelecimento_id if user_editar.estabelecimento_id else '') }}">
+                            <div id="edit_hidden_setor_ids_container">
+                                {% if request.form.getlist('setor_ids') %}
+                                    {% for setor_id in request.form.getlist('setor_ids') %}
+                                        <input type="hidden" name="setor_ids" value="{{ setor_id }}">
+                                    {% endfor %}
+                                {% else %}
+                                    {% for setor_id in extra_setores_ids %}
+                                        <input type="hidden" name="setor_ids" value="{{ setor_id }}">
+                                    {% endfor %}
+                                    {% if user_editar.setor_id and user_editar.setor_id not in extra_setores_ids %}
+                                        <input type="hidden" name="setor_ids" value="{{ user_editar.setor_id }}">
+                                    {% endif %}
+                                {% endif %}
+                            </div>
+                            <div id="edit_hidden_celula_ids_container">
+                                {% if request.form.getlist('celula_ids') %}
+                                    {% for celula_id in request.form.getlist('celula_ids') %}
+                                        <input type="hidden" name="celula_ids" value="{{ celula_id }}">
+                                    {% endfor %}
+                                {% else %}
+                                    {% for celula_id in extra_celulas_ids %}
+                                        <input type="hidden" name="celula_ids" value="{{ celula_id }}">
+                                    {% endfor %}
+                                    {% if user_editar.celula_id and user_editar.celula_id not in extra_celulas_ids %}
+                                        <input type="hidden" name="celula_ids" value="{{ user_editar.celula_id }}">
+                                    {% endif %}
+                                {% endif %}
+                            </div>
                             {% for est in estabelecimentos %}
                                 <div class="form-check">
-                                    <input class="form-check-input estab-checkbox" type="checkbox" id="edit_est{{ est.id }}" name="estabelecimento_id" value="{{ est.id }}" {% if (request.form.get('estabelecimento_id') == est.id|string) or (not request.form.get('estabelecimento_id') and user_editar.estabelecimento_id == est.id) %}checked{% endif %}>
-                                    <label class="form-check-label fw-bold" for="edit_est{{ est.id }}">{{ est.nome_fantasia }}</label>
+                                    <input class="form-check-input estab-checkbox" type="checkbox" id="edit_est{{ est.id }}" name="estabelecimento_id_visual" value="{{ est.id }}" {% if (request.form.get('estabelecimento_id') == est.id|string) or (not request.form.get('estabelecimento_id') and user_editar.estabelecimento_id == est.id) %}checked{% endif %} disabled>
+                                    <label class="form-check-label fw-bold" for="edit_est{{ est.id }}">
+                                        {{ est.nome_fantasia }}
+                                        <small class="text-muted">(Instituição: {{ est.instituicao.nome if est.instituicao else 'N/D' }})</small>
+                                    </label>
                                 </div>
                                 {% set setores_est = est.setores.all() %}
                                 {% if setores_est %}
                                     <div class="ms-4">
                                         {% for st in setores_est %}
                                             <div class="form-check">
-                                                <input class="form-check-input" type="checkbox" id="edit_setor{{ st.id }}" name="setor_ids" value="{{ st.id }}" {% if (request.form.getlist('setor_ids') and st.id|string in request.form.getlist('setor_ids')) or (not request.form.getlist('setor_ids') and (st.id in extra_setores_ids or st.id == user_editar.setor_id)) %}checked{% endif %}>
+                                                <input class="form-check-input" type="checkbox" id="edit_setor{{ st.id }}" name="setor_ids_visual" value="{{ st.id }}" {% if (request.form.getlist('setor_ids') and st.id|string in request.form.getlist('setor_ids')) or (not request.form.getlist('setor_ids') and (st.id in extra_setores_ids or st.id == user_editar.setor_id)) %}checked{% endif %} disabled>
                                                 <label class="form-check-label" for="edit_setor{{ st.id }}">{{ st.nome }}</label>
                                             </div>
                                             {% set celulas_set = st.celulas.all() %}
@@ -323,7 +374,7 @@
                                                 <div class="ms-4 mb-2">
                                                     {% for cel in celulas_set %}
                                                         <div class="form-check">
-                                                            <input class="form-check-input" type="checkbox" id="edit_celula{{ cel.id }}" name="celula_ids" value="{{ cel.id }}" {% if (request.form.getlist('celula_ids') and cel.id|string in request.form.getlist('celula_ids')) or (not request.form.getlist('celula_ids') and (cel.id in extra_celulas_ids or cel.id == user_editar.celula_id)) %}checked{% endif %}>
+                                                            <input class="form-check-input" type="checkbox" id="edit_celula{{ cel.id }}" name="celula_ids_visual" value="{{ cel.id }}" {% if (request.form.getlist('celula_ids') and cel.id|string in request.form.getlist('celula_ids')) or (not request.form.getlist('celula_ids') and (cel.id in extra_celulas_ids or cel.id == user_editar.celula_id)) %}checked{% endif %} disabled>
                                                             <label class="form-check-label" for="edit_celula{{ cel.id }}">{{ cel.nome }}</label>
                                                         </div>
                                                     {% endfor %}


### PR DESCRIPTION
### Motivation
- Prevenir conflitos entre seleção manual de organização e os valores herdados do `cargo` exibindo instituição/estabelecimento/setor/célula apenas como visual. 
- Garantir que o payload enviado ao servidor contenha os IDs organizacionais mesmo com os controles visuais desabilitados, usando inputs `hidden`. 
- Aplicar os defaults do `cargo` de forma determinística no frontend e reforçar no backend para evitar inconsistência entre payload manual e herança.

### Description
- Atualiza `templates/admin/usuarios.html` para tornar os checkboxes de instituição/estabelecimento/setor/célula desabilitados (visuais) e adicionar inputs `hidden` sincronizáveis para `estabelecimento_id`, `setor_ids` e `celula_ids` tanto no formulário de criação quanto no modal de edição. 
- Expande `static/js/main.js` em `applyCargoDefaults` para preencher estabelecimento padrão do cargo, gerar/atualizar os `hidden` containers (`hidden_setor_ids_container`, `hidden_celula_ids_container` e `hidden_estabelecimento_id`) e ajustar leitura/validação dos checkboxes visuais. 
- Ajusta `blueprints/admin.py` (`admin_usuarios`) para reconciliar o payload organizacional recebido com os defaults do `cargo` (substituindo os valores por aqueles do cargo quando aplicável) e logar um `warning` com os dados originais e reconciliados quando houver divergência. 
- Pequenas melhorias de fallback no template de edição para garantir que os `hidden` inputs reflitam os valores existentes do usuário quando `request.form` estiver vazio.

### Testing
- Executado `python -m py_compile blueprints/admin.py` e a verificação compilou sem erros (sucesso). 
- Executado `node --check static/js/main.js` e a verificação de sintaxe JavaScript passou (sucesso). 
- Não foram gerados testes UI automatizados nesta execução (ferramenta de captura de browser indisponível).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea24349894832ead4442fb8fe79bfa)