### PR TITLE
Allow article creation with attachment-only content; add server error handling and use native form submit

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -99,9 +99,10 @@ def novo_artigo():
         area_id = request.form.get('area_id', type=int)
         sistema_id = request.form.get('sistema_id', type=int)
 
-        # Campos obrigatórios
-        if not titulo or not texto_limpo:
-            flash('Título e texto são obrigatórios.', 'warning')
+        # Campos obrigatórios: título e ao menos texto ou anexo
+        has_uploads = any(f and f.filename for f in files)
+        if not titulo or (not texto_limpo and not has_uploads):
+            flash('Título e conteúdo são obrigatórios (texto ou anexo).', 'warning')
             return redirect(url_for('novo_artigo'))
 
         # 1.1) Descobre se é rascunho ou envio para revisão
@@ -143,72 +144,93 @@ def novo_artigo():
         elif vis is ArticleVisibility.CELULA:
             vis_cel_id = user.celula_id
 
-        # 3) Cria o artigo (sem arquivos ainda) e dá um flush para ter ID
-        artigo = Article(
-            titulo     = titulo,
-            texto      = texto_limpo,
-            status     = status,
-            user_id    = user.id,
-            celula_id  = user.celula_id or 1,
-            visibility = vis,
-            instituicao_id = inst_id,
-            estabelecimento_id = est_id,
-            setor_id = setor_vis_id,
-            vis_celula_id = vis_cel_id,
-            tipo_id = tipo_id,
-            area_id = area_id,
-            sistema_id = sistema_id,
-            arquivos   = None,
-            created_at = datetime.now(timezone.utc),
-            updated_at = datetime.now(timezone.utc)
+        app.logger.info(
+            "Criando artigo user_id=%s acao=%s vis=%s anexos=%s titulo_len=%s texto_len=%s progress_id=%s",
+            user.id,
+            acao,
+            vis.value,
+            len([f for f in files if f and f.filename]),
+            len(titulo),
+            len(texto_limpo),
+            progress_id,
         )
-        db.session.add(artigo)
-        db.session.flush()
+        try:
+            # 3) Cria o artigo (sem arquivos ainda) e dá um flush para ter ID
+            artigo = Article(
+                titulo     = titulo,
+                texto      = texto_limpo,
+                status     = status,
+                user_id    = user.id,
+                celula_id  = user.celula_id or 1,
+                visibility = vis,
+                instituicao_id = inst_id,
+                estabelecimento_id = est_id,
+                setor_id = setor_vis_id,
+                vis_celula_id = vis_cel_id,
+                tipo_id = tipo_id,
+                area_id = area_id,
+                sistema_id = sistema_id,
+                arquivos   = None,
+                created_at = datetime.now(timezone.utc),
+                updated_at = datetime.now(timezone.utc)
+            )
+            db.session.add(artigo)
+            db.session.flush()
 
-        # 3) Salva arquivos com nome único, extrai texto e cria Attachments
-        filenames = []
-        for f in files:
-            if f and f.filename:
-                original = secure_filename(f.filename)
-                if len(original) > 40:
-                    name, ext = os.path.splitext(original)
-                    original = name[:40 - len(ext)] + ext
-                unique_name = f"{uuid.uuid4().hex}_{original}"
-                dest       = os.path.join(app.config['UPLOAD_FOLDER'], unique_name)
-                f.save(dest)
-                filenames.append(unique_name)
+            # 3) Salva arquivos com nome único, extrai texto e cria Attachments
+            filenames = []
+            for f in files:
+                if f and f.filename:
+                    original = secure_filename(f.filename)
+                    if len(original) > 40:
+                        name, ext = os.path.splitext(original)
+                        original = name[:40 - len(ext)] + ext
+                    unique_name = f"{uuid.uuid4().hex}_{original}"
+                    dest       = os.path.join(app.config['UPLOAD_FOLDER'], unique_name)
+                    f.save(dest)
+                    filenames.append(unique_name)
 
-                # extrai texto e descobre MIME
-                texto_extraido = extract_text(dest, progress_callback=emit_progress)
-                mime_type, _   = guess_type(dest)
+                    # extrai texto e descobre MIME
+                    texto_extraido = extract_text(dest, progress_callback=emit_progress)
+                    mime_type, _   = guess_type(dest)
 
-                # cria o registro de attachment
-                attachment = Attachment(
-                    article   = artigo,
-                    filename  = unique_name,
-                    mime_type = mime_type or 'application/octet-stream',
-                    content   = texto_extraido
-                )
-                db.session.add(attachment)
+                    # cria o registro de attachment
+                    attachment = Attachment(
+                        article   = artigo,
+                        filename  = unique_name,
+                        mime_type = mime_type or 'application/octet-stream',
+                        content   = texto_extraido
+                    )
+                    db.session.add(attachment)
 
-        # 4) Atualiza o campo JSON de nomes no artigo
-        artigo.arquivos = json.dumps(filenames) if filenames else None
+            # 4) Atualiza o campo JSON de nomes no artigo
+            artigo.arquivos = json.dumps(filenames) if filenames else None
 
-        # 5) Persiste tudo num único commit
-        db.session.commit()
-        mark_progress_done(progress_id)
-
-        # 6) Notifica responsáveis/admins, se necessário
-        if status is ArticleStatus.PENDENTE:
-            destinatarios = eligible_review_notification_users(artigo)
-            for dest in destinatarios:
-                notif = Notification(
-                    user_id = dest.id,
-                    message = f'Novo artigo pendente para revisão: “{artigo.titulo}”',
-                    url     = url_for('aprovacao_detail', artigo_id=artigo.id)
-                )
-                db.session.add(notif)
+            # 5) Persiste tudo num único commit
             db.session.commit()
+            mark_progress_done(progress_id)
+
+            # 6) Notifica responsáveis/admins, se necessário
+            if status is ArticleStatus.PENDENTE:
+                destinatarios = eligible_review_notification_users(artigo)
+                for dest in destinatarios:
+                    notif = Notification(
+                        user_id = dest.id,
+                        message = f'Novo artigo pendente para revisão: “{artigo.titulo}”',
+                        url     = url_for('aprovacao_detail', artigo_id=artigo.id)
+                    )
+                    db.session.add(notif)
+                db.session.commit()
+        except Exception:
+            db.session.rollback()
+            app.logger.exception(
+                "Falha ao criar artigo user_id=%s progress_id=%s titulo=%r",
+                user.id,
+                progress_id,
+                titulo,
+            )
+            flash('Ocorreu um erro ao salvar o artigo. Tente novamente e, se persistir, contate o suporte.', 'danger')
+            return redirect(url_for('novo_artigo'))
 
         # 7) Feedback para o usuário
         flash(

--- a/templates/artigos/novo_artigo.html
+++ b/templates/artigos/novo_artigo.html
@@ -292,39 +292,18 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const form = document.querySelector('form');
-  form.addEventListener('submit', async (event) => {
-    event.preventDefault();
+  form.addEventListener('submit', (event) => {
     document.getElementById('hidden-texto').value = quill.root.innerHTML;
+
     const progressId = progressIdInput?.value || (crypto.randomUUID ? crypto.randomUUID() : String(Date.now()));
     if (progressIdInput) progressIdInput.value = progressId;
+
     resetProgressMessages();
     setOverlayState('Enviando artigo e anexos...', 0);
     startProgressPolling(progressId);
-    localStorage.removeItem(STORAGE_KEY);
 
-    try {
-      const formData = new FormData(form);
-      const submitter = event.submitter;
-      if (submitter?.name && !formData.has(submitter.name)) {
-        formData.append(submitter.name, submitter.value);
-      }
-      const response = await fetch(form.action || window.location.href, {
-        method: 'POST',
-        body: formData
-      });
-
-      if (response.redirected) {
-        completeBar();
-        window.location.href = response.url;
-        return;
-      }
-    } catch (err) {
-      console.error('Falha ao enviar artigo', err);
-    }
-
-    completeBar();
-    stopProgressPolling();
-    setTimeout(() => window.location.reload(), 400);
+    // Observação: submissão nativa do formulário é mantida para preservar
+    // redirects/flash do servidor e evitar perder estado em caso de erro.
   });
 
   // Preview de anexos

--- a/tests/test_required_fields.py
+++ b/tests/test_required_fields.py
@@ -1,4 +1,5 @@
 import pytest
+from io import BytesIO
 from app import app, db
 from core.models import (
     Instituicao,
@@ -91,6 +92,23 @@ def test_novo_artigo_requires_fields(client):
     with app.app_context():
         assert Article.query.count() == 0
 
+
+
+
+def test_novo_artigo_accepts_attachment_without_text(client):
+    _login_user(client, ['artigo_criar'])
+    client.post('/novo-artigo', data={
+        'titulo': 'OCR sem texto',
+        'texto': '',
+        'visibility': 'celula',
+        'acao': 'enviar',
+        'files': (BytesIO(b'conteudo teste ocr'), 'ocr.txt'),
+    }, content_type='multipart/form-data', follow_redirects=True)
+
+    with app.app_context():
+        artigo = Article.query.filter_by(titulo='OCR sem texto').first()
+        assert artigo is not None
+        assert artigo.status == ArticleStatus.PENDENTE
 
 def test_editar_artigo_requires_fields(client):
     uid = _login_user(client, ['artigo_criar', Permissao.ARTIGO_EDITAR_CELULA])


### PR DESCRIPTION
### Motivation
- Allow creating an article when the title is present and an attachment is uploaded even if `texto` is empty. 
- Improve robustness of the article creation flow by adding logging and transactional error handling. 
- Keep client-side form submission native to preserve server redirects and flash messages.

### Description
- Relaxed required-fields check in `novo_artigo` to accept submissions when `titulo` is present and at least one uploaded file exists, and updated the user-facing message accordingly. 
- Added an `app.logger.info` call to record article creation parameters and wrapped DB work in a `try/except` that calls `db.session.rollback()` and logs exceptions, flashes an error and redirects on failure. 
- Ensured attachments are saved, `Attachment` rows are created, `artigo.arquivos` is set, and notifications for pending articles are created and committed inside the transaction. 
- Changed the front-end submit handler in `templates/artigos/novo_artigo.html` to use the native form submission (removed the fetch-based async submit) while preserving progress-id setup and hidden `texto` population. 
- Added a new functional test `test_novo_artigo_accepts_attachment_without_text` and imported `BytesIO` to simulate multipart file uploads in `tests/test_required_fields.py`.

### Testing
- Ran the tests in `tests/test_required_fields.py` (via `pytest`) which include `test_novo_artigo_requires_fields` and the new `test_novo_artigo_accepts_attachment_without_text`, and they passed. 
- Ran the repository test suite with `pytest` and observed no regressions related to article creation flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9f1f6ea8832e951ed623f3c48dae)