### PR TITLE
Fix inconsistent cargo OS flag rename migration

### DIFF
--- a/migrations/versions/52f02b1c789a_rename_cargo_os_flag.py
+++ b/migrations/versions/52f02b1c789a_rename_cargo_os_flag.py
@@ -15,11 +15,39 @@ branch_labels = None
 depends_on = None
 
 
+def _column_exists(table_name: str, column_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return any(col['name'] == column_name for col in inspector.get_columns(table_name))
+
+
 def upgrade():
-    with op.batch_alter_table('cargo') as batch_op:
-        batch_op.alter_column('atende_ordem_servico', new_column_name='pode_atender_os')
+    has_old_column = _column_exists('cargo', 'atende_ordem_servico')
+    has_new_column = _column_exists('cargo', 'pode_atender_os')
+
+    if has_old_column and not has_new_column:
+        with op.batch_alter_table('cargo') as batch_op:
+            batch_op.alter_column('atende_ordem_servico', new_column_name='pode_atender_os')
+    elif has_new_column:
+        # A coluna nova já existe (ex.: base criada com migration mais recente); nada a fazer.
+        pass
+    else:
+        # Estado inesperado em bases antigas/inconsistentes: garante a coluna prevista pela release.
+        with op.batch_alter_table('cargo') as batch_op:
+            batch_op.add_column(sa.Column('pode_atender_os', sa.Boolean(), nullable=False, server_default='false'))
 
 
 def downgrade():
-    with op.batch_alter_table('cargo') as batch_op:
-        batch_op.alter_column('pode_atender_os', new_column_name='atende_ordem_servico')
+    has_old_column = _column_exists('cargo', 'atende_ordem_servico')
+    has_new_column = _column_exists('cargo', 'pode_atender_os')
+
+    if has_new_column and not has_old_column:
+        with op.batch_alter_table('cargo') as batch_op:
+            batch_op.alter_column('pode_atender_os', new_column_name='atende_ordem_servico')
+    elif has_old_column:
+        # A coluna antiga já existe; downgrade já está refletido.
+        pass
+    else:
+        # Mantém downgrade resiliente em cenários inconsistentes.
+        with op.batch_alter_table('cargo') as batch_op:
+            batch_op.add_column(sa.Column('atende_ordem_servico', sa.Boolean(), nullable=False, server_default='false'))


### PR DESCRIPTION
### Motivation
- Running `flask db upgrade` on a clean database failed because the rename migration assumed the old column `atende_ordem_servico` existed while a different migration already added `pode_atender_os` earlier. 
- The goal is to make the migration robust for both new (clean) and existing databases and avoid manual fixes in production. 

### Description
- Updated `migrations/versions/52f02b1c789a_rename_cargo_os_flag.py` to add a `_column_exists` inspector helper that checks column presence at runtime. 
- Changed `upgrade()` to rename `atende_ordem_servico` -> `pode_atender_os` only when the old column exists and the new one does not, to no-op when `pode_atender_os` already exists, and to create `pode_atender_os` with a safe default when neither column exists. 
- Implemented a symmetric, defensive `downgrade()` that renames back only when applicable, no-ops when already in the expected state, and adds the fallback old column when neither exists. 

### Testing
- Compiled the migration file with `python -m compileall migrations/versions/52f02b1c789a_rename_cargo_os_flag.py` and it compiled successfully. 
- Ran the test suite entry for migrations with `pytest -q tests/test_migrations.py` and it passed. 
- Verified the Alembic revision graph heads with a small script to ensure the migration chain remains consistent and resolves to a single head.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea85cb424c832e82acbce2ced16f6f)