### PR TITLE
Não desmarcar instituição ao desmarcar estabelecimento na hierarquia de cargos

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -472,7 +472,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
           setChecked(getByData(setorCheckboxes, "estabelecimentoId", estabelecimentoId), false);
           setChecked(getByData(celulaCheckboxes, "estabelecimentoId", estabelecimentoId), false);
-          syncInstituicaoByDescendants(instituicaoId, { allowAutoUncheck: true });
+          syncInstituicaoByDescendants(instituicaoId);
         });
       });
 


### PR DESCRIPTION
### Motivation
- Corrigir comportamento onde desmarcar um `estabelecimento` também estava desmarcando a `instituição`, contrariando a regra de que a desmarcação deve propagar apenas para baixo (descendentes). 

### Description
- Ajusta uma chamada em `static/js/main.js` para substituir `syncInstituicaoByDescendants(instituicaoId, { allowAutoUncheck: true })` por `syncInstituicaoByDescendants(instituicaoId)` no handler de mudança de `estabelecimento`, evitando a auto-desmarcação da instituição.
- Mantém inalterada a lógica já corrigida para o nível de `setor` e a sincronização dos descendentes (`setores` e `células`).

### Testing
- Executado `pytest -q tests/test_cargo.py` e todos os testes do arquivo passaram (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea61511e64832e994eaf3f49828610)