### PR TITLE
Mostrar histórico de ajustes e solicitações de revisão na tela de aprovação

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -629,10 +629,22 @@ def aprovacao_detail(artigo_id):
 
     # GET → renderiza detalhes e histórico
     arquivos = json.loads(artigo.arquivos or '[]')
+    comments_history = (
+        artigo.comments
+        .order_by(Comment.created_at.asc(), Comment.id.asc())
+        .all()
+    )
+    revision_history = (
+        artigo.revision_requests
+        .order_by(RevisionRequest.created_at.asc(), RevisionRequest.id.asc())
+        .all()
+    )
     return render_template(
         'artigos/aprovacao_detail.html',
         artigo   = artigo,
-        arquivos = arquivos
+        arquivos = arquivos,
+        comments_history=comments_history,
+        revision_history=revision_history
     )
 
 @articles_bp.route('/solicitar_revisao/<int:artigo_id>', methods=['GET','POST'], endpoint='solicitar_revisao')

--- a/templates/artigos/aprovacao_detail.html
+++ b/templates/artigos/aprovacao_detail.html
@@ -66,6 +66,40 @@
         <p class="text-muted mt-3">Sem anexos.</p>
         {% endif %}
 
+        {% if comments_history %}
+        <hr>
+        <h5 class="mt-4">Histórico de Ajustes</h5>
+        <ul class="list-group mb-3">
+          {% for c in comments_history %}
+          {% set nome = c.autor.nome_completo if c.autor and c.autor.nome_completo else (c.autor.username if c.autor else 'Usuário') %}
+          {% set parts = nome.split() %}
+          <li class="list-group-item">
+            <strong>{{ parts[0] }} {{ parts[-1] }}</strong>
+            <small class="text-muted">
+              {{ c.created_at.strftime('%d/%m/%Y %H:%M') if c.created_at else '' }}
+            </small><br>
+            {{ c.texto }}
+          </li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+
+        {% if revision_history %}
+        <hr>
+        <h5 class="mt-4">Histórico de Solicitações de Revisão</h5>
+        <ul class="list-group mb-3">
+          {% for rr in revision_history %}
+          <li class="list-group-item">
+            <strong>{{ rr.user.nome_completo if rr.user and rr.user.nome_completo else (rr.user.username if rr.user else 'Usuário') }}</strong>
+            <small class="text-muted">
+              {{ rr.created_at.strftime('%d/%m/%Y %H:%M') if rr.created_at else '' }}
+            </small><br>
+            {{ rr.comentario }}
+          </li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+
         <hr>
         {% if artigo.status == ArticleStatus.PENDENTE %}
         <form method="POST" id="reviewForm" novalidate>

--- a/tests/test_article_approval_review.py
+++ b/tests/test_article_approval_review.py
@@ -13,6 +13,7 @@ from core.models import (
     ArticleVisibility,
     ArticleStatus,
     Comment,
+    RevisionRequest,
 )
 from core.enums import Permissao
 from core.utils import (
@@ -335,3 +336,55 @@ def test_author_cannot_approve_own_article(app_ctx, client):
         art_db = Article.query.get(art_id)
         assert art_db.status == ArticleStatus.PENDENTE
         assert Comment.query.count() == 0
+
+
+def test_aprovacao_detail_shows_adjustment_and_revision_history(app_ctx, client):
+    with app.app_context():
+        inst = Instituicao(codigo='I1', nome='Inst')
+        est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao=inst)
+        setor = Setor(nome='S', estabelecimento=est)
+        cel = Celula(nome='C', estabelecimento=est, setor=setor)
+        db.session.add_all([inst, est, setor, cel])
+        db.session.flush()
+
+        autor = User(
+            username='autor', email='a@test', password_hash='x',
+            estabelecimento=est, setor=setor, celula=cel
+        )
+        revisor = User(
+            username='revisor', email='r@test', password_hash='x',
+            estabelecimento=est, setor=setor, celula=cel
+        )
+        db.session.add_all([autor, revisor])
+        db.session.flush()
+
+        art = Article(
+            titulo='TituloHistorico', texto='Conteudo', status=ArticleStatus.PENDENTE,
+            user_id=autor.id, celula_id=cel.id,
+            estabelecimento_id=est.id, setor_id=setor.id,
+            instituicao_id=inst.id, visibility=ArticleVisibility.CELULA
+        )
+        db.session.add(art)
+        db.session.flush()
+
+        db.session.add(Comment(artigo_id=art.id, user_id=revisor.id, texto='Precisa ajustar introdução'))
+        db.session.add(RevisionRequest(artigo_id=art.id, user_id=autor.id, comentario='Solicito nova revisão após ajustes'))
+
+        f = Funcao(codigo=Permissao.ARTIGO_APROVAR_CELULA.value, nome='ap')
+        db.session.add(f)
+        db.session.flush()
+        revisor.permissoes_personalizadas.append(f)
+        db.session.commit()
+
+        art_id = art.id
+        revisor_id = revisor.id
+
+    with client.session_transaction() as sess:
+        sess['user_id'] = revisor_id
+
+    resp = client.get(f'/aprovacao/{art_id}')
+    assert resp.status_code == 200
+    assert b'Hist\xc3\xb3rico de Ajustes' in resp.data
+    assert b'Precisa ajustar introdu\xc3\xa7\xc3\xa3o' in resp.data
+    assert b'Hist\xc3\xb3rico de Solicita\xc3\xa7\xc3\xb5es de Revis\xc3\xa3o' in resp.data
+    assert b'Solicito nova revis\xc3\xa3o ap\xc3\xb3s ajustes' in resp.data


### PR DESCRIPTION
### Motivation

- O aprovador precisa ver todo o histórico de ajustes e pedidos de revisão do artigo diretamente na página de aprovação para tomar decisões com contexto completo.
- A tela de aprovação antes não exibia as coleções completas de `Comment` e `RevisionRequest`, tornando necessário abrir outras telas para consultar o histórico.

### Description

- No GET de `aprovacao_detail` em `blueprints/articles.py` passei a carregar e ordenar `comments_history` e `revision_history` (por `created_at` e `id`) e a enviá-las ao template. 
- Em `templates/artigos/aprovacao_detail.html` adicionei as seções visíveis condicionalmente `Histórico de Ajustes` e `Histórico de Solicitações de Revisão` com autor/solicitante, data/hora e texto. 
- Adicionei o teste `test_aprovacao_detail_shows_adjustment_and_revision_history` em `tests/test_article_approval_review.py` para validar a renderização dos dois históricos na página.

### Testing

- Executei `pytest -q tests/test_article_approval_review.py -k "historico or aprovacao_requer_comentario"` e o teste relacionado ao comentário obrigatório passou (1 passed, 9 deselected).
- Executei `pytest -q tests/test_article_approval_review.py -k "shows_adjustment_and_revision_history"` e o novo teste de exibição de históricos passou (1 passed, 9 deselected).
- Todos os testes executados localmente passaram com sucesso (nenhum teste novo falhou).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb89694850832eb5d5d95e542db919)