### PR TITLE
Corrige destaque de títulos e restaura ações no detalhe de artigo

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -300,7 +300,12 @@ def artigo(artigo_id):
         return redirect(url_for('meus_artigos'))
 
     arquivos = json.loads(artigo.arquivos or '[]')
-    return render_template('artigos/artigo.html', artigo=artigo, arquivos=arquivos)
+    return render_template(
+        'artigos/artigo.html',
+        artigo=artigo,
+        arquivos=arquivos,
+        can_edit_article=user_can_edit_article(user, artigo)
+    )
 
 @articles_bp.route("/artigo/<int:artigo_id>/editar", methods=["GET", "POST"], endpoint='editar_artigo')
 def editar_artigo(artigo_id):

--- a/templates/artigos/artigo.html
+++ b/templates/artigos/artigo.html
@@ -137,14 +137,7 @@
 
         {# Botões de ação #}
         <div class="mt-4">
-          {% if session.username
-          and artigo.author.username == session.username
-          and artigo.status in [
-          ArticleStatus.RASCUNHO,
-          ArticleStatus.EM_REVISAO,
-          ArticleStatus.EM_AJUSTE,
-          ArticleStatus.REJEITADO
-          ] %}
+          {% if can_edit_article %}
           <a href="{{ url_for('editar_artigo', artigo_id=artigo.id) }}" class="btn btn-primary">
             Editar
           </a>
@@ -162,6 +155,9 @@
           style="position:absolute; bottom:10px; right:10px; cursor:pointer; font-size:1.3rem;"
         ></i>
         {% endif %}
+        <a href="{{ url_for('meus_artigos') }}" class="btn btn-outline-secondary ms-1">
+          Voltar para Meus Artigos
+        </a>
       </div>
 
       </div> {# .card-body #}

--- a/templates/artigos/meus_artigos.html
+++ b/templates/artigos/meus_artigos.html
@@ -18,13 +18,13 @@
                  class="list-group-item list-group-item-action d-flex justify-content-between align-items-start position-relative">
                 
                 <div>
-                  <div class="fw-bold">{{ artigo.titulo }}</div>
+                  <h4 class="mb-1 fw-bold">{{ artigo.titulo }}</h4>
                   <small class="text-muted">
-                    Criado em: {{ artigo.local_created.strftime('%d/%m/%Y %H:%M') }} |
-                    Atualizado em: {{ artigo.local_updated.strftime('%d/%m/%Y %H:%M') }} |
-                    Visibilidade: {{ artigo.visibility.label }}
-                    {% if artigo.tipo %}| Tipo: {{ artigo.tipo.nome }}{% endif %}
-                    {% if artigo.area %}| Área: {{ artigo.area.nome }}{% endif %}{% if artigo.sistema %}| Sistema: {{ artigo.sistema.nome }}{% endif %}
+                    <span class="fw-bold">Criado em:</span> {{ artigo.local_created.strftime('%d/%m/%Y %H:%M') }} |
+                    <span class="fw-bold">Atualizado em:</span> {{ artigo.local_updated.strftime('%d/%m/%Y %H:%M') }} |
+                    <span class="fw-bold">Visibilidade:</span> {{ artigo.visibility.label }}
+                    {% if artigo.tipo %}| <span class="fw-bold">Tipo:</span> {{ artigo.tipo.nome }}{% endif %}
+                    {% if artigo.area %}| <span class="fw-bold">Área:</span> {{ artigo.area.nome }}{% endif %}{% if artigo.sistema %}| <span class="fw-bold">Sistema:</span> {{ artigo.sistema.nome }}{% endif %}
                   </small>
                 </div>
 


### PR DESCRIPTION
### Motivation
- Tornar os títulos da listagem de artigos visualmente destacados conforme o anexo de referência para melhorar legibilidade. 
- Restaurar o botão de edição ausente quando um rascunho é aberto garantindo que a mesma regra de permissão centralizada seja usada. 
- Recuperar a ação de navegação para voltar à lista de artigos a partir da tela de detalhe. 

### Description
- Atualizei `templates/artigos/meus_artigos.html` para exibir o título como `<h4 class="mb-1 fw-bold">` e padronizar rótulos de metadados (`Criado em`, `Atualizado em`, `Visibilidade`, `Tipo`, `Área`, `Sistema`) com `span.fw-bold` para manter o destaque. 
- Alterei `templates/artigos/artigo.html` para usar a variável de contexto `can_edit_article` ao renderizar o botão `Editar` e adicionei o botão `Voltar para Meus Artigos` para melhorar a navegação. 
- Ajustei `blueprints/articles.py` para passar `can_edit_article=user_can_edit_article(user, artigo)` ao template de detalhe, centralizando a verificação de permissão via `user_can_edit_article`. 
- Arquivos alterados: `templates/artigos/meus_artigos.html`, `templates/artigos/artigo.html`, `blueprints/articles.py`. 

### Testing
- Executei `pytest tests/test_article_editing.py -q` e todos os testes da suíte executada passaram com sucesso (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8104bfb0832e937c95b0f4fb1163)