### PR TITLE
Add cookie icon to footer preferences button

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -384,8 +384,9 @@
     <footer class="border-top bg-body-tertiary py-3">
         <div class="container-fluid d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">
             <small class="text-muted">&copy; 2026 Orquetask</small>
-            <button type="button" class="btn btn-link btn-sm p-0 text-decoration-underline" data-cookie-open-preferences="true">
-                Gerenciar cookies
+            <button type="button" class="btn btn-link btn-sm p-0 text-decoration-underline d-inline-flex align-items-center" data-cookie-open-preferences="true">
+                <i class="bi bi-cookie me-1" aria-hidden="true"></i>
+                <span>Gerenciar cookies</span>
             </button>
         </div>
     </footer>


### PR DESCRIPTION
### Motivation
- Make the footer cookie preferences trigger use the same visual pattern as the navigation (icon + small spacing) so it is visually consistent with other nav items.

### Description
- Update `templates/base.html` to change the `data-cookie-open-preferences="true"` button to `d-inline-flex align-items-center`, add a Bootstrap icon `<i class="bi bi-cookie me-1" aria-hidden="true"></i>`, and wrap the label in a `<span>`.

### Testing
- Ran file/contents checks and VCS operations: `rg -n "data-cookie-open-preferences" templates/base.html`, `sed -n '360,410p' templates/base.html`, `nl -ba templates/base.html | sed -n '380,400p'`, and `git -C /workspace/repositorio_equipe status --short` which all completed successfully, and committed the change with `git -C /workspace/repositorio_equipe commit -m "Add Bootstrap cookie icon to preferences button"`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5448d0fc832eb26ff92d4f4fd101)