### PR TITLE
Add contextual observability logs for articles/attachments and OCR; propagate X-Request-ID

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, request, redirect, url_for, flash, session, jsonify, current_app as app
+from flask import Blueprint, render_template, request, redirect, url_for, flash, session, jsonify, current_app as app, g
 from sqlalchemy import or_, func, text
 import re
 
@@ -25,6 +25,8 @@ try:
         user_can_edit_article,
         user_can_approve_article,
         user_can_review_article,
+        log_article_event,
+        log_article_exception,
     )
 except ImportError:  # pragma: no cover - fallback for direct execution
     from core.utils import (
@@ -34,6 +36,8 @@ except ImportError:  # pragma: no cover - fallback for direct execution
         user_can_edit_article,
         user_can_approve_article,
         user_can_review_article,
+        log_article_event,
+        log_article_exception,
     )
 try:
     from ..core.services.ocr_queue import (
@@ -71,6 +75,29 @@ import json
 import uuid
 
 articles_bp = Blueprint('articles_bp', __name__)
+
+
+def _request_correlation_id():
+    return (
+        request.headers.get('X-Request-ID')
+        or request.headers.get('X-Correlation-ID')
+        or request.headers.get('X-Amzn-Trace-Id')
+        or request.environ.get('HTTP_X_REQUEST_ID')
+        or request.environ.get('HTTP_X_CORRELATION_ID')
+    )
+
+
+@articles_bp.before_request
+def _capture_correlation_id():
+    g.request_correlation_id = _request_correlation_id()
+
+
+@articles_bp.after_request
+def _propagate_request_id(response):
+    correlation_id = getattr(g, "request_correlation_id", None)
+    if correlation_id:
+        response.headers["X-Request-ID"] = correlation_id
+    return response
 
 
 def _new_article_form_defaults():
@@ -195,15 +222,22 @@ def novo_artigo():
         elif vis is ArticleVisibility.CELULA:
             vis_cel_id = user.celula_id
 
-        app.logger.info(
-            "Criando artigo user_id=%s acao=%s vis=%s anexos=%s titulo_len=%s texto_len=%s progress_id=%s",
-            user.id,
-            acao,
-            vis.value,
-            len([f for f in files if f and f.filename]),
-            len(titulo),
-            len(texto_limpo),
-            progress_id,
+        correlation_id = getattr(g, "request_correlation_id", None)
+        log_article_event(
+            app.logger,
+            "article_create_started",
+            user_id=user.id,
+            route=request.path,
+            action=acao,
+            article_id=None,
+            attachment_id=None,
+            filename=None,
+            file_size=None,
+            mime_type=None,
+            ocr_status=None,
+            attempt=None,
+            progress_id=progress_id,
+            correlation_id=correlation_id,
         )
         try:
             # 3) Cria o artigo (sem arquivos ainda) e dá um flush para ter ID
@@ -240,6 +274,9 @@ def novo_artigo():
                     dest       = os.path.join(app.config['UPLOAD_FOLDER'], unique_name)
                     f.save(dest)
                     filenames.append(unique_name)
+                    f.stream.seek(0, os.SEEK_END)
+                    file_size = f.stream.tell()
+                    f.stream.seek(0)
 
                     mime_type, _ = guess_type(dest)
                     ocr_eligible = is_pdf_ocr_eligible(unique_name, mime_type)
@@ -254,6 +291,22 @@ def novo_artigo():
                     if ocr_eligible:
                         enqueue_attachment_for_ocr(attachment)
                     db.session.add(attachment)
+                    log_article_event(
+                        app.logger,
+                        "article_attachment_registered",
+                        user_id=user.id,
+                        route=request.path,
+                        action=acao,
+                        article_id=artigo.id,
+                        attachment_id=getattr(attachment, "id", None),
+                        filename=unique_name,
+                        file_size=file_size,
+                        mime_type=mime_type,
+                        ocr_status=attachment.ocr_status,
+                        attempt=attachment.ocr_attempts,
+                        progress_id=progress_id,
+                        correlation_id=correlation_id,
+                    )
 
             # 4) Atualiza o campo JSON de nomes no artigo
             artigo.arquivos = json.dumps(filenames) if filenames else None
@@ -261,6 +314,16 @@ def novo_artigo():
             # 5) Persiste tudo num único commit
             db.session.commit()
             mark_progress_done(progress_id)
+            log_article_event(
+                app.logger,
+                "article_create_committed",
+                user_id=user.id,
+                route=request.path,
+                action=acao,
+                article_id=artigo.id,
+                progress_id=progress_id,
+                correlation_id=correlation_id,
+            )
 
             # 6) Notifica responsáveis/admins, se necessário
             if status is ArticleStatus.PENDENTE:
@@ -280,22 +343,42 @@ def novo_artigo():
             return _render_novo_artigo_form(form_data)
         except TimeoutError:
             db.session.rollback()
-            app.logger.exception(
-                "Timeout ao criar artigo user_id=%s progress_id=%s titulo=%r",
-                user.id,
-                progress_id,
-                titulo,
+            log_article_exception(
+                app.logger,
+                "article_create_timeout",
+                user_id=user.id,
+                route=request.path,
+                action=acao,
+                article_id=None,
+                attachment_id=None,
+                filename=None,
+                file_size=None,
+                mime_type=None,
+                ocr_status=None,
+                attempt=None,
+                progress_id=progress_id,
+                correlation_id=correlation_id,
             )
             flash('Erro de timeout: o processamento demorou além do esperado. Tente novamente.', 'danger')
             flash('Por limitação de multipart, os anexos precisam ser reenviados.', 'info')
             return _render_novo_artigo_form(form_data)
         except Exception as exc:
             db.session.rollback()
-            app.logger.exception(
-                "Falha ao criar artigo user_id=%s progress_id=%s titulo=%r",
-                user.id,
-                progress_id,
-                titulo,
+            log_article_exception(
+                app.logger,
+                "article_create_failed",
+                user_id=user.id,
+                route=request.path,
+                action=acao,
+                article_id=None,
+                attachment_id=None,
+                filename=None,
+                file_size=None,
+                mime_type=None,
+                ocr_status=None,
+                attempt=None,
+                progress_id=progress_id,
+                correlation_id=correlation_id,
             )
             if 'ocr' in str(exc).lower():
                 flash('Erro de OCR: falha ao processar o anexo para OCR.', 'danger')
@@ -422,6 +505,7 @@ def editar_artigo(artigo_id):
     can_submit_actions = True
 
     if request.method == "POST":
+        correlation_id = getattr(g, "request_correlation_id", None)
         raw_status = artigo.status
         if isinstance(raw_status, ArticleStatus):
             status_value = raw_status.value
@@ -435,6 +519,16 @@ def editar_artigo(artigo_id):
         acao = request.form.get("acao", "salvar")   # salvar | enviar
         progress_id = request.form.get("progress_id")
         init_progress(progress_id)
+        log_article_event(
+            app.logger,
+            "article_edit_started",
+            user_id=user.id,
+            route=request.path,
+            action=acao,
+            article_id=artigo.id,
+            progress_id=progress_id,
+            correlation_id=correlation_id,
+        )
 
         # campos básicos
         titulo = request.form["titulo"].strip()
@@ -511,6 +605,9 @@ def editar_artigo(artigo_id):
                     dest = os.path.join(app.config["UPLOAD_FOLDER"], unique_name)
                     f.save(dest)
                     existing.append(unique_name)
+                    f.stream.seek(0, os.SEEK_END)
+                    file_size = f.stream.tell()
+                    f.stream.seek(0)
 
                     mime_type, _ = guess_type(dest)
                     ocr_eligible = is_pdf_ocr_eligible(unique_name, mime_type)
@@ -523,6 +620,22 @@ def editar_artigo(artigo_id):
                     if ocr_eligible:
                         enqueue_attachment_for_ocr(attachment)
                     db.session.add(attachment)
+                    log_article_event(
+                        app.logger,
+                        "article_attachment_registered",
+                        user_id=user.id,
+                        route=request.path,
+                        action=acao,
+                        article_id=artigo.id,
+                        attachment_id=getattr(attachment, "id", None),
+                        filename=unique_name,
+                        file_size=file_size,
+                        mime_type=mime_type,
+                        ocr_status=attachment.ocr_status,
+                        attempt=attachment.ocr_attempts,
+                        progress_id=progress_id,
+                        correlation_id=correlation_id,
+                    )
 
             artigo.arquivos = json.dumps(existing) if existing else None
 
@@ -544,6 +657,16 @@ def editar_artigo(artigo_id):
 
             db.session.commit()
             mark_progress_done(progress_id)
+            log_article_event(
+                app.logger,
+                "article_edit_committed",
+                user_id=user.id,
+                route=request.path,
+                action=acao,
+                article_id=artigo.id,
+                progress_id=progress_id,
+                correlation_id=correlation_id,
+            )
             return redirect(url_for("artigo", artigo_id=artigo.id))
         except RequestEntityTooLarge:
             db.session.rollback()
@@ -552,13 +675,43 @@ def editar_artigo(artigo_id):
             return _render_editar_artigo_form(artigo, json.loads(artigo.arquivos or "[]"), can_submit_actions, form_data)
         except TimeoutError:
             db.session.rollback()
-            app.logger.exception("Timeout ao editar artigo id=%s user_id=%s", artigo.id, user.id)
+            log_article_exception(
+                app.logger,
+                "article_edit_timeout",
+                user_id=user.id,
+                route=request.path,
+                action=acao,
+                article_id=artigo.id,
+                attachment_id=None,
+                filename=None,
+                file_size=None,
+                mime_type=None,
+                ocr_status=None,
+                attempt=None,
+                progress_id=progress_id,
+                correlation_id=correlation_id,
+            )
             flash('Erro de timeout: o processamento demorou além do esperado. Tente novamente.', 'danger')
             flash('Por limitação de multipart, os anexos precisam ser reenviados.', 'info')
             return _render_editar_artigo_form(artigo, json.loads(artigo.arquivos or "[]"), can_submit_actions, form_data)
         except Exception as exc:
             db.session.rollback()
-            app.logger.exception("Falha ao editar artigo id=%s user_id=%s", artigo.id, user.id)
+            log_article_exception(
+                app.logger,
+                "article_edit_failed",
+                user_id=user.id,
+                route=request.path,
+                action=acao,
+                article_id=artigo.id,
+                attachment_id=None,
+                filename=None,
+                file_size=None,
+                mime_type=None,
+                ocr_status=None,
+                attempt=None,
+                progress_id=progress_id,
+                correlation_id=correlation_id,
+            )
             if 'ocr' in str(exc).lower():
                 flash('Erro de OCR: falha ao processar o anexo para OCR.', 'danger')
             else:

--- a/core/services/ocr_queue.py
+++ b/core/services/ocr_queue.py
@@ -10,11 +10,11 @@ from flask import current_app
 try:
     from ..database import db
     from ..models import Attachment
-    from ..utils import extract_text
+    from ..utils import extract_text, log_article_event, log_article_exception
 except ImportError:  # pragma: no cover
     from core.database import db
     from core.models import Attachment
-    from core.utils import extract_text
+    from core.utils import extract_text, log_article_event, log_article_exception
 
 OCR_STATUS_PENDENTE = "pendente"
 OCR_STATUS_PROCESSANDO = "processando"
@@ -100,6 +100,22 @@ def process_pending_ocr_attachments(
         attachment.ocr_attempts = (attachment.ocr_attempts or 0) + 1
         attachment.ocr_last_attempt_at = started_at
         db.session.commit()
+        log_article_event(
+            current_app.logger,
+            "ocr_processing_started",
+            user_id=None,
+            route="/ocr/process-pending",
+            action="ocr_process_attachment",
+            article_id=attachment.article_id,
+            attachment_id=attachment.id,
+            filename=attachment.filename,
+            file_size=None,
+            mime_type=attachment.mime_type,
+            ocr_status=attachment.ocr_status,
+            attempt=attachment.ocr_attempts,
+            progress_id=None,
+            correlation_id=None,
+        )
 
         file_path = upload_folder / attachment.filename
 
@@ -125,6 +141,22 @@ def process_pending_ocr_attachments(
             else:
                 attachment.ocr_status = OCR_STATUS_CONCLUIDO
                 result.concluded += 1
+            log_article_event(
+                current_app.logger,
+                "ocr_processing_finished",
+                user_id=None,
+                route="/ocr/process-pending",
+                action="ocr_process_attachment",
+                article_id=attachment.article_id,
+                attachment_id=attachment.id,
+                filename=attachment.filename,
+                file_size=None,
+                mime_type=attachment.mime_type,
+                ocr_status=attachment.ocr_status,
+                attempt=attachment.ocr_attempts,
+                progress_id=None,
+                correlation_id=None,
+            )
         except Exception as exc:  # pragma: no cover - proteção operacional
             attachment.ocr_status = OCR_STATUS_ERRO
             finished_at = datetime.now(timezone.utc)
@@ -134,10 +166,21 @@ def process_pending_ocr_attachments(
             attachment.ocr_error_message = str(exc)
             attachment.ocr_processing_time_seconds = max((finished_at - started_at).total_seconds(), 0.0)
             result.failed += 1
-            current_app.logger.exception(
-                "Falha no OCR do attachment id=%s filename=%s",
-                attachment.id,
-                attachment.filename,
+            log_article_exception(
+                current_app.logger,
+                "ocr_processing_failed",
+                user_id=None,
+                route="/ocr/process-pending",
+                action="ocr_process_attachment",
+                article_id=attachment.article_id,
+                attachment_id=attachment.id,
+                filename=attachment.filename,
+                file_size=None,
+                mime_type=attachment.mime_type,
+                ocr_status=attachment.ocr_status,
+                attempt=attachment.ocr_attempts,
+                progress_id=None,
+                correlation_id=None,
             )
 
         db.session.commit()

--- a/core/utils.py
+++ b/core/utils.py
@@ -2,6 +2,7 @@
 
 import bleach
 import re
+from typing import Any
 
 import os
 import json
@@ -54,6 +55,64 @@ except ImportError:  # pragma: no cover
 from sqlalchemy import select
 
 logger = logging.getLogger(__name__)
+_RESERVED_LOG_RECORD_FIELDS = set(logging.makeLogRecord({}).__dict__.keys())
+
+
+def build_article_log_context(
+    *,
+    user_id: int | None = None,
+    route: str | None = None,
+    action: str | None = None,
+    article_id: int | None = None,
+    attachment_id: int | None = None,
+    filename: str | None = None,
+    file_size: int | None = None,
+    mime_type: str | None = None,
+    ocr_status: str | None = None,
+    attempt: int | None = None,
+    progress_id: str | None = None,
+    correlation_id: str | None = None,
+) -> dict[str, Any]:
+    """Monta payload de contexto padronizado para logs de artigo/anexo/OCR."""
+    return {
+        "user_id": user_id,
+        "route": route,
+        "action": action,
+        "article_id": article_id,
+        "attachment_id": attachment_id,
+        "filename": filename,
+        "file_size": file_size,
+        "mime_type": mime_type,
+        "ocr_status": ocr_status,
+        "attempt": attempt,
+        "progress_id": progress_id,
+        "correlation_id": correlation_id,
+    }
+
+
+def log_article_event(
+    logger_obj: logging.Logger,
+    event: str,
+    *,
+    level: int = logging.INFO,
+    **context: Any,
+) -> None:
+    """Emite evento estruturado e consistente para observabilidade."""
+    payload = build_article_log_context(**context)
+    safe_extra = {"event_context": payload}
+    safe_extra.update({k: v for k, v in payload.items() if k not in _RESERVED_LOG_RECORD_FIELDS})
+    logger_obj.log(level, event, extra=safe_extra)
+
+
+def log_article_exception(
+    logger_obj: logging.Logger,
+    event: str,
+    **context: Any,
+) -> None:
+    payload = build_article_log_context(**context)
+    safe_extra = {"event_context": payload}
+    safe_extra.update({k: v for k, v in payload.items() if k not in _RESERVED_LOG_RECORD_FIELDS})
+    logger_obj.exception(event, extra=safe_extra)
 #-------------------------------------------------------------------------------------------
 # Configura o campo de texto para se comportar corretamente quando recebe tags HTML
 #-------------------------------------------------------------------------------------------

--- a/tests/test_article_logging.py
+++ b/tests/test_article_logging.py
@@ -1,0 +1,89 @@
+from io import BytesIO
+
+from app import app, db
+from core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User
+
+
+import pytest
+
+
+@pytest.fixture
+def client(app_ctx):
+    with app.app_context():
+        inst = Instituicao(codigo='IL', nome='Inst Log')
+        est = Estabelecimento(codigo='EL', nome_fantasia='Est Log', instituicao=inst)
+        setor = Setor(nome='Setor Log', estabelecimento=est)
+        cel = Celula(nome='Cel Log', estabelecimento=est, setor=setor)
+        db.session.add_all([inst, est, setor, cel])
+        db.session.commit()
+
+        func = Funcao.query.filter_by(codigo='artigo_criar').first()
+        if not func:
+            func = Funcao(codigo='artigo_criar', nome='artigo_criar')
+            db.session.add(func)
+            db.session.flush()
+
+        user = User(
+            username='logger_user',
+            email='logger@test',
+            password_hash='x',
+            estabelecimento_id=est.id,
+            setor_id=setor.id,
+            celula_id=cel.id,
+        )
+        user.permissoes_personalizadas.append(func)
+        db.session.add(user)
+        db.session.commit()
+        uid = user.id
+
+        with app_ctx.test_client() as client:
+            with client.session_transaction() as sess:
+                sess['user_id'] = uid
+                sess['username'] = 'logger_user'
+            yield client
+
+
+def test_novo_artigo_emite_eventos_criticos_com_contexto(monkeypatch, client):
+    eventos = []
+
+    def _fake_log_article_event(_logger, event, **context):
+        eventos.append((event, context))
+
+    monkeypatch.setattr('blueprints.articles.log_article_event', _fake_log_article_event)
+
+    response = client.post(
+        '/novo-artigo',
+        headers={'X-Request-ID': 'req-123'},
+        data={
+            'titulo': 'Artigo com log',
+            'texto': 'Conteudo',
+            'visibility': 'celula',
+            'acao': 'enviar',
+            'progress_id': 'prog-1',
+            'files': (BytesIO(b'conteudo txt'), 'arquivo.txt'),
+        },
+        content_type='multipart/form-data',
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    nomes = [nome for nome, _ in eventos]
+    assert 'article_create_started' in nomes
+    assert 'article_attachment_registered' in nomes
+    assert 'article_create_committed' in nomes
+
+    attachment_ctx = next(ctx for nome, ctx in eventos if nome == 'article_attachment_registered')
+    assert attachment_ctx['user_id'] is not None
+    assert attachment_ctx['route'] == '/novo-artigo'
+    assert attachment_ctx['action'] == 'enviar'
+    assert attachment_ctx['filename'].endswith('_arquivo.txt')
+    assert attachment_ctx['file_size'] == len(b'conteudo txt')
+    assert attachment_ctx['mime_type'] == 'text/plain'
+    assert attachment_ctx['progress_id'] == 'prog-1'
+    assert attachment_ctx['correlation_id'] == 'req-123'
+
+
+def test_articles_propagam_x_request_id_no_response(client):
+    response = client.get('/upload-progress/abc', headers={'X-Request-ID': 'corr-xyz'})
+    assert response.status_code == 200
+    assert response.headers.get('X-Request-ID') == 'corr-xyz'


### PR DESCRIPTION
### Motivation
- Improve observability for article creation/edit, attachment handling and OCR processing with a stable, structured logging payload. 
- Ensure exceptions emit stable messages via `logger.exception(...)` with consistent contextual fields for downstream monitoring. 
- Propagate request correlation id (`X-Request-ID`/`X-Correlation-ID`) through article routes to link frontend requests and background/OCR work. 

### Description
- Add reusable logging helpers in `core/utils.py`: `build_article_log_context`, `log_article_event` and `log_article_exception` to standardize context fields (`user_id`, `route`, `action`, `article_id`, `attachment_id`, `filename`, `file_size`, `mime_type`, `ocr_status`, `attempt`, `progress_id`, `correlation_id`).
- Instrument `blueprints/articles.py` to capture and propagate correlation id via a `before_request`/`after_request` pair, compute `file_size` for uploaded attachments, and emit structured events (`article_create_started`, `article_attachment_registered`, `article_create_committed`, `article_edit_started`, `article_edit_committed`) while using `log_article_exception` for stable exception logs (`article_create_timeout`, `article_create_failed`, `article_edit_timeout`, `article_edit_failed`).
- Instrument `core/services/ocr_queue.py` to emit OCR lifecycle events (`ocr_processing_started`, `ocr_processing_finished`, `ocr_processing_failed`) and to use `log_article_exception` when OCR processing errors occur.
- Add `tests/test_article_logging.py` that mocks the logging helper to assert critical events are emitted with the expected contextual fields and that `X-Request-ID` is propagated in responses. Also compute and include `file_size` in attachment events.

### Testing
- Added unit tests `tests/test_article_logging.py` and ran it together with `tests/test_required_fields.py::test_novo_artigo_accepts_attachment_without_text` using `pytest -q`; both tests passed (final run: 3 tests passed, multiple warnings unrelated to changes). 
- The new logging helpers and instrumentation were exercised by the tests which verified event names and presence/values of context fields and response header propagation (`X-Request-ID`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd91ef1a0832e99e532f2e7cddabe)