### PR TITLE
Corrige herança de vínculos de cargo e visibilidade por célula/setor

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -497,6 +497,27 @@ def admin_usuarios():
             celulas = Celula.query.filter(Celula.id.in_(celula_ids)).all()
             setor_ids = list(dict.fromkeys(c.setor_id for c in celulas if c.setor_id))
 
+        celulas_resolvidas = []
+        if celula_ids:
+            celulas_resolvidas = Celula.query.filter(Celula.id.in_(celula_ids)).all()
+            celulas_por_id = {c.id: c for c in celulas_resolvidas}
+            celula_ids = [cid for cid in celula_ids if cid in celulas_por_id]
+            setores_derivados_das_celulas = [
+                celulas_por_id[cid].setor_id
+                for cid in celula_ids
+                if celulas_por_id[cid].setor_id
+            ]
+            setor_ids = list(dict.fromkeys([*setor_ids, *setores_derivados_das_celulas]))
+
+        setor_primario_id = None
+        celula_primaria_id = celula_ids[0] if celula_ids else None
+        if celula_primaria_id:
+            celula_primaria = next((c for c in celulas_resolvidas if c.id == celula_primaria_id), None)
+            if celula_primaria and celula_primaria.setor_id:
+                setor_primario_id = celula_primaria.setor_id
+        if setor_primario_id is None and setor_ids:
+            setor_primario_id = setor_ids[0]
+
         if not estabelecimento_id:
             if setor_ids:
                 setor_obj = Setor.query.get(setor_ids[0])
@@ -643,9 +664,9 @@ def admin_usuarios():
                     usr.data_nascimento = data_nascimento
                     usr.data_admissao = data_admissao
                     usr.estabelecimento_id = estabelecimento_id
-                    usr.setor_id = setor_ids[0] if setor_ids else None
+                    usr.setor_id = setor_primario_id
                     usr.cargo_id = cargo_id
-                    usr.celula_id = celula_ids[0] if celula_ids else None
+                    usr.celula_id = celula_primaria_id
                     usr.extra_setores = []
                     usr.extra_celulas = []
                     usr.extra_setores = [Setor.query.get(sid) for sid in setor_ids]
@@ -678,9 +699,9 @@ def admin_usuarios():
                         data_nascimento=data_nascimento,
                         data_admissao=data_admissao,
                         estabelecimento_id=estabelecimento_id,
-                        setor_id=setor_ids[0] if setor_ids else None,
+                        setor_id=setor_primario_id,
                         cargo_id=cargo_id,
-                        celula_id=celula_ids[0] if celula_ids else None,
+                        celula_id=celula_primaria_id,
                     )
                     app.logger.debug("Creating new user record")
                     usr.set_password(password)

--- a/core/utils.py
+++ b/core/utils.py
@@ -649,6 +649,8 @@ def user_can_view_article(user, article):
         return True
     if user.celula_id and article.extra_celulas.filter_by(id=user.celula_id).count():
         return True
+    if any(article.extra_celulas.filter_by(id=c.id).count() for c in user.extra_celulas.all()):
+        return True
 
     vis = article.visibility
 
@@ -663,6 +665,8 @@ def user_can_view_article(user, article):
             return True
     elif vis is ArticleVisibility.SETOR:
         if user_setor and article.setor_id == user_setor.id:
+            return True
+        if article.setor_id and user.extra_setores.filter_by(id=article.setor_id).count():
             return True
     elif vis is ArticleVisibility.CELULA:
         # Usa a célula explícita de visibilidade se definida; caso contrário,

--- a/tests/test_admin_usuarios.py
+++ b/tests/test_admin_usuarios.py
@@ -256,6 +256,51 @@ def test_user_defaults_from_cargo(client):
         assert usr.celula_id == ids['cel']
 
 
+def test_user_defaults_from_cargo_with_multiple_setores_and_celulas_keeps_consistency(client):
+    login_admin(client)
+    ids = client.base_ids
+    with app.app_context():
+        est = Estabelecimento.query.get(ids['est'])
+        setor_1 = Setor.query.get(ids['setor'])
+        cel_1 = Celula.query.get(ids['cel'])
+        cel_2_mesmo_setor = Celula(nome='Cel 2 Setor 1', estabelecimento_id=est.id, setor_id=setor_1.id)
+        setor_2 = Setor(nome='Setor 2', estabelecimento_id=est.id)
+        db.session.add_all([cel_2_mesmo_setor, setor_2])
+        db.session.flush()
+        cel_3_setor_2 = Celula(nome='Cel 3 Setor 2', estabelecimento_id=est.id, setor_id=setor_2.id)
+        db.session.add(cel_3_setor_2)
+        db.session.flush()
+
+        cargo = Cargo(nome='Gestor Multi', ativo=True)
+        cargo.default_setores.extend([setor_1, setor_2])
+        cargo.default_celulas.extend([cel_1, cel_2_mesmo_setor, cel_3_setor_2])
+        db.session.add(cargo)
+        db.session.commit()
+        cargo_id = cargo.id
+        setor_1_id = setor_1.id
+        setor_2_id = setor_2.id
+        cel_1_id = cel_1.id
+        cel_2_id = cel_2_mesmo_setor.id
+        cel_3_id = cel_3_setor_2.id
+
+    response = client.post('/admin/usuarios', data={
+        'username': 'gestormulti',
+        'email': 'gestormulti@example.com',
+        'ativo_check': 'on',
+        'cargo_id': cargo_id
+    }, follow_redirects=True)
+    assert response.status_code == 200
+
+    with app.app_context():
+        usr = User.query.filter_by(username='gestormulti').first()
+        assert usr is not None
+        assert usr.cargo_id == cargo_id
+        assert usr.celula_id is not None
+        assert usr.setor_id == usr.celula.setor_id
+        assert {s.id for s in usr.extra_setores.all()} == {setor_1_id, setor_2_id}
+        assert {c.id for c in usr.extra_celulas.all()} == {cel_1_id, cel_2_id, cel_3_id}
+
+
 def test_get_permissoes_combinadas(client):
     login_admin(client)
     ids = client.base_ids

--- a/tests/test_article_visibility.py
+++ b/tests/test_article_visibility.py
@@ -281,3 +281,101 @@ def test_user_cannot_view_wrong_instituicao(client):
 
         assert user_can_view_article(user2, art) is False
 
+
+def test_user_can_view_setor_visibility_via_extra_setor_herdado(client):
+    from core.utils import user_can_view_article
+    with app.app_context():
+        user = User.query.first()
+        est = user.estabelecimento
+        setor_extra = Setor(nome='Setor Extra', estabelecimento=est)
+        db.session.add(setor_extra)
+        db.session.flush()
+        cel_extra = Celula(nome='Celula Extra', estabelecimento=est, setor=setor_extra)
+        db.session.add(cel_extra)
+        db.session.flush()
+
+        user.extra_setores.append(setor_extra)
+
+        art = Article(
+            titulo='T9',
+            texto='C9',
+            user_id=user.id,
+            celula_id=user.celula_id,
+            visibility=ArticleVisibility.SETOR,
+            setor_id=setor_extra.id,
+        )
+        db.session.add(art)
+        db.session.commit()
+
+        assert user_can_view_article(user, art) is True
+
+
+def test_celula_visibility_does_not_leak_to_another_celula_same_setor(client):
+    from core.utils import user_can_view_article
+    with app.app_context():
+        user1 = User.query.first()
+        est = user1.estabelecimento
+        setor = user1.setor
+        cel2 = Celula(nome='Celula 2 mesmo setor', estabelecimento=est, setor=setor)
+        db.session.add(cel2)
+        db.session.flush()
+
+        user2 = User(
+            username='u9',
+            email='u9@test',
+            password_hash='x',
+            estabelecimento=est,
+            setor=setor,
+            celula=cel2,
+        )
+        db.session.add(user2)
+
+        art = Article(
+            titulo='T10',
+            texto='C10',
+            user_id=user1.id,
+            celula_id=user1.celula_id,
+            visibility=ArticleVisibility.CELULA,
+            vis_celula_id=user1.celula_id,
+        )
+        db.session.add(art)
+        db.session.commit()
+
+        assert user_can_view_article(user2, art) is False
+
+
+def test_regression_visibility_celula_only_matching_celula_id_or_extra_celulas(client):
+    from core.utils import user_can_view_article
+    with app.app_context():
+        author = User.query.first()
+        est = author.estabelecimento
+        setor = author.setor
+        cel2 = Celula(nome='Celula B', estabelecimento=est, setor=setor)
+        db.session.add(cel2)
+        db.session.flush()
+        viewer = User(
+            username='u10',
+            email='u10@test',
+            password_hash='x',
+            estabelecimento=est,
+            setor=setor,
+            celula=author.celula,
+        )
+        db.session.add(viewer)
+        db.session.flush()
+
+        art = Article(
+            titulo='T11',
+            texto='C11',
+            user_id=author.id,
+            celula_id=author.celula_id,
+            visibility=ArticleVisibility.CELULA,
+            vis_celula_id=cel2.id,
+        )
+        db.session.add(art)
+        db.session.commit()
+
+        assert user_can_view_article(viewer, art) is False
+        viewer.extra_celulas.append(cel2)
+        db.session.commit()
+        assert user_can_view_article(viewer, art) is True


### PR DESCRIPTION
### Motivation

- Garantir que ao criar/editar usuários os vínculos organizacionais (`setor_id`, `celula_id`, `extra_setores`, `extra_celulas`) sejam gravados de forma consistente quando herdados de um `Cargo` com múltiplos setores/células.
- Corrigir a lógica de visibilidade de artigos para suportar usuários que herdam múltiplas células/setores sem permitir vazamento de visibilidade entre células do mesmo setor.

### Description

- Em `blueprints/admin.py` normalizei as `celula_ids` recebidas, resolvi as células existentes, derivei/uni os `setor_ids` a partir das células e determinei um `setor_primario_id` consistente com a `celula_primaria_id` antes de persistir o `User`.
- Mantive e preenchi `usr.setor_id`, `usr.celula_id`, `usr.extra_setores` e `usr.extra_celulas` de forma determinística tanto na criação quanto na edição do usuário, respeitando defaults herdados do `Cargo`.
- Em `core/utils.py` atualizei `user_can_view_article` para que: a) permissões extras via `article.extra_celulas` considerem interseção com `user.extra_celulas`, e b) a visibilidade `SETOR` também leve em conta `user.extra_setores` além do setor primário.
- Adicionei/ajustei testes nas suítes `tests/test_admin_usuarios.py` e `tests/test_article_visibility.py` cobrindo múltiplas células no mesmo setor, múltiplos setores herdados do cargo e a garantia de que `visibility=CELULA` só permite acesso para `celula_id`/`extra_celulas` correspondentes.

### Testing

- Executei `pytest -q tests/test_admin_usuarios.py tests/test_article_visibility.py` e a execução final retornou com todos os testes verdes.
- As alterações foram validadas por testes unitários que cobrem criação/edição de usuário com defaults de cargo e cenários de visibilidade por célula/setor envolvendo vínculos extras do usuário.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2ef94b4c832e9882109683988782)