### PR TITLE
Remover referências a Ordem de Serviço no cadastro de Cargos

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -1024,7 +1024,6 @@ def admin_cargos():
         descricao = request.form.get('descricao', '').strip()
         nivel_hierarquico = request.form.get('nivel_hierarquico', type=int)
         ativo = request.form.get('ativo_check') == 'on'
-        atende_os = request.form.get('pode_atender_os') == 'on'
         estabelecimento_ids = list({int(e) for e in request.form.getlist('estabelecimento_ids') if e})
         setor_ids = list({int(s) for s in request.form.getlist('setor_ids') if s})
         celula_ids = list({int(c) for c in request.form.getlist('celula_ids') if c})
@@ -1089,7 +1088,6 @@ def admin_cargos():
                         cargo.descricao = descricao
                         cargo.nivel_hierarquico = nivel_hierarquico
                         cargo.ativo = ativo
-                        cargo.pode_atender_os = atende_os
                         action_msg = 'atualizado'
                     else:
                         cargo = Cargo(
@@ -1097,7 +1095,7 @@ def admin_cargos():
                             descricao=descricao,
                             nivel_hierarquico=nivel_hierarquico,
                             ativo=ativo,
-                            pode_atender_os=atende_os,
+                            pode_atender_os=False,
                         )
                         db.session.add(cargo)
                         action_msg = 'criado'

--- a/templates/admin/cargos.html
+++ b/templates/admin/cargos.html
@@ -222,15 +222,6 @@
                         </div>
                     </div>
                     <div class="card mb-3">
-                        <div class="card-header"><h6 class="mb-0">Permissões Ordem de Serviço</h6></div>
-                        <div class="card-body">
-                            <div class="form-check form-switch">
-                                <input class="form-check-input" type="checkbox" role="switch" id="pode_atender_os" name="pode_atender_os" {% if request.form.get('pode_atender_os') == 'on' %}checked{% endif %}>
-                                <label class="form-check-label" for="pode_atender_os">Pode atender OS?</label>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="card mb-3">
                         <div class="card-header"><h6 class="mb-0">Permissões de Artigos</h6></div>
                         <div class="card-body">
                             {% set grupos = [
@@ -385,15 +376,6 @@
                                     </div>
                                 {% endif %}
                             {% endfor %}
-                        </div>
-                    </div>
-                    <div class="card mb-3">
-                        <div class="card-header"><h6 class="mb-0">Permissões Ordem de Serviço</h6></div>
-                        <div class="card-body">
-                            <div class="form-check form-switch">
-                                <input class="form-check-input" type="checkbox" role="switch" id="edit_pode_atender_os" name="pode_atender_os" {% if (request.form.get('pode_atender_os') == 'on') or (not request.form.get('pode_atender_os') and cargo_editar.pode_atender_os) %}checked{% endif %}>
-                                <label class="form-check-label" for="edit_pode_atender_os">Pode atender OS?</label>
-                            </div>
                         </div>
                     </div>
                     <div class="card mb-3">


### PR DESCRIPTION
### Motivation
- A aplicação não vai trabalhar com Ordens de Serviço (OS) por enquanto, então é necessário remover qualquer campo e opção de UI relacionados a OS no cadastro/edição de cargos para evitar confusão.
- Evitar que o backend dependa de um campo de formulário que não será mais apresentado na interface.

### Description
- Removi a seção "Permissões Ordem de Serviço" (o switch “Pode atender OS?”) do template de criação de cargos em `templates/admin/cargos.html`.
- Removi a mesma seção do modal de edição de cargo em `templates/admin/cargos.html`.
- Atualizei `admin_cargos` em `blueprints/admin.py` para não ler mais `pode_atender_os` do `request.form`, não sobrescrever o valor existente na edição e definir `pode_atender_os=False` ao criar um novo `Cargo`.

### Testing
- Executei `pytest -q tests/test_cargo.py` e os testes específicos de cargos passaram (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb76286e88832e8f64039881cdcc36)