### PR TITLE
Tratamento amigável para uploads acima do limite (413) com log contextual e teste de integração

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ import logging
 import click
 from flask_migrate import Migrate
 from werkzeug.security import check_password_hash, generate_password_hash # generate_password_hash se for resetar senha no admin
+from werkzeug.exceptions import RequestEntityTooLarge
 from sqlalchemy import or_, func
 #from models import user_funcoes
 
@@ -226,6 +227,47 @@ for folder in (UPLOAD_FOLDER, PROFILE_PICS_FOLDER):
     os.makedirs(folder, exist_ok=True)
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 app.config['PROFILE_PICS_FOLDER'] = PROFILE_PICS_FOLDER
+
+
+def _human_readable_size(size_in_bytes: int) -> str:
+    """Converte bytes para uma representação curta e amigável."""
+    if size_in_bytes < 1024:
+        return f"{size_in_bytes} B"
+    if size_in_bytes < 1024 * 1024:
+        return f"{size_in_bytes / 1024:.0f} KB"
+    return f"{size_in_bytes / (1024 * 1024):.1f} MB"
+
+
+@app.errorhandler(RequestEntityTooLarge)
+def handle_request_entity_too_large(error):
+    max_content_length = app.config.get('MAX_CONTENT_LENGTH')
+
+    limite_texto = ''
+    if isinstance(max_content_length, int) and max_content_length > 0:
+        limite_texto = f" Limite atual: {_human_readable_size(max_content_length)}."
+
+    flash(
+        "O arquivo enviado excede o tamanho máximo permitido. "
+        f"Reduza o tamanho e tente novamente.{limite_texto}",
+        'danger',
+    )
+
+    app.logger.warning(
+        (
+            "HTTP 413 RequestEntityTooLarge | method=%s path=%s endpoint=%s "
+            "user_id=%s content_length=%s max_content_length=%s remote_addr=%s"
+        ),
+        request.method,
+        request.path,
+        request.endpoint,
+        session.get('user_id'),
+        request.content_length,
+        max_content_length,
+        request.remote_addr,
+    )
+
+    redirect_target = request.referrer or request.url or url_for('pagina_inicial')
+    return redirect(redirect_target)
 
 
 

--- a/tests/test_security_controls.py
+++ b/tests/test_security_controls.py
@@ -1,4 +1,5 @@
 import os
+from io import BytesIO
 import pytest
 
 from app import app, db
@@ -124,6 +125,54 @@ def test_secure_cookie_flags_present(app_ctx):
     assert app.config["SESSION_COOKIE_SECURE"] is True
     assert app.config["SESSION_COOKIE_HTTPONLY"] is True
     assert app.config["SESSION_COOKIE_SAMESITE"] == "Lax"
+
+
+def test_perfil_upload_above_max_content_length_redirects_with_flash(client, app_ctx):
+    original_limit = app.config.get("MAX_CONTENT_LENGTH")
+    app.config["MAX_CONTENT_LENGTH"] = 1024
+    try:
+        with app.app_context():
+            from core.models import Instituicao, Estabelecimento, Setor, Celula
+
+            inst = Instituicao(codigo="INST413", nome="Inst413")
+            est = Estabelecimento(codigo="E413", nome_fantasia="Estab413", instituicao=inst)
+            setor = Setor(nome="Setor413", estabelecimento=est)
+            celula = Celula(nome="Cel413", estabelecimento=est, setor=setor)
+            db.session.add_all([inst, est, setor, celula])
+            db.session.flush()
+
+            user = User(
+                username="upload_413_user",
+                email="upload_413_user@example.com",
+                estabelecimento=est,
+                setor=setor,
+                celula=celula,
+            )
+            user.set_password("Secret1!")
+            db.session.add(user)
+            db.session.commit()
+            user_id = user.id
+
+        with client.session_transaction() as sess:
+            sess["user_id"] = user_id
+            sess["username"] = "upload_413_user"
+
+        oversized_payload = BytesIO(b"a" * 2048)
+        response = client.post(
+            "/perfil",
+            data={"foto": (oversized_payload, "big.jpg")},
+            content_type="multipart/form-data",
+            follow_redirects=True,
+            headers={"Referer": "/perfil"},
+        )
+
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        assert 'class="alert alert-danger' in body
+        assert "O arquivo enviado excede o tamanho máximo permitido." in body
+        assert "Limite atual: 1 KB." in body
+    finally:
+        app.config["MAX_CONTENT_LENGTH"] = original_limit
 
 
 def test_send_email_without_smtp_credentials_raises(monkeypatch):


### PR DESCRIPTION
### Motivation
- Melhorar a experiência do usuário ao receber um erro 413 por upload grande, exibindo uma mensagem amigável e retornando ao formulário.
- Informar o limite configurado (`MAX_CONTENT_LENGTH`) quando disponível para reduzir tentativas repetidas.
- Manter a consistência visual com os flashes existentes e adicionar logs técnicos com contexto para investigação de incidentes.

### Description
- Adiciona import `RequestEntityTooLarge`, função auxiliar `_human_readable_size` e um handler global `@app.errorhandler(RequestEntityTooLarge)` em `app.py` que faz `flash(..., 'danger')` e redireciona para `request.referrer`/`request.url` com fallback para `pagina_inicial`.
- O flash mostra mensagem amigável em português e inclui o `MAX_CONTENT_LENGTH` formatado quando presente, compatível com `templates/partials/_flash_messages.html` (usa categoria `danger` que renderiza como `alert-danger`).
- Registra um log padronizado em nível `warning` contendo `method`, `path`, `endpoint`, `user_id`, `content_length`, `max_content_length` e `remote_addr` para facilitar triagem de 413.
- Adiciona teste de integração `test_perfil_upload_above_max_content_length_redirects_with_flash` em `tests/test_security_controls.py` que configura temporariamente `MAX_CONTENT_LENGTH`, envia um `POST` multipart oversized e valida presença do `alert-danger`, do texto amigável e do texto do limite.

### Testing
- Executei `pytest -q tests/test_security_controls.py -k max_content_length` e o teste relacionado passou com sucesso. 
- O novo teste verifica redirecionamento com `follow_redirects=True` e checa o HTML resultante por `class="alert alert-danger"`, pelo texto amigável e por `Limite atual: 1 KB.`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd465f24c832e8be59d87d6cb67d6)