### PR TITLE
Ajusta alinhamento dos switches no modal de preferências de cookies

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -153,6 +153,14 @@
             min-width: 170px;
         }
 
+        #cookiePreferencesModal .form-check.form-switch {
+            padding-left: 3.25rem;
+        }
+
+        #cookiePreferencesModal .form-check.form-switch .form-check-input {
+            margin-left: -2.25rem;
+        }
+
         @media (max-width: 575.98px) {
             #cookiePreferencesModal .modal-footer .btn {
                 width: 100%;


### PR DESCRIPTION
### Motivation
- Corrigir o deslocamento horizontal dos switches de categorias (Analíticos e Marketing) no modal de preferências de cookies para que fiquem dentro dos cards e não saiam da tela.

### Description
- Adiciona regras CSS em `templates/base.html` escopadas a `#cookiePreferencesModal` para aumentar o `padding-left` do bloco `.form-check.form-switch`.
- Ajusta o `margin-left` de `.form-check-input` dentro do modal para alinhar visualmente os toggles com o conteúdo.
- Commit realizado com a mensagem `Ajusta alinhamento dos switches no modal de cookies`.

### Testing
- Executado `git -C /workspace/repositorio_equipe status --short` e `git -C /workspace/repositorio_equipe diff -- templates/base.html` para validar o diff, ambos concluíram com sucesso.
- O `git commit` da alteração também foi concluído com sucesso; nenhum teste automatizado de unidade/integracao foi executado nesta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea66b242c0832ebe4c82e59b0b3fdf)