### PR TITLE
Permitir que admin redefina senha provisória e obrigue troca no próximo login

### DIFF
--- a/templates/admin/usuarios.html
+++ b/templates/admin/usuarios.html
@@ -265,6 +265,19 @@
                                     <label for="edit_email" class="form-label">Email <span class="text-danger">*</span></label>
                                     <input type="email" class="form-control form-control-sm" id="edit_email" name="email" value="{{ request.form.get('email', user_editar.email if user_editar.email else '') }}" required maxlength="120">
                                 </div>
+                                <div class="col-md-4 mb-1">
+                                    <label for="edit_password" class="form-label">Redefinir Senha</label>
+                                    <input
+                                        type="password"
+                                        class="form-control form-control-sm"
+                                        id="edit_password"
+                                        name="password"
+                                        autocomplete="new-password"
+                                    >
+                                    <small class="text-muted">
+                                        Opcional. Ao informar uma senha provisória, o usuário será obrigado a trocá-la no próximo acesso.
+                                    </small>
+                                </div>
                             </div>
                             <div class="row">
                                 <div class="col-md-6 mb-1">

--- a/tests/test_admin_usuarios.py
+++ b/tests/test_admin_usuarios.py
@@ -418,6 +418,42 @@ def test_edit_user_updates_relations(client):
         assert {f.id for f in u.permissoes_personalizadas} == {func2_id}
 
 
+def test_edit_user_can_reset_password_and_require_change_on_next_login(client):
+    login_admin(client)
+    ids = client.base_ids
+    with app.app_context():
+        u = User(
+            username='resetavel',
+            email='resetavel@example.com',
+            estabelecimento_id=ids['est'],
+            setor_id=ids['setor'],
+            celula_id=ids['cel'],
+            deve_trocar_senha=False,
+        )
+        u.set_password('SenhaAntiga#2026')
+        db.session.add(u)
+        db.session.commit()
+        uid = u.id
+
+    nova_senha = 'SenhaProvisoria#2026'
+    response = client.post('/admin/usuarios', data={
+        'id_para_atualizar': str(uid),
+        'username': 'resetavel',
+        'email': 'resetavel@example.com',
+        'password': nova_senha,
+        'ativo_check': 'on',
+        'estabelecimento_id': ids['est'],
+        'setor_ids': [str(ids['setor'])],
+        'celula_ids': [str(ids['cel'])],
+    }, follow_redirects=True)
+
+    assert response.status_code == 200
+    with app.app_context():
+        atualizado = User.query.get(uid)
+        assert atualizado.check_password(nova_senha) is True
+        assert atualizado.deve_trocar_senha is True
+
+
 def test_admin_usuarios_form_keeps_email_required(client):
     login_admin(client)
     response = client.get('/admin/usuarios')


### PR DESCRIPTION
### Motivation
- Permitir que o Administrador informe uma senha provisória ao editar um usuário sem expor a senha real do usuário. 
- Reutilizar a lógica já existente de `set_password(...)` e do campo `deve_trocar_senha` para forçar a troca no próximo acesso, sem criar fluxo paralelo. 
- Melhorar o suporte a cenários de recuperação (admin define senha temporária) garantindo segurança (hash) e obrigatoriedade de troca pelo usuário.

### Description
- Adicionado campo `password` (tipo `password`, com `autocomplete="new-password"`) ao modal de edição em `templates/admin/usuarios.html` para permitir que o admin informe uma senha provisória. 
- Reaproveita-se o fluxo existente no backend: quando `password` é recebido na edição, o código chama `set_password(...)` e define `deve_trocar_senha = True` (nenhuma rota ou lógica paralela foi criada). 
- Atualizado `tests/test_admin_usuarios.py` com o teste `test_edit_user_can_reset_password_and_require_change_on_next_login` que valida o hash da nova senha e a marcação de `deve_trocar_senha`.

### Testing
- Rodei o subconjunto de testes de usuários com `pytest -q tests/test_admin_usuarios.py -k "reset_password_and_require_change_on_next_login or edit_user_updates_relations"` e ambos os testes selecionados passaram. 
- Resultado: `2 passed, 15 deselected` para a execução solicitada. 
- Logs e templates preservam redaction e boas práticas (campo de senha não é pré-preenchido e logging de formulários mantém `***REDACTED***`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea78bd702c832e8e43bdfd243b4e31)