### PR TITLE
Refina layout e espaçamento da página de login

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -289,19 +289,32 @@
 }
 
 .login-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   flex: 1 1 auto;
   min-height: 100%;
-  padding: 2rem 1rem;
+  padding: 0.5rem;
   background: linear-gradient(135deg, var(--page-bg) 0%, rgba(13, 110, 253, 0.08) 100%);
   color: var(--text-default);
 }
 
 .login-card {
-  max-width: 450px;
-  width: 100%;
+  width: min(100%, 460px);
   border-radius: 1.25rem;
+  margin: 0;
   background-color: var(--content-bg);
+  border: 0;
   box-shadow: 0 20px 55px var(--shadow-soft);
+}
+
+#login-flash-messages {
+  margin-bottom: 1rem;
+}
+
+#login-flash-messages:empty {
+  display: none;
+  margin: 0;
 }
 
 .login-brand img {
@@ -343,7 +356,7 @@
 
 @media (max-width: 576px) {
   .login-page {
-    padding: 1.5rem 0.75rem;
+    padding: 0.25rem;
   }
 
   .login-card {

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -8,9 +8,9 @@ data-remembered-username="{{ remembered_user.username if remembered_user else ''
 {% block title %}Login{% endblock %}
 
 {% block content %}
-  <div class="login-page d-flex align-items-center justify-content-center">
-    <div class="login-card card border-0 shadow-lg">
-      <div class="card-body p-4 p-md-5">
+  <div class="login-page">
+    <div class="login-card card">
+      <div class="card-body p-3 p-md-4">
         <div class="login-brand text-center mb-4">
           <img src="{{ url_for('static', filename='icons/sua_logo.png') }}" class="login-logo mb-2 invert-on-dark" alt="Logo Orquetask">
           <div>
@@ -19,16 +19,18 @@ data-remembered-username="{{ remembered_user.username if remembered_user else ''
           </div>
         </div>
 
-        {% with messages = get_flashed_messages(with_categories=true) %}
-          {% if messages %}
-            {% for category, message in messages %}
-              <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
-                {{ message }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-              </div>
-            {% endfor %}
-          {% endif %}
-        {% endwith %}
+        <div id="login-flash-messages">
+          {% with messages = get_flashed_messages(with_categories=true) %}
+            {% if messages %}
+              {% for category, message in messages %}
+                <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
+                  {{ message }}
+                  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                </div>
+              {% endfor %}
+            {% endif %}
+          {% endwith %}
+        </div>
 
         <div id="user-photo" class="mb-4 text-center login-avatar">
           <i class="bi bi-person-circle"></i>


### PR DESCRIPTION
### Motivation
- Simplificar a estrutura da tela de login para manter apenas um wrapper de página e um card, delegando centralização e dimensionamento ao CSS.
- Eliminar espaçamento invisível causado por contêineres de mensagens flash quando não há mensagens, complementando a limpeza feita por JS com CSS.

### Description
- Simplifiquei `templates/auth/login.html` removendo classes utilitárias duplicadas do wrapper e do card e reduzindo o padding interno do card para `p-3 p-md-4`.
- Adicionei um contêiner dedicado `#login-flash-messages` em `templates/auth/login.html` para isolar mensagens flash locais dentro do card.
- Atualizei `static/css/custom.css` para tornar `.login-page` um flex container centralizado com `display:flex; align-items:center; justify-content:center;` e reduzir o padding externo para evitar altura inflada do contêiner principal.
- Tornei o card mais responsivo definindo `width: min(100%, 460px)`, removendo margens externas (`margin: 0`) e retirando a borda para controle visual mais consistente; adicionei `#login-flash-messages:empty { display: none; }` para evitar espaços quando não houver flashes.

### Testing
- Executei `git diff --check` para verificar problemas de whitespace e formatação, sem resultados problemáticos (sucesso).
- Conferi o estado dos arquivos com `git status --short` para validar as alterações, mostrando apenas os arquivos esperados (sucesso).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea381e10a4832e8573e4b7e8f89e94)