### PR TITLE
Adjust viewport handling for login and replace global spacing with opt-in classes

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -234,8 +234,8 @@
   text-overflow: ellipsis;
 }
 
-/* dá espaço extra abaixo do conteúdo principal */
-body > .container {
+/* Espaçamento opt-in por tela para evitar efeitos globais */
+.page-content-bottom-space {
   padding-bottom: 2rem;
 }
 
@@ -247,8 +247,8 @@ body > .container {
   background-color: var(--bg-hover-subtle);
 }
 
-/* ou, se quiser empurrar só o card do artigo */
-.card.shadow-sm {
+/* Espaçamento opt-in para cards específicos */
+.card-screen-spacing {
   margin-bottom: 2rem;
 }
 
@@ -289,7 +289,8 @@ body > .container {
 }
 
 .login-page {
-  min-height: 100vh;
+  flex: 1 1 auto;
+  min-height: 100%;
   padding: 2rem 1rem;
   background: linear-gradient(135deg, var(--page-bg) 0%, rgba(13, 110, 253, 0.08) 100%);
   color: var(--text-default);

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,6 +20,7 @@
         body {
             margin: 0;
             min-height: 100vh;
+            min-height: 100dvh;
             display: flex;
             flex-direction: column;
             background-color: var(--page-bg); /* Ajuste conforme tema */
@@ -90,7 +91,7 @@
                 position: fixed;
                 top: 56px;  /* <<< CORRIGIDO: COMEÇA ABAIXO DA NAVBAR (ajuste 56px se a altura da sua navbar for outra) */
                 left: 0;
-                height: calc(100vh - 56px); /* <<< CORRIGIDO: ALTURA RESTANTE (ajuste 56px) */
+                height: calc(100dvh - 56px); /* <<< CORRIGIDO: ALTURA RESTANTE (ajuste 56px) */
                 width: 280px;
                 transform: none !important;
                 visibility: visible !important;
@@ -359,7 +360,7 @@
         </div>
     {% endif %} {# Fim do if de layout logado em páginas não-auth #}
 
-    <main class="main-page-content">
+    <main class="main-page-content main-content">
         {% if not is_auth_local_flash_page %}
         {# Flash messages globais exibidas fora do card apenas para páginas sem flash local #}
         <div id="flash-container" class="container-fluid">


### PR DESCRIPTION
### Motivation
- Prevent unwanted vertical scroll on short pages (login, empty dashboards) by using dynamic viewport sizing instead of forcing `100vh`.
- Remove aggressive global spacing rules that cause side effects across unrelated screens.
- Prefer `dvh`/`100dvh`-based measurements for more correct mobile viewport behavior.

### Description
- Update `templates/base.html` to add `min-height: 100dvh` on `body`, change the desktop sidebar height to `calc(100dvh - 56px)`, and expose `main-content` on the main area by adding the `main-content` class to `<main>`.
- Replace global CSS spacing rules in `static/css/custom.css`: remove `body > .container { padding-bottom: 2rem; }` and `.card.shadow-sm { margin-bottom: 2rem; }` and add opt-in utilities `.page-content-bottom-space` and `.card-screen-spacing` instead.
- Change `.login-page` to `flex: 1 1 auto` with `min-height: 100%` so it fills the available main area without forcing viewport overflow.

### Testing
- Verified the expected selectors and replacements with `rg -n "\.page-content-bottom-space|\.card-screen-spacing|\.login-page|100dvh|main-content" static/css/custom.css templates/base.html` and confirmed matches were present (success).
- Confirmed legacy global selectors were removed with the check `if rg -n "body > \.container|\.card\.shadow-sm\s*\{" static/css/custom.css; then exit 1; else echo "legacy global selectors removed"; fi` which reported the selectors removed (success).
- Performed a repository diff/stat verification via `git show --stat --oneline HEAD` to review modified files and changes (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea358bceb8832e89f819055567f985)