### PR TITLE
Corrige loop no fluxo de troca de senha obrigatória

### DIFF
--- a/blueprints/auth.py
+++ b/blueprints/auth.py
@@ -46,6 +46,9 @@ MANDATORY_PASSWORD_CHANGE_ENDPOINTS = {
     'politica_cookies',
     'troca_senha_obrigatoria',
 }
+MANDATORY_PASSWORD_CHANGE_PATHS = {
+    '/troca-senha-obrigatoria',
+}
 
 
 def _login_avatar_serializer():
@@ -76,6 +79,20 @@ def _endpoint_name(endpoint: str) -> str:
     return endpoint.split('.')[-1] if endpoint else ''
 
 
+def _is_mandatory_password_change_allowed_request(endpoint_name: str, path: str) -> bool:
+    if endpoint_name in MANDATORY_PASSWORD_CHANGE_ENDPOINTS:
+        return True
+    if endpoint_name == 'static':
+        return True
+    if not path:
+        return False
+    return (
+        path in MANDATORY_PASSWORD_CHANGE_PATHS
+        or path.startswith('/reset-senha/')
+        or path.startswith('/criar-senha/')
+    )
+
+
 @auth_bp.before_app_request
 def enforce_mandatory_password_change():
     user_id = session.get('user_id')
@@ -92,9 +109,7 @@ def enforce_mandatory_password_change():
         return None
 
     endpoint_name = _endpoint_name(request.endpoint)
-    if endpoint_name in MANDATORY_PASSWORD_CHANGE_ENDPOINTS:
-        return None
-    if endpoint_name == 'static':
+    if _is_mandatory_password_change_allowed_request(endpoint_name, request.path):
         return None
 
     flash('Você precisa trocar sua senha antes de continuar.', 'warning')
@@ -117,6 +132,11 @@ def login():
     e redireciona para a página inicial do usuário. Em caso de falha no POST,
     re-renderiza o formulário de login com mensagem de erro.
     """
+
+    if 'user_id' in session:
+        logged_user = User.query.get(session['user_id'])
+        if logged_user and logged_user.deve_trocar_senha:
+            return redirect(url_for('troca_senha_obrigatoria'))
 
     if request.method == "POST":
         username = request.form.get("username", "").strip()
@@ -249,7 +269,11 @@ def troca_senha_obrigatoria():
         flash('Faça login para continuar.', 'warning')
         return redirect(url_for('login'))
 
-    user = User.query.get_or_404(session['user_id'])
+    user = User.query.get(session['user_id'])
+    if not user:
+        session.clear()
+        flash('Sua sessão expirou. Faça login novamente.', 'warning')
+        return redirect(url_for('login'))
     if not user.deve_trocar_senha:
         return redirect(url_for('pagina_inicial'))
 

--- a/tests/test_security_controls.py
+++ b/tests/test_security_controls.py
@@ -218,6 +218,75 @@ def test_login_blocks_navigation_until_password_is_changed(client, app_ctx):
     assert unblocked.status_code == 200
 
 
+def test_mandatory_password_change_page_is_accessible_without_permissions(client, app_ctx):
+    with app.app_context():
+        from core.models import Instituicao, Estabelecimento, Setor, Celula
+
+        inst = Instituicao(codigo="INST4C", nome="Inst4C")
+        est = Estabelecimento(codigo="E4C", nome_fantasia="Estab4C", instituicao=inst)
+        setor = Setor(nome="Setor4C", estabelecimento=est)
+        celula = Celula(nome="Cel4C", estabelecimento=est, setor=setor)
+        db.session.add_all([inst, est, setor, celula])
+        db.session.flush()
+
+        user = User(
+            username="must_change_sem_permissoes",
+            email="must_change_sem_permissoes@example.com",
+            estabelecimento=est,
+            setor=setor,
+            celula=celula,
+            deve_trocar_senha=True,
+        )
+        user.set_password("Secret1!")
+        db.session.add(user)
+        db.session.commit()
+
+    login = client.post(
+        "/login",
+        data={"username": "must_change_sem_permissoes", "password": "Secret1!"},
+        follow_redirects=False,
+    )
+    assert login.status_code == 302
+    assert "/troca-senha-obrigatoria" in login.headers["Location"]
+
+    page = client.get("/troca-senha-obrigatoria", follow_redirects=False)
+    assert page.status_code == 200
+
+
+def test_login_get_redirects_to_mandatory_password_change_when_pending(client, app_ctx):
+    user_id = None
+    with app.app_context():
+        from core.models import Instituicao, Estabelecimento, Setor, Celula
+
+        inst = Instituicao(codigo="INST4D", nome="Inst4D")
+        est = Estabelecimento(codigo="E4D", nome_fantasia="Estab4D", instituicao=inst)
+        setor = Setor(nome="Setor4D", estabelecimento=est)
+        celula = Celula(nome="Cel4D", estabelecimento=est, setor=setor)
+        db.session.add_all([inst, est, setor, celula])
+        db.session.flush()
+
+        user = User(
+            username="must_change_redirect_login",
+            email="must_change_redirect_login@example.com",
+            estabelecimento=est,
+            setor=setor,
+            celula=celula,
+            deve_trocar_senha=True,
+        )
+        user.set_password("Secret1!")
+        db.session.add(user)
+        db.session.commit()
+        user_id = user.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = user_id
+        sess["username"] = "must_change_redirect_login"
+
+    resp = client.get("/login", follow_redirects=False)
+    assert resp.status_code == 302
+    assert "/troca-senha-obrigatoria" in resp.headers["Location"]
+
+
 def test_mandatory_password_change_blocks_home_and_unblocks_after_change(client, app_ctx):
     user_id = None
     username = "must_change_block"


### PR DESCRIPTION
### Motivation
- Corrigir situação em que o fluxo obrigatório de troca de senha ficava em loop (`login → troca-senha → login`) porque a rota de troca era bloqueada pelas verificações de permissão ou por falha na resolução do endpoint.
- Garantir que qualquer usuário autenticado com `deve_trocar_senha = True` consiga acessar a rota de troca sem depender das permissões normais do sistema.

### Description
- Adiciona `MANDATORY_PASSWORD_CHANGE_PATHS` e a função auxiliar `_is_mandatory_password_change_allowed_request` para liberar a rota de troca obrigatória tanto por `endpoint` quanto por `path` e rotas com prefixo (`/reset-senha/`, `/criar-senha/`).
- Substitui a checagem direta de `endpoint` em `enforce_mandatory_password_change` por chamada a `_is_mandatory_password_change_allowed_request` para tornar a liberação mais robusta.
- Evita loop no fluxo ao implementar redirecionamento em `GET /login` quando já existe sessão com `deve_trocar_senha = True` e torna `troca_senha_obrigatoria` resiliente a sessão inválida limpando a sessão e redirecionando ao `login` (em vez de `404`).
- Adiciona testes em `tests/test_security_controls.py` cobrindo acesso à página de troca sem permissões e redirecionamento de `GET /login` quando a troca é obrigatória.

### Testing
- Executei `pytest -q tests/test_security_controls.py` e a suíte apresentou `11 passed, 20 warnings`.
- Os testes relevantes adicionados são `test_mandatory_password_change_page_is_accessible_without_permissions` e `test_login_get_redirects_to_mandatory_password_change_when_pending` e eles passaram.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea92404980832e97a135f223e2ad5d)