### PR TITLE
Refatora layout base para footer sticky e main semântico

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -13,8 +13,15 @@
     
     <style>
         /* === ESTILOS GLOBAIS PARA LAYOUT COM NAVBAR FIXA E SIDEBAR FIXA/OFFCANVAS === */
+        html, body {
+            height: 100%;
+        }
+
         body {
             margin: 0;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
             background-color: var(--page-bg); /* Ajuste conforme tema */
         }
 
@@ -100,15 +107,18 @@
             }
         }
 
-        .main-page-content-wrapper {
-            /* Este wrapper agora só precisa existir, o padding está no body */
-        }
         .main-page-content {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            min-height: 0;
             padding: 1.5rem; /* Espaçamento interno do conteúdo */
             background-color: var(--content-bg);
             color: var(--text-default);
-            /* Para garantir que o conteúdo não seja muito baixo em páginas curtas */
-            min-height: calc(100vh - 56px - 3rem); /* Altura da viewport - navbar - (padding-top+bottom do .main-page-content) */
+        }
+
+        footer {
+            margin-top: auto;
         }
         #flash-container { margin-bottom: 1.5rem; }
 
@@ -349,7 +359,7 @@
         </div>
     {% endif %} {# Fim do if de layout logado em páginas não-auth #}
 
-    <div class="main-page-content-wrapper">
+    <main class="main-page-content">
         {% if not is_auth_local_flash_page %}
         {# Flash messages globais exibidas fora do card apenas para páginas sem flash local #}
         <div id="flash-container" class="container-fluid">
@@ -358,9 +368,9 @@
         {% endif %}
 
         {% block content %}{% endblock content %}
-    </div>
+    </main>
 
-    <footer class="border-top bg-body-tertiary py-3 mt-4">
+    <footer class="border-top bg-body-tertiary py-3">
         <div class="container-fluid d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">
             <small class="text-muted">&copy; 2026 Orquetask</small>
             <button type="button" class="btn btn-link btn-sm p-0 text-decoration-underline" data-cookie-open-preferences="true">


### PR DESCRIPTION
### Motivation
- Garantir que o layout ocupe toda a altura da viewport e que o rodapé fique "sticky" sem depender de utilitários de margem, mantendo navbar e sidebar fixas funcionando corretamente.
- Consolidar a convenção de classes do conteúdo principal para evitar divergência entre wrappers e facilitar comportamento flexível do layout.

### Description
- Ajusta estilos globais adicionando `html, body { height: 100%; }` e transformando o `body` em container flex vertical com `min-height: 100vh` para estruturar o layout por colunas.
- Substitui o wrapper `div.main-page-content-wrapper` por um elemento semântico `main` com `class="main-page-content"` e aplica `flex: 1` para que ocupe o espaço disponível.
- Atualiza a regra `.main-page-content` para `display: flex; flex-direction: column; flex: 1; min-height: 0;` e mantém o `padding` e as cores de fundo do conteúdo.
- Garante o comportamento do rodapé com `footer { margin-top: auto; }` e remove a dependência de `mt-4` no HTML.
- Preserva a lógica de layout autenticado (`has-sidebar-layout`) e os `padding-top`/`padding-left` condicionais para manter navbar/sidebar fixas e a altura útil correta.

### Testing
- Nenhum teste automatizado foi executado nesta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea33be10b4832ebff3c309e680aadc)