### PR TITLE
Desacopla OCR de anexos da requisição e cria rotina técnica assíncrona

### DIFF
--- a/app.py
+++ b/app.py
@@ -111,6 +111,10 @@ try:
     from .core.services.permission_sync import sync_permission_catalog_with_lock
 except ImportError:  # pragma: no cover - fallback for direct execution
     from core.services.permission_sync import sync_permission_catalog_with_lock
+try:
+    from .core.services.ocr_queue import process_pending_ocr_attachments
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from core.services.ocr_queue import process_pending_ocr_attachments
 
 from mimetypes import guess_type # Se for usar, descomente
 from werkzeug.utils import secure_filename # Útil para uploads, como na sua foto de perfil
@@ -238,6 +242,28 @@ def bootstrap_permissions_command() -> None:
     click.echo(
         "✅ Catálogo de permissões sincronizado. "
         f"created={result.created} updated={result.updated} unchanged={result.unchanged}"
+    )
+
+
+@app.cli.command("process-ocr-pendente")
+@click.option("--batch-size", default=20, show_default=True, type=int)
+@click.option("--stuck-timeout-minutes", default=30, show_default=True, type=int)
+@click.option("--low-yield-threshold", default=80, show_default=True, type=int)
+def process_ocr_pendente_command(
+    batch_size: int,
+    stuck_timeout_minutes: int,
+    low_yield_threshold: int,
+) -> None:
+    """Processa OCR dos anexos pendentes fora da request web."""
+    result = process_pending_ocr_attachments(
+        batch_size=batch_size,
+        stuck_timeout_minutes=stuck_timeout_minutes,
+        low_yield_threshold=low_yield_threshold,
+    )
+    click.echo(
+        "✅ OCR pendente processado. "
+        f"recover={result.recovered_stuck} processed={result.processed} "
+        f"concluido={result.concluded} baixo_aproveitamento={result.low_yield} erro={result.failed}"
     )
 
 

--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -20,7 +20,6 @@ except ImportError:
 try:
     from ..core.utils import (
         sanitize_html,
-        extract_text,
         eligible_review_notification_users,
         user_can_view_article,
         user_can_edit_article,
@@ -30,7 +29,6 @@ try:
 except ImportError:  # pragma: no cover - fallback for direct execution
     from core.utils import (
         sanitize_html,
-        extract_text,
         eligible_review_notification_users,
         user_can_view_article,
         user_can_edit_article,
@@ -38,8 +36,19 @@ except ImportError:  # pragma: no cover - fallback for direct execution
         user_can_review_article,
     )
 try:
+    from ..core.services.ocr_queue import (
+        enqueue_attachment_for_ocr,
+        is_pdf_ocr_eligible,
+        OCR_STATUS_CONCLUIDO,
+    )
+except ImportError:  # pragma: no cover
+    from core.services.ocr_queue import (
+        enqueue_attachment_for_ocr,
+        is_pdf_ocr_eligible,
+        OCR_STATUS_CONCLUIDO,
+    )
+try:
     from ..core.progress import (
-        add_progress_message,
         clear_progress,
         get_progress,
         init_progress,
@@ -47,7 +56,6 @@ try:
     )
 except ImportError:  # pragma: no cover
     from core.progress import (
-        add_progress_message,
         clear_progress,
         get_progress,
         init_progress,
@@ -125,15 +133,6 @@ def novo_artigo():
         progress_id = request.form.get("progress_id")
         init_progress(progress_id)
 
-        def emit_progress(payload) -> None:
-            if isinstance(payload, dict):
-                msg = payload.get("message")
-                percent = payload.get("percent")
-            else:
-                msg = str(payload) if payload is not None else None
-                percent = None
-            add_progress_message(progress_id, msg, percent=percent)
-
         inst_id = est_id = setor_vis_id = vis_cel_id = None
         if vis is ArticleVisibility.INSTITUICAO and user.estabelecimento:
             inst_id = user.estabelecimento.instituicao_id
@@ -190,17 +189,19 @@ def novo_artigo():
                     f.save(dest)
                     filenames.append(unique_name)
 
-                    # extrai texto e descobre MIME
-                    texto_extraido = extract_text(dest, progress_callback=emit_progress)
-                    mime_type, _   = guess_type(dest)
+                    mime_type, _ = guess_type(dest)
+                    ocr_eligible = is_pdf_ocr_eligible(unique_name, mime_type)
 
                     # cria o registro de attachment
                     attachment = Attachment(
                         article   = artigo,
                         filename  = unique_name,
                         mime_type = mime_type or 'application/octet-stream',
-                        content   = texto_extraido
+                        content   = None,
+                        ocr_status= OCR_STATUS_CONCLUIDO,
                     )
+                    if ocr_eligible:
+                        enqueue_attachment_for_ocr(attachment)
                     db.session.add(attachment)
 
             # 4) Atualiza o campo JSON de nomes no artigo
@@ -367,15 +368,6 @@ def editar_artigo(artigo_id):
         progress_id = request.form.get("progress_id")
         init_progress(progress_id)
 
-        def emit_progress(payload) -> None:
-            if isinstance(payload, dict):
-                msg = payload.get("message")
-                percent = payload.get("percent")
-            else:
-                msg = str(payload) if payload is not None else None
-                percent = None
-            add_progress_message(progress_id, msg, percent=percent)
-
         # campos básicos
         titulo = request.form["titulo"].strip()
         texto  = request.form["texto"].strip()
@@ -442,17 +434,17 @@ def editar_artigo(artigo_id):
                 f.save(dest)
                 existing.append(unique_name)
 
-                # 1) extrai texto
-                texto_extraido = extract_text(dest, progress_callback=emit_progress)
-                # 2) descobre o MIME
                 mime_type, _ = guess_type(dest)
-                # 3) adiciona o attachment ao session
+                ocr_eligible = is_pdf_ocr_eligible(unique_name, mime_type)
                 attachment = Attachment(
                     article=artigo,
                     filename=unique_name,
                     mime_type=mime_type or "application/octet-stream",
-                    content=texto_extraido
+                    content=None,
+                    ocr_status=OCR_STATUS_CONCLUIDO,
                 )
+                if ocr_eligible:
+                    enqueue_attachment_for_ocr(attachment)
                 db.session.add(attachment)
 
         artigo.arquivos = json.dumps(existing) if existing else None

--- a/core/models.py
+++ b/core/models.py
@@ -442,6 +442,12 @@ class Attachment(db.Model):
     original_filename = db.Column(db.Text, nullable=True) # Nome original do arquivo
     mime_type = db.Column(db.Text, nullable=False)
     content = db.Column(db.Text, nullable=True)  # texto extraído para busca
+    ocr_status = db.Column(db.String(32), nullable=False, default='concluido', server_default='concluido')
+    ocr_attempts = db.Column(db.Integer, nullable=False, default=0, server_default='0')
+    ocr_requested_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    ocr_started_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    ocr_finished_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    ocr_last_error = db.Column(db.Text, nullable=True)
     created_at = db.Column(db.DateTime(timezone=True), server_default=func.now(), nullable=False)
 
     article = db.relationship('Article', back_populates='attachments')

--- a/core/services/ocr_queue.py
+++ b/core/services/ocr_queue.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from mimetypes import guess_type
+from pathlib import Path
+
+from flask import current_app
+
+try:
+    from ..database import db
+    from ..models import Attachment
+    from ..utils import extract_text
+except ImportError:  # pragma: no cover
+    from core.database import db
+    from core.models import Attachment
+    from core.utils import extract_text
+
+OCR_STATUS_PENDENTE = "pendente"
+OCR_STATUS_PROCESSANDO = "processando"
+OCR_STATUS_CONCLUIDO = "concluido"
+OCR_STATUS_ERRO = "erro"
+OCR_STATUS_BAIXO_APROVEITAMENTO = "baixo_aproveitamento"
+
+
+@dataclass
+class OCRBatchResult:
+    recovered_stuck: int = 0
+    processed: int = 0
+    concluded: int = 0
+    low_yield: int = 0
+    failed: int = 0
+
+
+def is_pdf_ocr_eligible(filename: str, mime_type: str | None = None) -> bool:
+    guessed_mime = mime_type or guess_type(filename)[0]
+    return (guessed_mime == "application/pdf") or filename.lower().endswith(".pdf")
+
+
+def enqueue_attachment_for_ocr(attachment: Attachment) -> None:
+    attachment.ocr_status = OCR_STATUS_PENDENTE
+    attachment.ocr_requested_at = datetime.now(timezone.utc)
+    attachment.ocr_started_at = None
+    attachment.ocr_finished_at = None
+    attachment.ocr_last_error = None
+
+
+def _recover_stuck_processing(stuck_timeout_minutes: int) -> int:
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=stuck_timeout_minutes)
+    stuck_items = (
+        Attachment.query
+        .filter(Attachment.ocr_status == OCR_STATUS_PROCESSANDO)
+        .filter(Attachment.ocr_started_at.isnot(None))
+        .filter(Attachment.ocr_started_at < cutoff)
+        .all()
+    )
+
+    for item in stuck_items:
+        item.ocr_status = OCR_STATUS_PENDENTE
+        item.ocr_last_error = "Reenfileirado automaticamente após timeout em processando."
+    if stuck_items:
+        db.session.commit()
+
+    return len(stuck_items)
+
+
+def process_pending_ocr_attachments(
+    batch_size: int = 20,
+    stuck_timeout_minutes: int = 30,
+    low_yield_threshold: int = 80,
+) -> OCRBatchResult:
+    result = OCRBatchResult()
+    result.recovered_stuck = _recover_stuck_processing(stuck_timeout_minutes)
+
+    pendentes = (
+        Attachment.query
+        .filter(Attachment.ocr_status == OCR_STATUS_PENDENTE)
+        .order_by(Attachment.ocr_requested_at.asc().nullsfirst(), Attachment.created_at.asc())
+        .limit(batch_size)
+        .all()
+    )
+
+    upload_folder = Path(current_app.config["UPLOAD_FOLDER"])
+
+    for attachment in pendentes:
+        result.processed += 1
+
+        attachment.ocr_status = OCR_STATUS_PROCESSANDO
+        attachment.ocr_started_at = datetime.now(timezone.utc)
+        attachment.ocr_attempts = (attachment.ocr_attempts or 0) + 1
+        db.session.commit()
+
+        file_path = upload_folder / attachment.filename
+
+        try:
+            content = extract_text(str(file_path))
+            attachment.content = content
+            attachment.ocr_finished_at = datetime.now(timezone.utc)
+            attachment.ocr_last_error = None
+
+            if len((content or "").strip()) < low_yield_threshold:
+                attachment.ocr_status = OCR_STATUS_BAIXO_APROVEITAMENTO
+                result.low_yield += 1
+            else:
+                attachment.ocr_status = OCR_STATUS_CONCLUIDO
+                result.concluded += 1
+        except Exception as exc:  # pragma: no cover - proteção operacional
+            attachment.ocr_status = OCR_STATUS_ERRO
+            attachment.ocr_finished_at = datetime.now(timezone.utc)
+            attachment.ocr_last_error = str(exc)
+            result.failed += 1
+            current_app.logger.exception(
+                "Falha no OCR do attachment id=%s filename=%s",
+                attachment.id,
+                attachment.filename,
+            )
+
+        db.session.commit()
+
+    return result

--- a/migrations/versions/a1f0b3c9d2e4_add_ocr_queue_fields_to_attachment.py
+++ b/migrations/versions/a1f0b3c9d2e4_add_ocr_queue_fields_to_attachment.py
@@ -1,7 +1,7 @@
 """add ocr queue fields to attachment
 
 Revision ID: a1f0b3c9d2e4
-Revises: 4c93f35865c8
+Revises: 5a7c9d1e2f34
 Create Date: 2026-04-24 00:00:00.000000
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'a1f0b3c9d2e4'
-down_revision = '4c93f35865c8'
+down_revision = '5a7c9d1e2f34'
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/a1f0b3c9d2e4_add_ocr_queue_fields_to_attachment.py
+++ b/migrations/versions/a1f0b3c9d2e4_add_ocr_queue_fields_to_attachment.py
@@ -1,0 +1,36 @@
+"""add ocr queue fields to attachment
+
+Revision ID: a1f0b3c9d2e4
+Revises: 4c93f35865c8
+Create Date: 2026-04-24 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a1f0b3c9d2e4'
+down_revision = '4c93f35865c8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('attachment', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('ocr_status', sa.String(length=32), nullable=False, server_default='concluido'))
+        batch_op.add_column(sa.Column('ocr_attempts', sa.Integer(), nullable=False, server_default='0'))
+        batch_op.add_column(sa.Column('ocr_requested_at', sa.DateTime(timezone=True), nullable=True))
+        batch_op.add_column(sa.Column('ocr_started_at', sa.DateTime(timezone=True), nullable=True))
+        batch_op.add_column(sa.Column('ocr_finished_at', sa.DateTime(timezone=True), nullable=True))
+        batch_op.add_column(sa.Column('ocr_last_error', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('attachment', schema=None) as batch_op:
+        batch_op.drop_column('ocr_last_error')
+        batch_op.drop_column('ocr_finished_at')
+        batch_op.drop_column('ocr_started_at')
+        batch_op.drop_column('ocr_requested_at')
+        batch_op.drop_column('ocr_attempts')
+        batch_op.drop_column('ocr_status')

--- a/tests/test_ocr_queue.py
+++ b/tests/test_ocr_queue.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+from datetime import datetime, timezone
+
+from core.database import db
+from core.models import Attachment
+from core.services.ocr_queue import (
+    OCR_STATUS_BAIXO_APROVEITAMENTO,
+    OCR_STATUS_CONCLUIDO,
+    OCR_STATUS_PENDENTE,
+    OCR_STATUS_PROCESSANDO,
+    enqueue_attachment_for_ocr,
+    is_pdf_ocr_eligible,
+    process_pending_ocr_attachments,
+)
+
+
+def test_is_pdf_ocr_eligible():
+    assert is_pdf_ocr_eligible("arquivo.pdf") is True
+    assert is_pdf_ocr_eligible("arquivo.bin", "application/pdf") is True
+    assert is_pdf_ocr_eligible("arquivo.txt", "text/plain") is False
+
+
+def test_process_pending_ocr_attachments_success(app_ctx, monkeypatch, tmp_path):
+    app_ctx.config["UPLOAD_FOLDER"] = str(tmp_path)
+    file_path = Path(tmp_path) / "anexo.pdf"
+    file_path.write_bytes(b"%PDF-1.4")
+
+    attachment = Attachment(article_id=1, filename="anexo.pdf", mime_type="application/pdf")
+    enqueue_attachment_for_ocr(attachment)
+    db.session.add(attachment)
+    db.session.commit()
+
+    monkeypatch.setattr("core.services.ocr_queue.extract_text", lambda *_: "texto suficiente " * 10)
+
+    result = process_pending_ocr_attachments(batch_size=10, low_yield_threshold=20)
+
+    db.session.refresh(attachment)
+    assert result.processed == 1
+    assert result.concluded == 1
+    assert attachment.ocr_status == OCR_STATUS_CONCLUIDO
+    assert attachment.ocr_attempts == 1
+    assert attachment.ocr_started_at is not None
+    assert attachment.ocr_finished_at is not None
+    assert "texto suficiente" in (attachment.content or "")
+
+
+def test_process_pending_ocr_attachments_recovers_stuck(app_ctx, monkeypatch):
+    attachment = Attachment(article_id=1, filename="travado.pdf", mime_type="application/pdf")
+    attachment.ocr_status = OCR_STATUS_PROCESSANDO
+    attachment.ocr_started_at = datetime.now(timezone.utc)
+    db.session.add(attachment)
+    db.session.commit()
+
+    monkeypatch.setattr("core.services.ocr_queue.extract_text", lambda *_: "curto")
+
+    result = process_pending_ocr_attachments(batch_size=10, low_yield_threshold=10, stuck_timeout_minutes=0)
+
+    db.session.refresh(attachment)
+    assert result.recovered_stuck == 1
+    assert attachment.ocr_status == OCR_STATUS_BAIXO_APROVEITAMENTO
+    assert attachment.ocr_attempts == 1
+    assert attachment.ocr_last_error is None


### PR DESCRIPTION
### Motivation
- Evitar execução de OCR bloqueante durante as requests de criação/edição de artigo para melhorar latência e robustez do upload de anexos. 
- Persistir anexos imediatamente e delegar extração para uma rotina técnica assíncrona para lidar com timeouts, retries e baixa qualidade de OCR. 

### Description
- Remove a chamada síncrona a `extract_text(...)` nas rotas de `novo_artigo` e `editar_artigo` em `blueprints/articles.py` e passa a criar `Attachment` com `content=None`; PDFs elegíveis são enfileirados com `ocr_status='pendente'` via `enqueue_attachment_for_ocr`. 
- Adiciona serviço técnico `core/services/ocr_queue.py` com funções `enqueue_attachment_for_ocr`, `is_pdf_ocr_eligible` e `process_pending_ocr_attachments` que implementam o fluxo `pendente -> processando -> concluido|erro|baixo_aproveitamento` e recuperação de itens presos. 
- Estende o modelo `Attachment` em `core/models.py` e cria migration `migrations/versions/a1f0b3c9d2e4_add_ocr_queue_fields_to_attachment.py` adicionando as colunas `ocr_status`, `ocr_attempts`, `ocr_requested_at`, `ocr_started_at`, `ocr_finished_at` e `ocr_last_error`. 
- Expõe comando CLI agendável `flask process-ocr-pendente` (opções: `--batch-size`, `--stuck-timeout-minutes`, `--low-yield-threshold`) para executar o processamento fora da web request e inclui testes de integração unitária em `tests/test_ocr_queue.py`. 

### Testing
- Executado `pytest -q tests/test_required_fields.py tests/test_article_editing.py tests/test_ocr_queue.py` como suíte focal e todos os testes passaram (`13 passed`).
- Adicionados testes em `tests/test_ocr_queue.py` cobrindo elegibilidade de PDF, processamento bem-sucedido e recuperação de itens presos, e esses cenários foram validados na execução acima.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebcdd35210832eba4afdde8f4dfdc3)