### PR TITLE
Corrige posicionamento do footer em páginas com conteúdo longo

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -109,10 +109,9 @@
         }
 
         .main-page-content {
-            flex: 1;
+            flex: 1 0 auto;
             display: flex;
             flex-direction: column;
-            min-height: 0;
             padding: 1.5rem 3rem 2rem;
             background-color: var(--content-bg);
             color: var(--text-default);
@@ -199,6 +198,7 @@
         }
 
         footer {
+            flex-shrink: 0;
             margin-top: auto;
         }
         #flash-container { margin-bottom: 1.5rem; }


### PR DESCRIPTION
### Motivation
- Corrigir o problema em que o `footer` aparecia no meio da tela em páginas com muito conteúdo (ex.: página de pesquisar artigos) fazendo o layout flex permitir que o conteúdo principal cresça corretamente.

### Description
- Ajustei `templates/base.html` para usar `flex: 1 0 auto` em `.main-page-content` e adicionei `flex-shrink: 0` ao `footer` para evitar que ele encolha, garantindo que o rodapé fique sempre ancorado ao final da página.

### Testing
- Executei os testes automatizados com `pytest -q` e todos passaram: `92 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7ed97d44832e9f169d569d0c0810)