### PR TITLE
Corrige fluxo de rascunho para não enviar aprovação automaticamente

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -105,7 +105,10 @@ def novo_artigo():
             return redirect(url_for('novo_artigo'))
 
         # 1.1) Descobre se é rascunho ou envio para revisão
-        acao   = request.form.get('acao', 'enviar')  # 'rascunho' ou 'enviar'
+        # Quando a submissão ocorre via fetch/FormData sem submitter explícito,
+        # o campo `acao` pode não ser enviado. Nesse caso, salva como rascunho
+        # por padrão para evitar envio indevido para aprovação.
+        acao   = request.form.get('acao', 'rascunho')  # 'rascunho' ou 'enviar'
         status = (ArticleStatus.RASCUNHO
                   if acao == 'rascunho'
                   else ArticleStatus.PENDENTE)

--- a/templates/artigos/novo_artigo.html
+++ b/templates/artigos/novo_artigo.html
@@ -304,6 +304,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     try {
       const formData = new FormData(form);
+      const submitter = event.submitter;
+      if (submitter?.name && !formData.has(submitter.name)) {
+        formData.append(submitter.name, submitter.value);
+      }
       const response = await fetch(form.action || window.location.href, {
         method: 'POST',
         body: formData

--- a/tests/test_notification_filtering.py
+++ b/tests/test_notification_filtering.py
@@ -11,8 +11,9 @@ from core.models import (
     User,
     Funcao,
     Notification,
+    Article,
 )
-from core.enums import Permissao
+from core.enums import Permissao, ArticleStatus
 
 
 def add_perm(user, code):
@@ -77,4 +78,27 @@ def test_notification_only_for_allowed_users(client_with_users):
     n1 = Notification.query.filter_by(user_id=data['ap1'].id).count()
     n2 = Notification.query.filter_by(user_id=data['ap2'].id).count()
     assert n1 == 1
+    assert n2 == 0
+
+
+def test_novo_artigo_sem_acao_fica_rascunho(client_with_users):
+    client, data = client_with_users
+    login(client, data['author'])
+    resp = client.post('/novo-artigo', data={
+        'titulo': 'Sem ação explícita',
+        'texto': '<p>x</p>',
+        'visibility': 'celula',
+    })
+    assert resp.status_code == 302
+
+    artigo = Article.query.filter_by(
+        user_id=data['author'].id,
+        titulo='Sem ação explícita'
+    ).order_by(Article.id.desc()).first()
+    assert artigo is not None
+    assert artigo.status == ArticleStatus.RASCUNHO
+
+    n1 = Notification.query.filter_by(user_id=data['ap1'].id).count()
+    n2 = Notification.query.filter_by(user_id=data['ap2'].id).count()
+    assert n1 == 0
     assert n2 == 0


### PR DESCRIPTION
### Motivation
- Submissões via `fetch` podem não incluir o botão clicado, fazendo com que o campo `acao` venha ausente e rascunhos sejam indevidamente marcados como pendentes e enviados para aprovação.

### Description
- Ajusta o fallback de `acao` para `'rascunho'` em `novo_artigo` no arquivo `blueprints/articles.py` para não transformar posts sem `acao` em `PENDENTE`.
- Garante que o `FormData` enviado pelo JavaScript inclua o botão clicado usando `event.submitter` em `templates/artigos/novo_artigo.html` para preservar a intenção entre `Salvar Rascunho` e `Enviar para Revisão`.
- Adiciona um teste de regressão em `tests/test_notification_filtering.py` que valida que um POST sem `acao` resulta em `ArticleStatus.RASCUNHO` e não gera notificações de aprovação.

### Testing
- Executei `pytest -q tests/test_notification_filtering.py` e os testes relacionados passaram (`2 passed`).
- Os testes exibiram apenas avisos de compatibilidade do SQLAlchemy e não apontaram falha nas mudanças aplicadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb86fb0a50832eb149f83fea09915e)