### PR TITLE
Fix article edit action visibility and protect non-editable statuses

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -319,7 +319,19 @@ def editar_artigo(artigo_id):
         flash("Você não tem permissão para editar este artigo.", "danger")
         return redirect(url_for("artigo", artigo_id=artigo_id))
 
+    editable_statuses = {
+        ArticleStatus.RASCUNHO,
+        ArticleStatus.EM_REVISAO,
+        ArticleStatus.EM_AJUSTE,
+        ArticleStatus.REJEITADO,
+    }
+    can_submit_actions = artigo.status in editable_statuses
+
     if request.method == "POST":
+        if not can_submit_actions:
+            flash("Este artigo não permite alterações no status atual.", "warning")
+            return redirect(url_for("artigo", artigo_id=artigo_id))
+
         acao = request.form.get("acao", "salvar")   # salvar | enviar
         progress_id = request.form.get("progress_id")
         init_progress(progress_id)
@@ -439,7 +451,15 @@ def editar_artigo(artigo_id):
     tipos_artigo = ArtigoTipo.query.filter_by(ativo=True).order_by(ArtigoTipo.nome).all()
     areas_artigo = ArtigoArea.query.filter_by(ativo=True).order_by(ArtigoArea.nome).all()
     sistemas_artigo = ArtigoSistema.query.filter_by(ativo=True).order_by(ArtigoSistema.nome).all()
-    return render_template("artigos/editar_artigo.html", artigo=artigo, arquivos=arquivos, tipos_artigo=tipos_artigo, areas_artigo=areas_artigo, sistemas_artigo=sistemas_artigo)
+    return render_template(
+        "artigos/editar_artigo.html",
+        artigo=artigo,
+        arquivos=arquivos,
+        tipos_artigo=tipos_artigo,
+        areas_artigo=areas_artigo,
+        sistemas_artigo=sistemas_artigo,
+        can_submit_actions=can_submit_actions,
+    )
 
 @articles_bp.route("/aprovacao", endpoint='aprovacao')
 def aprovacao():

--- a/templates/artigos/editar_artigo.html
+++ b/templates/artigos/editar_artigo.html
@@ -149,9 +149,7 @@
           <div id="preview" class="row g-3 mb-3"></div>
 
           <div class="mt-4">
-            {% set allowed = [ArticleStatus.RASCUNHO, ArticleStatus.EM_REVISAO, ArticleStatus.EM_AJUSTE,
-            ArticleStatus.REJEITADO] %}
-            {% if session.get('username') == artigo.author.username and artigo.status in allowed %}
+            {% if can_submit_actions %}
             <button type="submit" name="acao" value="salvar" class="btn btn-outline-primary me-2">Salvar</button>
             <button type="submit" name="acao" value="enviar" class="btn btn-success">Enviar para revisão</button>
             {% endif %}

--- a/tests/test_required_fields.py
+++ b/tests/test_required_fields.py
@@ -110,3 +110,26 @@ def test_editar_artigo_requires_fields(client):
         art = Article.query.get(aid)
         assert art.titulo == 'T'
         assert art.texto == 'C'
+
+
+def test_editar_artigo_buttons_visible_for_editor_with_permission(client):
+    author_id = _login_user(client, ['artigo_criar'])
+    with app.app_context():
+        author = User.query.get(author_id)
+        inst = Instituicao.query.first()
+        art = Article(
+            titulo='Rascunho compartilhado', texto='Conteúdo', status=ArticleStatus.RASCUNHO,
+            user_id=author_id, celula_id=author.celula_id, setor_id=author.setor_id,
+            estabelecimento_id=author.estabelecimento_id, instituicao_id=inst.id
+        )
+        db.session.add(art)
+        db.session.commit()
+        aid = art.id
+
+    _login_user(client, [Permissao.ARTIGO_EDITAR_CELULA])
+    response = client.get(f'/artigo/{aid}/editar')
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert 'name="acao" value="salvar"' in html
+    assert 'name="acao" value="enviar"' in html


### PR DESCRIPTION
### Motivation
- The edit page hid the `Salvar` / `Enviar para revisão` buttons by comparing `session.username` to the article author, preventing valid editors from seeing actions. 
- The UI decision should reflect backend business rules about which article statuses allow submission/editing. 
- The server must also guard `POST` updates so edits are rejected when the article is in a non-editable status.

### Description
- In `blueprints/articles.py` introduce an `editable_statuses` set (`RASCUNHO`, `EM_REVISAO`, `EM_AJUSTE`, `REJEITADO`) and compute `can_submit_actions` from `artigo.status`. 
- Block `POST` updates in `editar_artigo` when `can_submit_actions` is false, returning a flash and redirect. 
- Expose `can_submit_actions` to the template and replace the previous author/session check in `templates/artigos/editar_artigo.html` with `if can_submit_actions` to control rendering of the `Salvar` and `Enviar para revisão` buttons. 
- Add a regression test `test_editar_artigo_buttons_visible_for_editor_with_permission` in `tests/test_required_fields.py` that ensures a user with edit permission (same cell) but not the original author sees the action buttons on a draft.

### Testing
- Ran `pytest -q tests/test_required_fields.py`, which passed (`5 passed`).
- Verified the updated template and backend render the buttons when `can_submit_actions` is true and block `POST` updates when false.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb831095f0832ea37e657528e55a1b)