### PR TITLE
Ajusta botão de Gerenciar cookies e corrige layout do modal de preferências

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -118,6 +118,47 @@
             color: var(--text-default);
         }
 
+        .cookie-manage-trigger {
+            cursor: pointer;
+            color: var(--bs-secondary-color);
+        }
+
+        .cookie-manage-trigger:hover,
+        .cookie-manage-trigger:focus-visible {
+            color: var(--bs-primary);
+            opacity: 1;
+        }
+
+        #cookiePreferencesModal .modal-dialog {
+            width: 100%;
+            max-width: 500px;
+            margin: 1rem auto;
+        }
+
+        #cookiePreferencesModal .modal-content {
+            max-height: calc(100dvh - 2rem);
+        }
+
+        #cookiePreferencesModal .modal-body {
+            overflow-y: auto;
+        }
+
+        #cookiePreferencesModal .modal-footer {
+            flex-wrap: wrap;
+            justify-content: flex-end;
+            gap: .5rem;
+        }
+
+        #cookiePreferencesModal .modal-footer .btn {
+            min-width: 170px;
+        }
+
+        @media (max-width: 575.98px) {
+            #cookiePreferencesModal .modal-footer .btn {
+                width: 100%;
+            }
+        }
+
         .page-root {
             padding: 0;
         }
@@ -384,9 +425,8 @@
     <footer class="border-top bg-body-tertiary py-3">
         <div class="container-fluid d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">
             <small class="text-muted">&copy; 2026 Orquetask</small>
-            <button type="button" class="btn btn-link btn-sm p-0 text-decoration-underline d-inline-flex align-items-center" data-cookie-open-preferences="true">
-                <i class="bi bi-cookie me-1" aria-hidden="true"></i>
-                <span>Gerenciar cookies</span>
+            <button type="button" class="btn btn-link btn-sm p-0 d-inline-flex align-items-center cookie-manage-trigger" data-cookie-open-preferences="true" data-bs-toggle="tooltip" data-bs-placement="top" title="Gerenciar cookies" aria-label="Gerenciar cookies">
+                <i class="bi bi-cookie fs-5" aria-hidden="true"></i>
             </button>
         </div>
     </footer>


### PR DESCRIPTION
### Motivation
- Tornar o botão de gerenciamento de cookies mais conciso exibindo somente o ícone, mantendo acessibilidade e affordance ao usuário. 
- Evitar que o modal de preferência de cookies “estoure” a viewport e garantir que os botões fiquem sempre visíveis e alinhados em diferentes larguras.

### Description
- Atualiza `templates/base.html` para remover o texto visível do botão de rodapé e manter apenas o ícone, adicionando `data-bs-toggle="tooltip"`, `title="Gerenciar cookies"` e `aria-label="Gerenciar cookies"` para acessibilidade e contexto. 
- Adiciona estilos em linha no mesmo template para a classe `.cookie-manage-trigger` com `cursor: pointer` e estados de hover/focus para contraste visual. 
- Restringe o modal `#cookiePreferencesModal` definindo `width: 100%` e `max-width: 500px`, limita a altura do `.modal-content` ao viewport com `max-height: calc(100dvh - 2rem)` e habilita `overflow-y: auto` em `.modal-body` para rolagem interna. 
- Torna o `.modal-footer` responsivo com `flex-wrap`, espaçamento e largura mínima/100% para botões em telas pequenas para manter alinhamento e visibilidade.

### Testing
- Executado `python -m py_compile app.py` e a verificação de bytecode do Python foi bem-sucedida.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea64f9e678832eb7fc7c1ace6ab089)