### PR TITLE
Refine hierarchical cargos tree and unify hierarchy styles (admin)

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -15,6 +15,13 @@
   --border-darker: #d0d7de;
   --highlight-color: #ffe69c;
   --section-header-bg: #eef1f6;
+  --hier-surface: #ffffff;
+  --hier-surface-muted: #f8fafc;
+  --hier-border: #dde3ea;
+  --hier-hover: rgba(13, 110, 253, 0.08);
+  --hier-active-bg: rgba(13, 110, 253, 0.14);
+  --hier-active-border: rgba(13, 110, 253, 0.36);
+  --hier-indent-step: 1.1rem;
   --overlay-light: rgba(255, 255, 255, 0.7);
   --shadow-soft: rgba(0,0,0,0.05);
   --shadow-muted: rgba(0,0,0,0.04);
@@ -37,6 +44,12 @@
   --border-darker: #333;
   --highlight-color: #665c00;
   --section-header-bg: #3b3b3b;
+  --hier-surface: #242424;
+  --hier-surface-muted: #2c2c2c;
+  --hier-border: #3f3f3f;
+  --hier-hover: rgba(141, 181, 255, 0.14);
+  --hier-active-bg: rgba(13, 110, 253, 0.24);
+  --hier-active-border: rgba(141, 181, 255, 0.5);
   --overlay-light: rgba(0,0,0,0.7);
   --shadow-soft: rgba(0,0,0,0.5);
   --shadow-muted: rgba(0,0,0,0.6);
@@ -428,70 +441,130 @@
   transition: none;
 }
 
-.instituicao-container {
-  margin-bottom: 1.5rem;
+.cargo-tree {
+  margin-top: 0.5rem;
 }
 
-.estabelecimento-wrapper {
-  background-color: var(--bg-muted) !important;
-  border: 1px solid var(--border-default);
-  border-radius: 0.25rem;
-  padding: 0.75rem;
-  margin-bottom: 1rem;
+.hier-node {
+  background-color: transparent;
 }
 
-.instituicao-container .estabelecimento-wrapper:first-child {
-  margin-top: 1rem;
+.hier-header {
+  min-height: 2.2rem;
+  border-radius: 0.45rem;
+  padding: 0.3rem 0.45rem;
+  transition: background-color .2s ease;
 }
 
-.instituicao-container .estabelecimento-wrapper:first-child {
-  margin-top: 1rem;
+.hier-header:hover {
+  background-color: var(--hier-hover);
 }
 
-.estabelecimento-wrapper {
-  background-color: #f8f9fa;
-}
-.setor-container {
-  margin-left: 1rem;
-  margin-bottom: 0.5rem;
-  padding: 0.5rem;
-  background-color: var(--bg-default) !important;
-  border: 1px solid var(--border-light);
-  border-radius: 0.25rem;
+.hier-level-icon {
+  color: var(--text-default);
+  opacity: 0.75;
+  font-size: 0.95rem;
 }
 
+.hier-title {
+  color: var(--text-default);
+  line-height: 1.2;
+}
+
+.level-instituicao > .hier-header .hier-title {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.level-estabelecimento > .hier-header .hier-title {
+  font-size: 0.93rem;
+  font-weight: 600;
+}
+
+.level-setor > .hier-header .hier-title,
+.level-celula > .hier-header .hier-title {
+  font-size: 0.88rem;
+  font-weight: 500;
+}
+
+.hier-children {
+  margin-left: var(--hier-indent-step);
+  padding-left: 0.45rem;
+}
+
+.level-instituicao {
+  margin-bottom: 0.75rem;
+  padding: 0.45rem 0.4rem;
+  border: 1px solid var(--hier-border);
+  border-radius: 0.55rem;
+  background: var(--hier-surface);
+}
+
+.estabelecimento-wrapper,
+.setor-container,
 .celula-container {
-  margin-left: 2rem;
-  margin-bottom: 0.5rem;
-  border-left: 1px solid var(--border-default);
-  padding-left: 1rem;
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
-  background-color: var(--bg-muted) !important;
+  margin-top: 0.35rem;
+  margin-bottom: 0.35rem;
+}
+
+.cargo-list {
+  margin-left: calc(var(--hier-indent-step) * 0.9);
 }
 
 .cargo-item {
-  margin-left: 3rem;
-  margin-bottom: 0.25rem;
-  border-left: 1px solid var(--border-lighter);
-  padding-left: 1rem;
-  background-color: var(--bg-default) !important;
+  border: 1px solid transparent !important;
+  border-radius: 0.45rem !important;
+  margin: 0.25rem 0;
+  padding: 0.45rem 0.6rem;
+  background-color: var(--hier-surface-muted) !important;
+  transition: background-color .15s ease, border-color .15s ease;
+}
+
+.cargo-item:hover {
+  background-color: var(--hier-hover) !important;
+}
+
+.cargo-item.is-active {
+  background-color: var(--hier-active-bg) !important;
+  border-color: var(--hier-active-border) !important;
+}
+
+.cargo-icon {
+  font-size: 0.8rem;
+  opacity: 0.7;
 }
 
 .linha-cargo {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 0.75rem;
+}
+
+.cargo-meta {
+  min-width: 0;
 }
 
 .nome-cargo {
   cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .acoes-cargo {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.35rem;
+  margin-left: auto;
+}
+
+.cargo-action-btn {
+  --bs-btn-padding-y: 0.12rem;
+  --bs-btn-padding-x: 0.38rem;
+  --bs-btn-font-size: 0.76rem;
+  --bs-btn-border-radius: 0.38rem;
+  --bs-btn-line-height: 1.1;
 }
 
 .search-highlight {

--- a/templates/admin/cargos.html
+++ b/templates/admin/cargos.html
@@ -34,97 +34,98 @@
                                         <button class="btn btn-outline-secondary d-none" type="button" id="toggleTree">Voltar à visualização em árvore</button>
                                     </div>
                                 </div>
-                                <div class="ms-2" id="cargoContainer">
+                                <div class="cargo-tree" id="cargoContainer">
                                     {% for inst in estrutura %}
-                                        <div class="card mb-2 instituicao-container">
-                                            <div class="card-header d-flex align-items-center">
-                                                <button class="btn btn-sm btn-link p-0 me-2 toggle-section caret-toggle expanded" data-level="setores" data-bs-toggle="collapse" data-bs-target="#inst-{{ inst.obj.id }}" aria-expanded="true"><i class="bi bi-caret-right-fill"></i></button>
-                                                <h5 class="mb-0">Instituição: <span class="inst-name" data-name="{{ inst.obj.nome }}">{{ inst.obj.nome }}</span></h5>
-                                            </div>
-                                            <div id="inst-{{ inst.obj.id }}" class="collapse show">
+                                        <section class="hier-node level-instituicao instituicao-container">
+                                            <header class="hier-header d-flex align-items-center">
+                                                <button class="btn btn-sm btn-link p-0 me-2 toggle-section caret-toggle expanded" data-level="estabelecimentos" data-bs-toggle="collapse" data-bs-target="#inst-{{ inst.obj.id }}" aria-expanded="true"><i class="bi bi-caret-right-fill"></i></button>
+                                                <i class="bi bi-building me-2 hier-level-icon" aria-hidden="true"></i>
+                                                <h5 class="mb-0 hier-title">Instituição <span class="inst-name" data-name="{{ inst.obj.nome }}">{{ inst.obj.nome }}</span></h5>
+                                            </header>
+                                            <div id="inst-{{ inst.obj.id }}" class="collapse show hier-children">
                                                 {% for est in inst.estabelecimentos %}
-                                                    <div class="ms-4 mb-3 p-2 border rounded estabelecimento-wrapper">
-                                                        <h6 class="fw-bold">Estabelecimento: <span class="est-name" data-name="{{ est.obj.nome_fantasia }}">{{ est.obj.nome_fantasia }}</span></h6>
-                                                        <div class="estabelecimento-conteudo mt-2">
+                                                    <article class="hier-node level-estabelecimento estabelecimento-wrapper">
+                                                        <header class="hier-header d-flex align-items-center">
+                                                            <button class="btn btn-sm btn-link p-0 me-2 toggle-section caret-toggle expanded" data-level="setores" data-bs-toggle="collapse" data-bs-target="#est-{{ est.obj.id }}" aria-expanded="true"><i class="bi bi-caret-right-fill"></i></button>
+                                                            <i class="bi bi-shop me-2 hier-level-icon" aria-hidden="true"></i>
+                                                            <h6 class="mb-0 hier-title">Estabelecimento <span class="est-name" data-name="{{ est.obj.nome_fantasia }}">{{ est.obj.nome_fantasia }}</span></h6>
+                                                        </header>
+                                                        <div id="est-{{ est.obj.id }}" class="collapse show hier-children">
                                                             {% for setor in est.setores %}
-                                                            <div class="setor-container p-2 mb-2 rounded">
-                                                                <div class="d-flex align-items-center">
-                                                                    <button class="btn btn-sm btn-link p-0 me-2 toggle-section caret-toggle expanded" data-level="celulas" data-bs-toggle="collapse" data-bs-target="#setor-{{ setor.obj.id }}" aria-expanded="true"><i class="bi bi-caret-right-fill"></i></button>
-                                                                    <strong class="mb-0">Setor: <span class="setor-name" data-name="{{ setor.obj.nome }}">{{ setor.obj.nome }}</span></strong>
-                                                                </div>
-                                                                <div id="setor-{{ setor.obj.id }}" class="ms-3 collapse show">
-                                                                    {% if setor.cargos %}
-                                                                        <ul class="list-group list-group-flush mb-2">
-                                                                            {% for cargo in setor.cargos %}
-                                                                                <li class="list-group-item cargo-item {{ 'text-muted' if not cargo.ativo else '' }}" data-cargo="{{ cargo.nome }}" data-setor="{{ setor.obj.nome }}" data-celula="" data-instituicao="{{ inst.obj.nome }}">
-                                                                                    <div class="linha-cargo">
-                                                                                        <div class="nome-cargo cargo-name" data-name="{{ cargo.nome }}" data-url="{{ url_for('admin_cargos', edit_id=cargo.id) }}#cadastro">{{ cargo.nome }}</div>
-                                                                                        <div class="acoes-cargo">
-                                                                                        {% set confirm_message_text = 'DESATIVAR' if cargo.ativo else 'ATIVAR' %}
-                                                                                        {% set cargo_nome_js = cargo.nome | tojson %}
-                                                                                        <form action="{{ url_for('admin_toggle_ativo_cargo', id=cargo.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_message_text }} o cargo ' + {{ cargo_nome_js }} + '?');">
-                                                                                            {% if cargo.ativo %}
-                                                                                                <button type="submit" class="btn btn-sm btn-outline-warning" title="Desativar Cargo">
-                                                                                                    <i class="bi bi-toggle-on"></i>
+                                                                <section class="hier-node level-setor setor-container">
+                                                                    <header class="hier-header d-flex align-items-center">
+                                                                        <button class="btn btn-sm btn-link p-0 me-2 toggle-section caret-toggle expanded" data-level="celulas" data-bs-toggle="collapse" data-bs-target="#setor-{{ setor.obj.id }}" aria-expanded="true"><i class="bi bi-caret-right-fill"></i></button>
+                                                                        <i class="bi bi-diagram-3 me-2 hier-level-icon" aria-hidden="true"></i>
+                                                                        <h6 class="mb-0 hier-title">Setor <span class="setor-name" data-name="{{ setor.obj.nome }}">{{ setor.obj.nome }}</span></h6>
+                                                                    </header>
+                                                                    <div id="setor-{{ setor.obj.id }}" class="collapse show hier-children">
+                                                                        {% if setor.cargos %}
+                                                                            <ul class="list-group list-group-flush mb-2 cargo-list">
+                                                                                {% for cargo in setor.cargos %}
+                                                                                    <li class="list-group-item cargo-item {{ 'text-muted' if not cargo.ativo else '' }}" data-cargo="{{ cargo.nome }}" data-setor="{{ setor.obj.nome }}" data-celula="" data-instituicao="{{ inst.obj.nome }}">
+                                                                                        <div class="linha-cargo">
+                                                                                            <div class="cargo-meta d-flex align-items-center">
+                                                                                                <i class="bi bi-briefcase me-2 cargo-icon" aria-hidden="true"></i>
+                                                                                                <div class="nome-cargo cargo-name" data-name="{{ cargo.nome }}" data-url="{{ url_for('admin_cargos', edit_id=cargo.id) }}#cadastro">{{ cargo.nome }}</div>
+                                                                                            </div>
+                                                                                            <div class="acoes-cargo">
+                                                                                            {% set confirm_message_text = 'DESATIVAR' if cargo.ativo else 'ATIVAR' %}
+                                                                                            {% set cargo_nome_js = cargo.nome | tojson %}
+                                                                                            <form action="{{ url_for('admin_toggle_ativo_cargo', id=cargo.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_message_text }} o cargo ' + {{ cargo_nome_js }} + '?');">
+                                                                                                <button type="submit" class="btn btn-sm cargo-action-btn {{ 'btn-outline-secondary' if cargo.ativo else 'btn-outline-primary' }}" title="{{ 'Desativar Cargo' if cargo.ativo else 'Ativar Cargo' }}">
+                                                                                                    <i class="bi {{ 'bi-toggle-on' if cargo.ativo else 'bi-toggle-off' }}"></i>
                                                                                                 </button>
-                                                                                            {% else %}
-                                                                                                <button type="submit" class="btn btn-sm btn-outline-success" title="Ativar Cargo">
-                                                                                                    <i class="bi bi-toggle-off"></i>
-                                                                                                </button>
-                                                                                            {% endif %}
-                                                                                        </form>
+                                                                                            </form>
+                                                                                            </div>
                                                                                         </div>
-                                                                                    </div>
-                                                                                </li>
-                                                                            {% endfor %}
-                                                                        </ul>
-                                                                    {% endif %}
-                                                                    {% for cel in setor.celulas %}
-                                                                        <div class="celula-container ps-3 mb-2">
-                                                                            <div class="d-flex align-items-center">
-                                                                                <button class="btn btn-sm btn-link p-0 me-2 toggle-section caret-toggle expanded" data-level="cargos" data-bs-toggle="collapse" data-bs-target="#cel-{{ cel.obj.id }}" aria-expanded="true"><i class="bi bi-caret-right-fill"></i></button>
-                                                                                <span class="fw-bold">Célula: <span class="celula-name" data-name="{{ cel.obj.nome }}">{{ cel.obj.nome }}</span></span>
-                                                                            </div>
-                                                                            <div id="cel-{{ cel.obj.id }}" class="ms-3 collapse show">
-                                                                                {% if cel.cargos %}
-                                                                                    <ul class="list-group list-group-flush">
-                                                                                        {% for cargo in cel.cargos %}
-                                                                                            <li class="list-group-item cargo-item {{ 'text-muted' if not cargo.ativo else '' }}" data-cargo="{{ cargo.nome }}" data-setor="{{ setor.obj.nome }}" data-celula="{{ cel.obj.nome }}" data-instituicao="{{ inst.obj.nome }}">
-                                                                                                <div class="linha-cargo">
-                                                                                                    <div class="nome-cargo cargo-name" data-name="{{ cargo.nome }}" data-url="{{ url_for('admin_cargos', edit_id=cargo.id) }}#cadastro">{{ cargo.nome }}</div>
-                                                                                                    <div class="acoes-cargo">
-                                                                                                        {% set confirm_message_text = 'DESATIVAR' if cargo.ativo else 'ATIVAR' %}
-                                                                                                        {% set cargo_nome_js = cargo.nome | tojson %}
-                                                                                                        <form action="{{ url_for('admin_toggle_ativo_cargo', id=cargo.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_message_text }} o cargo ' + {{ cargo_nome_js }} + '?');">
-                                                                                                            {% if cargo.ativo %}
-                                                                                                                <button type="submit" class="btn btn-sm btn-outline-warning" title="Desativar Cargo">
-                                                                                                                    <i class="bi bi-toggle-on"></i>
+                                                                                    </li>
+                                                                                {% endfor %}
+                                                                            </ul>
+                                                                        {% endif %}
+                                                                        {% for cel in setor.celulas %}
+                                                                            <section class="hier-node level-celula celula-container">
+                                                                                <header class="hier-header d-flex align-items-center">
+                                                                                    <button class="btn btn-sm btn-link p-0 me-2 toggle-section caret-toggle expanded" data-level="cargos" data-bs-toggle="collapse" data-bs-target="#cel-{{ cel.obj.id }}" aria-expanded="true"><i class="bi bi-caret-right-fill"></i></button>
+                                                                                    <i class="bi bi-grid-3x3-gap me-2 hier-level-icon" aria-hidden="true"></i>
+                                                                                    <p class="mb-0 hier-title">Célula <span class="celula-name" data-name="{{ cel.obj.nome }}">{{ cel.obj.nome }}</span></p>
+                                                                                </header>
+                                                                                <div id="cel-{{ cel.obj.id }}" class="collapse show hier-children">
+                                                                                    {% if cel.cargos %}
+                                                                                        <ul class="list-group list-group-flush cargo-list">
+                                                                                            {% for cargo in cel.cargos %}
+                                                                                                <li class="list-group-item cargo-item {{ 'text-muted' if not cargo.ativo else '' }}" data-cargo="{{ cargo.nome }}" data-setor="{{ setor.obj.nome }}" data-celula="{{ cel.obj.nome }}" data-instituicao="{{ inst.obj.nome }}">
+                                                                                                    <div class="linha-cargo">
+                                                                                                        <div class="cargo-meta d-flex align-items-center">
+                                                                                                            <i class="bi bi-briefcase me-2 cargo-icon" aria-hidden="true"></i>
+                                                                                                            <div class="nome-cargo cargo-name" data-name="{{ cargo.nome }}" data-url="{{ url_for('admin_cargos', edit_id=cargo.id) }}#cadastro">{{ cargo.nome }}</div>
+                                                                                                        </div>
+                                                                                                        <div class="acoes-cargo">
+                                                                                                            {% set confirm_message_text = 'DESATIVAR' if cargo.ativo else 'ATIVAR' %}
+                                                                                                            {% set cargo_nome_js = cargo.nome | tojson %}
+                                                                                                            <form action="{{ url_for('admin_toggle_ativo_cargo', id=cargo.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_message_text }} o cargo ' + {{ cargo_nome_js }} + '?');">
+                                                                                                                <button type="submit" class="btn btn-sm cargo-action-btn {{ 'btn-outline-secondary' if cargo.ativo else 'btn-outline-primary' }}" title="{{ 'Desativar Cargo' if cargo.ativo else 'Ativar Cargo' }}">
+                                                                                                                    <i class="bi {{ 'bi-toggle-on' if cargo.ativo else 'bi-toggle-off' }}"></i>
                                                                                                                 </button>
-                                                                                                            {% else %}
-                                                                                                                <button type="submit" class="btn btn-sm btn-outline-success" title="Ativar Cargo">
-                                                                                                                    <i class="bi bi-toggle-off"></i>
-                                                                                                                </button>
-                                                                                                            {% endif %}
-                                                                                                        </form>
+                                                                                                            </form>
+                                                                                                        </div>
                                                                                                     </div>
-                                                                                                </div>
-                                                                                            </li>
-                                                                                        {% endfor %}
-                                                                                    </ul>
-                                                                                {% else %}
-                                                                                    <p class="text-muted ms-3">Nenhum cargo nesta célula.</p>
-                                                                                {% endif %}
-                                                                            </div>
-                                                                        </div>
-                                                                    {% endfor %}
-                                                                </div>
-                                                            </div>
+                                                                                                </li>
+                                                                                            {% endfor %}
+                                                                                        </ul>
+                                                                                    {% else %}
+                                                                                        <p class="text-muted ms-3">Nenhum cargo nesta célula.</p>
+                                                                                    {% endif %}
+                                                                                </div>
+                                                                            </section>
+                                                                        {% endfor %}
+                                                                    </div>
+                                                                </section>
                                                             {% endfor %}
                                                         </div>
-                                                    </div>
+                                                    </article>
                                                 {% endfor %}
                                             </div>
-                                        </div>
+                                        </section>
                                     {% endfor %}
                                 </div>
                                 <div class="d-none" id="graphContainer">
@@ -548,6 +549,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
     document.querySelectorAll('.cargo-name').forEach(function(el) {
         el.addEventListener('click', function() {
+            const cargoItem = el.closest('.cargo-item');
+            if (cargoItem) {
+                document.querySelectorAll('.cargo-item.is-active').forEach(function(item) {
+                    item.classList.remove('is-active');
+                });
+                cargoItem.classList.add('is-active');
+            }
             const url = el.dataset.url;
             if (url) window.location.href = url;
         });


### PR DESCRIPTION
### Motivation
- Replace the ad-hoc accordion/card hierarchy with a consistent semantic tree (instituição > estabelecimento > setor > célula > cargo) to improve discoverability and accessibility.
- Standardize visual language for hierarchy headers using discrete `bi-*` icons and graduated typographic weights so higher levels read stronger and inner levels read lighter.
- Make cargo actions visually quieter and consistently aligned at the right to reduce visual noise and avoid nested “boxes inside boxes”.
- Simplify and consolidate hierarchy-related tokens for light/dark themes to reduce duplication and make spacing/borders predictable.

### Description
- Reworked the hierarchy markup in `templates/admin/cargos.html` to use semantic containers (`section`/`article`) with new classes like `hier-node`, `hier-header`, `hier-children`, and level classes (`level-instituicao`, `level-estabelecimento`, `level-setor`, `level-celula`).
- Added discrete level icons (`bi-building`, `bi-shop`, `bi-diagram-3`, `bi-grid-3x3-gap`, `bi-briefcase`) and adjusted header text classes (`hier-title`) to enforce typographic weight differences.
- Moved cargo action buttons into a right-aligned `acoes-cargo` container and introduced smaller button styling via `cargo-action-btn`, switching to `btn-outline-*` variants to reduce visual aggression.
- Introduced a click-selection visual state by adding JS that toggles `.is-active` on the clicked `.cargo-item`, and added CSS for `.cargo-item:hover` and `.cargo-item.is-active` to provide subtle hover and clear active states.
- Consolidated and added new CSS variables in `static/css/custom.css` (e.g. `--hier-surface`, `--hier-hover`, `--hier-active-bg`, `--hier-indent-step`) and replaced duplicated/overly heavy rules with a simplified, progressive-indentation layout for the hierarchy.

### Testing
- Ran a quick Python syntax check with `python -m py_compile -q app.py`, which completed successfully.
- Manually reviewed the generated diffs to ensure the template and CSS changes are consistent and do not introduce obvious markup/syntax errors.
- No automated unit tests were present for these templates/styles; visual verification is recommended in a browser to confirm spacing/icons/interactive collapse behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea384188d0832ea109afe7400b7ab6)