### PR TITLE
Adicionar botão de edição de cargo e remover redirecionamento pelo nome

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -607,6 +607,28 @@
   --bs-btn-line-height: 1.1;
 }
 
+.cargo-edit-btn {
+  --bs-btn-padding-y: 0.12rem;
+  --bs-btn-padding-x: 0.38rem;
+  --bs-btn-font-size: 0.78rem;
+  --bs-btn-border-radius: 0.38rem;
+  --bs-btn-line-height: 1.1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--primary);
+  border: 1px solid rgba(13, 110, 253, 0.35);
+  background-color: transparent;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.cargo-edit-btn:hover {
+  color: #fff;
+  background-color: var(--primary);
+  border-color: var(--primary);
+}
+
 .search-highlight {
   background-color: var(--highlight-color);
   padding: 0 2px;

--- a/templates/admin/cargos.html
+++ b/templates/admin/cargos.html
@@ -74,6 +74,9 @@
                                                                                                 </div>
                                                                                             </div>
                                                                                             <div class="acoes-cargo">
+                                                                                            <a href="{{ url_for('admin_cargos', edit_id=cargo.id) }}#cadastro" class="btn btn-sm cargo-edit-btn" title="Editar Cargo" aria-label="Editar Cargo">
+                                                                                                <i class="bi bi-pencil" aria-hidden="true"></i>
+                                                                                            </a>
                                                                                             {% set confirm_message_text = 'DESATIVAR' if cargo.ativo else 'ATIVAR' %}
                                                                                             {% set cargo_nome_js = cargo.nome | tojson %}
                                                                                             <form action="{{ url_for('admin_toggle_ativo_cargo', id=cargo.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_message_text }} o cargo ' + {{ cargo_nome_js }} + '?');">
@@ -110,6 +113,9 @@
                                                                                                             </div>
                                                                                                         </div>
                                                                                                         <div class="acoes-cargo">
+                                                                                                            <a href="{{ url_for('admin_cargos', edit_id=cargo.id) }}#cadastro" class="btn btn-sm cargo-edit-btn" title="Editar Cargo" aria-label="Editar Cargo">
+                                                                                                                <i class="bi bi-pencil" aria-hidden="true"></i>
+                                                                                                            </a>
                                                                                                             {% set confirm_message_text = 'DESATIVAR' if cargo.ativo else 'ATIVAR' %}
                                                                                                             {% set cargo_nome_js = cargo.nome | tojson %}
                                                                                                             <form action="{{ url_for('admin_toggle_ativo_cargo', id=cargo.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Tem certeza que deseja {{ confirm_message_text }} o cargo ' + {{ cargo_nome_js }} + '?');">
@@ -566,8 +572,6 @@ document.addEventListener('DOMContentLoaded', function() {
                 });
                 cargoItem.classList.add('is-active');
             }
-            const url = el.dataset.url;
-            if (url) window.location.href = url;
         });
     });
 


### PR DESCRIPTION
### Motivation
- Melhorar a usabilidade permitindo edição direta de um cargo sem forçar navegação ao clicar no nome, evitando cliques acidentais que mudam de página.
- Tornar a ação de editar explícita e visualmente consistente ao lado das demais ações de cada item de cargo.

### Description
- Adiciona um link de edição com ícone de lápis dentro de `.acoes-cargo` em `templates/admin/cargos.html` que aponta para `url_for('admin_cargos', edit_id=cargo.id) + '#cadastro'` para itens em setor e em célula.
- Remove o redirecionamento `window.location.href` do handler de clique em `.cargo-name`, preservando apenas o realce da seleção (`.is-active`).
- Cria o estilo `.cargo-edit-btn` em `static/css/custom.css` com `cursor: pointer`, ajustes de tamanho/linha, borda leve e estado `:hover` destacado para garantir visibilidade e acessibilidade.

### Testing
- Inspeção do diff e verificação do patch com `git diff -- templates/admin/cargos.html static/css/custom.css`, que retornou as alterações esperadas (sucesso).
- Checagem do estado do repositório com `git status --short` e commit com `git commit`, ambos executados com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea565babac832ea9d1acafd0d206ae)