### PR TITLE
Fix cookie preferences modal switch alignment and footer overflow

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -136,34 +136,55 @@
         }
 
         #cookiePreferencesModal .modal-content {
+            display: flex;
+            flex-direction: column;
             max-height: calc(100dvh - 2rem);
         }
 
         #cookiePreferencesModal .modal-body {
+            flex: 1 1 auto;
             overflow-y: auto;
         }
 
         #cookiePreferencesModal .modal-footer {
+            flex: 0 0 auto;
             flex-wrap: wrap;
             justify-content: flex-end;
             gap: .5rem;
+            padding: .75rem 1rem 1rem;
         }
 
         #cookiePreferencesModal .modal-footer .btn {
             min-width: 170px;
+            max-width: 100%;
         }
 
         #cookiePreferencesModal .form-check.form-switch {
-            padding-left: 3.25rem;
+            display: flex;
+            align-items: flex-start;
+            gap: .75rem;
+            padding-left: 1rem;
         }
 
         #cookiePreferencesModal .form-check.form-switch .form-check-input {
-            margin-left: -2.25rem;
+            flex: 0 0 auto;
+            margin-left: 0;
+            margin-top: .15rem;
+        }
+
+        #cookiePreferencesModal .form-check.form-switch .form-check-label {
+            flex: 1 1 auto;
+            min-width: 0;
         }
 
         @media (max-width: 575.98px) {
+            #cookiePreferencesModal .modal-footer {
+                justify-content: stretch;
+            }
+
             #cookiePreferencesModal .modal-footer .btn {
                 width: 100%;
+                min-width: 0;
             }
         }
 


### PR DESCRIPTION
### Motivation
- Corrigir o comportamento do toggle dentro de `#cookiePreferencesModal` que estava sendo deslocado por uma regra com `margin-left` negativo e saindo do card, quebrando o layout. 
- Garantir que o `input` (switch) e o `label` permaneçam contidos dentro do card e que o rodapé do modal não saia da área visível em telas pequenas. 

### Description
- Removi a dependência de `margin-left: -2.25rem` e zerei o deslocamento do toggle para evitar posicionamento fora do card. 
- Reestruturei `.form-check.form-switch` para usar `display: flex` com `gap` e `align-items`, defini `form-check-input` como `flex: 0 0 auto` e dei ao `form-check-label` `flex: 1 1 auto` para manter input e texto juntos e responsivos. 
- Converti `#cookiePreferencesModal .modal-content` para coluna flex, defini `modal-body` como `flex: 1 1 auto` para rolagem interna, e deixei `modal-footer` como `flex: 0 0 auto` com padding e limites de largura nos botões. 
- Ajustei a media query móvel para que os botões no `modal-footer` façam stacking com largura total e sem overflow (`min-width: 0` / `justify-content: stretch`). 

### Testing
- Executei os testes automatizados com `pytest -q tests/test_security_controls.py` e todos os testes passaram (`9 passed`) com warnings legados do SQLAlchemy. 
- Não foram realizados testes visuais automatizados neste ambiente, apenas os testes unitários mencionados acima.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6905a4b0832e8f8d5360fa9c0acd)