### PR TITLE
Ajusta indicador visual de status na listagem de cargos

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -543,18 +543,27 @@
 }
 
 .cargo-icon {
-  font-size: 0.8rem;
-  opacity: 0.7;
+  font-size: 0.9rem;
 }
 
 .linha-cargo {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.45rem;
 }
 
 .cargo-meta {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.cargo-meta-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   min-width: 0;
 }
 
@@ -565,11 +574,29 @@
   text-overflow: ellipsis;
 }
 
+.cargo-status {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1;
+}
+
+.cargo-status i {
+  font-size: 0.7rem;
+}
+
+.cargo-status--ativo {
+  color: #22c55e;
+}
+
+.cargo-status--inativo {
+  color: #ef4444;
+}
+
 .acoes-cargo {
   display: flex;
   align-items: center;
   gap: 0.35rem;
-  margin-left: auto;
+  margin-left: 0.35rem;
 }
 
 .cargo-action-btn {

--- a/templates/admin/cargos.html
+++ b/templates/admin/cargos.html
@@ -62,11 +62,16 @@
                                                                         {% if setor.cargos %}
                                                                             <ul class="list-group list-group-flush mb-2 cargo-list">
                                                                                 {% for cargo in setor.cargos %}
-                                                                                    <li class="list-group-item cargo-item {{ 'text-muted' if not cargo.ativo else '' }}" data-cargo="{{ cargo.nome }}" data-setor="{{ setor.obj.nome }}" data-celula="" data-instituicao="{{ inst.obj.nome }}">
+                                                                                    <li class="list-group-item cargo-item" data-cargo="{{ cargo.nome }}" data-setor="{{ setor.obj.nome }}" data-celula="" data-instituicao="{{ inst.obj.nome }}">
                                                                                         <div class="linha-cargo">
-                                                                                            <div class="cargo-meta d-flex align-items-center">
+                                                                                            <div class="cargo-meta">
                                                                                                 <i class="bi bi-briefcase me-2 cargo-icon" aria-hidden="true"></i>
-                                                                                                <div class="nome-cargo cargo-name" data-name="{{ cargo.nome }}" data-url="{{ url_for('admin_cargos', edit_id=cargo.id) }}#cadastro">{{ cargo.nome }}</div>
+                                                                                                <div class="cargo-meta-inline">
+                                                                                                    <div class="nome-cargo cargo-name" data-name="{{ cargo.nome }}" data-url="{{ url_for('admin_cargos', edit_id=cargo.id) }}#cadastro">{{ cargo.nome }}</div>
+                                                                                                    <span class="cargo-status {{ 'cargo-status--ativo' if cargo.ativo else 'cargo-status--inativo' }}" title="{{ 'Ativo' if cargo.ativo else 'Inativo' }}" aria-label="Status: {{ 'Ativo' if cargo.ativo else 'Inativo' }}">
+                                                                                                        <i class="bi bi-circle-fill" aria-hidden="true"></i>
+                                                                                                    </span>
+                                                                                                </div>
                                                                                             </div>
                                                                                             <div class="acoes-cargo">
                                                                                             {% set confirm_message_text = 'DESATIVAR' if cargo.ativo else 'ATIVAR' %}
@@ -93,11 +98,16 @@
                                                                                     {% if cel.cargos %}
                                                                                         <ul class="list-group list-group-flush cargo-list">
                                                                                             {% for cargo in cel.cargos %}
-                                                                                                <li class="list-group-item cargo-item {{ 'text-muted' if not cargo.ativo else '' }}" data-cargo="{{ cargo.nome }}" data-setor="{{ setor.obj.nome }}" data-celula="{{ cel.obj.nome }}" data-instituicao="{{ inst.obj.nome }}">
+                                                                                                <li class="list-group-item cargo-item" data-cargo="{{ cargo.nome }}" data-setor="{{ setor.obj.nome }}" data-celula="{{ cel.obj.nome }}" data-instituicao="{{ inst.obj.nome }}">
                                                                                                     <div class="linha-cargo">
-                                                                                                        <div class="cargo-meta d-flex align-items-center">
+                                                                                                        <div class="cargo-meta">
                                                                                                             <i class="bi bi-briefcase me-2 cargo-icon" aria-hidden="true"></i>
-                                                                                                            <div class="nome-cargo cargo-name" data-name="{{ cargo.nome }}" data-url="{{ url_for('admin_cargos', edit_id=cargo.id) }}#cadastro">{{ cargo.nome }}</div>
+                                                                                                            <div class="cargo-meta-inline">
+                                                                                                                <div class="nome-cargo cargo-name" data-name="{{ cargo.nome }}" data-url="{{ url_for('admin_cargos', edit_id=cargo.id) }}#cadastro">{{ cargo.nome }}</div>
+                                                                                                                <span class="cargo-status {{ 'cargo-status--ativo' if cargo.ativo else 'cargo-status--inativo' }}" title="{{ 'Ativo' if cargo.ativo else 'Inativo' }}" aria-label="Status: {{ 'Ativo' if cargo.ativo else 'Inativo' }}">
+                                                                                                                    <i class="bi bi-circle-fill" aria-hidden="true"></i>
+                                                                                                                </span>
+                                                                                                            </div>
                                                                                                         </div>
                                                                                                         <div class="acoes-cargo">
                                                                                                             {% set confirm_message_text = 'DESATIVAR' if cargo.ativo else 'ATIVAR' %}


### PR DESCRIPTION
### Motivation
- Agrupar visualmente o `status` com o `nome` do cargo para melhorar leitura e evitar que o estado fique separado do rótulo do cargo.
- Evitar aplicar aparência apagada (`text-muted`/opacity) ao item inteiro quando um cargo está inativo para preservar legibilidade e ações.
- Padronizar tamanho e alinhamento do ícone de status e reduzir espaçamento horizontal excessivo na linha do cargo.

### Description
- Atualiza `templates/admin/cargos.html` para mover o indicador de status para dentro de `.cargo-meta` e introduz o wrapper inline `cargo-meta-inline` que agrupa `nome-cargo` + `cargo-status` (com `bi-circle-fill`).
- Remove a aplicação de `text-muted` no `li.cargo-item` e passa a controlar a aparência do status via classes específicas (`cargo-status--ativo`, `cargo-status--inativo`).
- Atualiza `static/css/custom.css` para remover `opacity` do `.cargo-icon`, ajustar `font-size` do ícone, tornar `.cargo-meta` `inline-flex` com `width: fit-content`, reduzir `gap` em `.linha-cargo` e ajustar `margin-left` de `.acoes-cargo`.
- Adiciona estilos para `.cargo-status` e as classes de estado com cores fortes: `#22c55e` para ativo e `#ef4444` para inativo, além de um tamanho fixo para o ícone de status.

### Testing
- Executado `git -C /workspace/repositorio_equipe diff --check HEAD^ HEAD` e não retornou problemas (sucesso).
- Executado `git -C /workspace/repositorio_equipe show --stat --oneline HEAD` para inspecionar o resumo das alterações (sucesso).
- Commit das alterações foi criado com `git` sem erros (sucesso).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea52c7139c832e976641e72ef8b426)