### PR TITLE
Corrige propagação de desmarcação na hierarquia de cargos

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -380,21 +380,37 @@ document.addEventListener("DOMContentLoaded", function () {
         }
       };
 
-      const syncEstabelecimentoByDescendants = (estabelecimentoId) => {
+      const syncEstabelecimentoByDescendants = (estabelecimentoId, { allowAutoUncheck = false } = {}) => {
         const relatedEstabelecimentos = getByData(estabelecimentoCheckboxes, "estabelecimentoId", estabelecimentoId);
         if (!relatedEstabelecimentos.length) return;
         const hasCheckedSetor = anyChecked(getByData(setorCheckboxes, "estabelecimentoId", estabelecimentoId));
         const hasCheckedCelula = anyChecked(getByData(celulaCheckboxes, "estabelecimentoId", estabelecimentoId));
-        setChecked(relatedEstabelecimentos, hasCheckedSetor || hasCheckedCelula);
+
+        if (hasCheckedSetor || hasCheckedCelula) {
+          setChecked(relatedEstabelecimentos, true);
+          return;
+        }
+
+        if (allowAutoUncheck) {
+          setChecked(relatedEstabelecimentos, false);
+        }
       };
 
-      const syncInstituicaoByDescendants = (instituicaoId) => {
+      const syncInstituicaoByDescendants = (instituicaoId, { allowAutoUncheck = false } = {}) => {
         const relatedInstituicoes = getByData(instituicaoCheckboxes, "instituicaoId", instituicaoId);
         if (!relatedInstituicoes.length) return;
         const hasCheckedEstabelecimento = anyChecked(getByData(estabelecimentoCheckboxes, "instituicaoId", instituicaoId));
         const hasCheckedSetor = anyChecked(getByData(setorCheckboxes, "instituicaoId", instituicaoId));
         const hasCheckedCelula = anyChecked(getByData(celulaCheckboxes, "instituicaoId", instituicaoId));
-        setChecked(relatedInstituicoes, hasCheckedEstabelecimento || hasCheckedSetor || hasCheckedCelula);
+
+        if (hasCheckedEstabelecimento || hasCheckedSetor || hasCheckedCelula) {
+          setChecked(relatedInstituicoes, true);
+          return;
+        }
+
+        if (allowAutoUncheck) {
+          setChecked(relatedInstituicoes, false);
+        }
       };
 
       const syncAllParents = () => {
@@ -439,7 +455,8 @@ document.addEventListener("DOMContentLoaded", function () {
             setChecked(getByData(instituicaoCheckboxes, "instituicaoId", instituicaoId), true);
             return;
           }
-          syncSetorByDescendants(setorId);
+
+          setChecked(getByData(celulaCheckboxes, "setorId", setorId), false);
           syncEstabelecimentoByDescendants(estabelecimentoId);
           syncInstituicaoByDescendants(instituicaoId);
         });
@@ -452,15 +469,20 @@ document.addEventListener("DOMContentLoaded", function () {
             setChecked(getByData(instituicaoCheckboxes, "instituicaoId", instituicaoId), true);
             return;
           }
-          syncEstabelecimentoByDescendants(estabelecimentoId);
-          syncInstituicaoByDescendants(instituicaoId);
+
+          setChecked(getByData(setorCheckboxes, "estabelecimentoId", estabelecimentoId), false);
+          setChecked(getByData(celulaCheckboxes, "estabelecimentoId", estabelecimentoId), false);
+          syncInstituicaoByDescendants(instituicaoId, { allowAutoUncheck: true });
         });
       });
 
       instituicaoCheckboxes.forEach((checkbox) => {
         checkbox.addEventListener("change", () => {
           if (checkbox.checked) return;
-          syncInstituicaoByDescendants(checkbox.dataset.instituicaoId);
+          const { instituicaoId } = checkbox.dataset;
+          setChecked(getByData(estabelecimentoCheckboxes, "instituicaoId", instituicaoId), false);
+          setChecked(getByData(setorCheckboxes, "instituicaoId", instituicaoId), false);
+          setChecked(getByData(celulaCheckboxes, "instituicaoId", instituicaoId), false);
         });
       });
 


### PR DESCRIPTION
### Motivation
- Corrigir comportamento em que desmarcar um nível intermediário (por exemplo, um `setor`) desmarcava indevidamente níveis superiores (`estabelecimento` e `instituição`).
- Garantir que a desmarcação propague apenas para baixo quando explicitamente desejado e que o recalculo dos pais não faça uncheck agressivo para cima.

### Description
- Ajusta `static/js/main.js` alterando `syncEstabelecimentoByDescendants` e `syncInstituicaoByDescendants` para aceitar um parâmetro `{ allowAutoUncheck }` e só realizar auto-uncheck quando esse sinalizador for verdadeiro.
- Ao desmarcar um `setor`, agora é feita cascata explícita para baixo desmarcando suas `células` sem forçar a desmarcação de `estabelecimento`/`instituição` automaticamente.
- Ao desmarcar um `estabelecimento`, agora são desmarcados explicitamente seus `setores` e `células` e a instituição é recalculada com `allowAutoUncheck: true` para evitar propagação agressiva para cima.
- Ao desmarcar uma `instituição`, é aplicada cascata descendente explícita (estabelecimentos, setores e células); o comportamento de marcação (propagação para cima) foi mantido.

### Testing
- Executado `pytest -q tests/test_cargo.py`, que passou com sucesso (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5c6b6854832eb6b8225a8993bae5)