### PR TITLE
Add OCR operational metrics to admin dashboard

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash, session, current_app as app
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlalchemy.exc import IntegrityError
 
 try:
@@ -75,7 +75,7 @@ except ImportError:  # pragma: no cover
     )
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from zoneinfo import ZoneInfo
 from werkzeug.utils import secure_filename
 from mimetypes import guess_type
@@ -134,6 +134,68 @@ def admin_dashboard():
         .all()
     )
 
+    ocr_statuses = [
+        'pendente',
+        'processando',
+        'concluido',
+        'erro',
+        'baixo_aproveitamento',
+    ]
+    ocr_raw_counts = dict(
+        db.session.query(Attachment.ocr_status, func.count(Attachment.id))
+        .filter(Attachment.ocr_status.in_(ocr_statuses))
+        .group_by(Attachment.ocr_status)
+        .all()
+    )
+    ocr_total_eligible = sum(ocr_raw_counts.values())
+    ocr_status_metrics = {}
+    for status in ocr_statuses:
+        count = int(ocr_raw_counts.get(status, 0) or 0)
+        percentage = round((count / ocr_total_eligible) * 100, 2) if ocr_total_eligible else 0.0
+        ocr_status_metrics[status] = {
+            'count': count,
+            'percentage': percentage,
+        }
+
+    ocr_avg_char_count = (
+        db.session.query(func.avg(Attachment.ocr_char_count))
+        .filter(Attachment.ocr_status.in_(ocr_statuses))
+        .filter(Attachment.ocr_char_count.isnot(None))
+        .scalar()
+    ) or 0.0
+    ocr_avg_processing_seconds = (
+        db.session.query(func.avg(Attachment.ocr_processing_time_seconds))
+        .filter(Attachment.ocr_status.in_(ocr_statuses))
+        .filter(Attachment.ocr_processing_time_seconds.isnot(None))
+        .scalar()
+    ) or 0.0
+
+    processing_stuck_threshold_minutes = int(app.config.get('OCR_STUCK_THRESHOLD_MINUTES', 30))
+    processing_stuck_cutoff = datetime.now(timezone.utc) - timedelta(minutes=processing_stuck_threshold_minutes)
+    ocr_stuck_processing_items = (
+        Attachment.query
+        .filter(Attachment.ocr_status == 'processando')
+        .filter(Attachment.ocr_started_at.isnot(None))
+        .filter(Attachment.ocr_started_at < processing_stuck_cutoff)
+        .order_by(Attachment.ocr_started_at.asc())
+        .limit(5)
+        .all()
+    )
+
+    ocr_latest_errors = (
+        Attachment.query
+        .filter(Attachment.ocr_status.in_(['erro', 'baixo_aproveitamento']))
+        .filter(
+            or_(
+                Attachment.ocr_last_error.isnot(None),
+                Attachment.ocr_error_message.isnot(None),
+            )
+        )
+        .order_by(Attachment.ocr_last_attempt_at.desc().nullslast(), Attachment.created_at.desc())
+        .limit(5)
+        .all()
+    )
+
     return render_template(
         "admin/dashboard.html",
         user_total=user_total,
@@ -143,6 +205,13 @@ def admin_dashboard():
         notifications_unread=notifications_unread,
         notifications_read=notifications_read,
         user_sector_counts=user_sector_counts,
+        ocr_status_metrics=ocr_status_metrics,
+        ocr_total_eligible=ocr_total_eligible,
+        ocr_avg_char_count=round(float(ocr_avg_char_count), 2),
+        ocr_avg_processing_seconds=round(float(ocr_avg_processing_seconds), 2),
+        ocr_latest_errors=ocr_latest_errors,
+        ocr_stuck_processing_items=ocr_stuck_processing_items,
+        processing_stuck_threshold_minutes=processing_stuck_threshold_minutes,
     )
 
 @admin_bp.route('/admin/instituicoes', methods=['GET', 'POST'])

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -44,6 +44,70 @@
                 </div>
             </div>
         </div>
+
+        <div class="row">
+            <div class="col-lg-8 mb-4">
+                <div class="card futuristic-card">
+                    <div class="card-header">OCR por Status (Elegíveis)</div>
+                    <div class="card-body">
+                        <canvas id="ocrStatusChart" class="dashboard-chart"></canvas>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-4 mb-4">
+                <div class="card futuristic-card h-100">
+                    <div class="card-header">Resumo OCR</div>
+                    <div class="card-body">
+                        <p class="mb-1"><strong>Total elegível:</strong> {{ ocr_total_eligible }}</p>
+                        <p class="mb-1"><strong>Média de caracteres:</strong> {{ ocr_avg_char_count }}</p>
+                        <p class="mb-0"><strong>Média de processamento (s):</strong> {{ ocr_avg_processing_seconds }}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-lg-6 mb-4">
+                <div class="card futuristic-card h-100">
+                    <div class="card-header">Últimos erros OCR</div>
+                    <div class="card-body">
+                        {% if ocr_latest_errors %}
+                            <ul class="mb-0">
+                                {% for item in ocr_latest_errors %}
+                                    <li>
+                                        #{{ item.id }} (artigo {{ item.article_id }}):
+                                        {{ item.ocr_last_error or item.ocr_error_message }}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        {% else %}
+                            <p class="mb-0">Sem erros OCR recentes.</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-6 mb-4">
+                <div class="card futuristic-card h-100">
+                    <div class="card-header">
+                        Itens presos em processando (>{{ processing_stuck_threshold_minutes }} min)
+                    </div>
+                    <div class="card-body">
+                        {% if ocr_stuck_processing_items %}
+                            <ul class="mb-0">
+                                {% for item in ocr_stuck_processing_items %}
+                                    <li>
+                                        #{{ item.id }} (artigo {{ item.article_id }}) iniciado em
+                                        {{ item.ocr_started_at.strftime('%d/%m/%Y %H:%M:%S') if item.ocr_started_at else '-' }}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        {% else %}
+                            <p class="mb-0">Nenhum item preso no limiar atual.</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 {% endblock %}
 
@@ -131,6 +195,41 @@
                 scales: {
                     x: { ticks: { color: '#fff' }, grid: { color: '#333' }, beginAtZero: true },
                     y: { ticks: { color: '#fff' }, grid: { color: '#333' } }
+                }
+            }
+        });
+
+        const ocrData = {{ ocr_status_metrics|tojson }};
+        new Chart(document.getElementById('ocrStatusChart'), {
+            type: 'bar',
+            data: {
+                labels: Object.keys(ocrData),
+                datasets: [
+                    {
+                        label: 'Quantidade',
+                        data: Object.values(ocrData).map(v => v.count),
+                        backgroundColor: 'rgba(25, 135, 84, 0.65)',
+                        yAxisID: 'y'
+                    },
+                    {
+                        label: '% do total elegível',
+                        data: Object.values(ocrData).map(v => v.percentage),
+                        backgroundColor: 'rgba(13, 110, 253, 0.55)',
+                        yAxisID: 'y1'
+                    }
+                ]
+            },
+            options: {
+                ...baseOptions,
+                scales: {
+                    x: { ticks: { color: '#fff' }, grid: { color: '#333' } },
+                    y: { ticks: { color: '#fff' }, grid: { color: '#333' }, beginAtZero: true },
+                    y1: {
+                        position: 'right',
+                        ticks: { color: '#fff' },
+                        grid: { drawOnChartArea: false },
+                        beginAtZero: true
+                    }
                 }
             }
         });

--- a/tests/test_admin_dashboard.py
+++ b/tests/test_admin_dashboard.py
@@ -1,7 +1,9 @@
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from app import app, db
-from core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User
+from core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User, Article, Attachment
 
 
 @pytest.fixture
@@ -50,5 +52,75 @@ def login_admin(client):
 
 def test_admin_dashboard(client):
     login_admin(client)
+    ids = client.base_ids
+    now = datetime.now(timezone.utc)
+    with app.app_context():
+        admin_user = User.query.filter_by(username='adm').first()
+        article = Article(
+            titulo='Artigo OCR',
+            texto='conteudo',
+            user_id=admin_user.id,
+            celula_id=ids['cel'],
+        )
+        db.session.add(article)
+        db.session.flush()
+
+        db.session.add_all([
+            Attachment(
+                article_id=article.id,
+                filename='pendente.pdf',
+                original_filename='pendente.pdf',
+                mime_type='application/pdf',
+                ocr_status='pendente',
+            ),
+            Attachment(
+                article_id=article.id,
+                filename='processando.pdf',
+                original_filename='processando.pdf',
+                mime_type='application/pdf',
+                ocr_status='processando',
+                ocr_started_at=now - timedelta(minutes=45),
+            ),
+            Attachment(
+                article_id=article.id,
+                filename='concluido.pdf',
+                original_filename='concluido.pdf',
+                mime_type='application/pdf',
+                ocr_status='concluido',
+                ocr_char_count=120,
+                ocr_processing_time_seconds=10.2,
+            ),
+            Attachment(
+                article_id=article.id,
+                filename='erro.pdf',
+                original_filename='erro.pdf',
+                mime_type='application/pdf',
+                ocr_status='erro',
+                ocr_last_error='Falha no OCR',
+                ocr_char_count=0,
+                ocr_processing_time_seconds=4.0,
+            ),
+            Attachment(
+                article_id=article.id,
+                filename='baixo.pdf',
+                original_filename='baixo.pdf',
+                mime_type='application/pdf',
+                ocr_status='baixo_aproveitamento',
+                ocr_error_message='Texto insuficiente',
+                ocr_char_count=22,
+                ocr_processing_time_seconds=3.3,
+            ),
+        ])
+        db.session.commit()
+
     resp = client.get('/admin/dashboard')
     assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'OCR por Status (Elegíveis)' in html
+    assert 'Resumo OCR' in html
+    assert 'Total elegível:</strong> 5' in html
+    assert 'Últimos erros OCR' in html
+    assert 'Falha no OCR' in html
+    assert 'Texto insuficiente' in html
+    assert 'Itens presos em processando' in html
+    assert '(artigo' in html


### PR DESCRIPTION
### Motivation
- Provide operational visibility into the OCR queue by surfacing counts by `Attachment.ocr_status` and identifying stuck or failing items. 
- Help troubleshoot OCR quality/performance by exposing averages for `ocr_char_count` and `ocr_processing_time_seconds` and surfacing recent error messages.

### Description
- Added OCR aggregation to `admin_dashboard` in `blueprints/admin.py` that computes counts and percentages for statuses `pendente`, `processando`, `concluido`, `erro`, `baixo_aproveitamento`, plus `ocr_total_eligible`.
- Calculated averages for `ocr_char_count` and `ocr_processing_time_seconds`, and selected latest OCR errors (`ocr_last_error` / `ocr_error_message`) and items stuck in `processando` older than a configurable threshold (`OCR_STUCK_THRESHOLD_MINUTES`, default 30).
- Updated `templates/admin/dashboard.html` to add an OCR status chart (counts + percentage), OCR summary card, recent errors block, and stuck-processing block while preserving existing dashboard widgets.
- Expanded `tests/test_admin_dashboard.py` to create sample `Attachment` rows across OCR statuses and assert presence of the new OCR blocks and values in the rendered dashboard.

### Testing
- Ran `pytest -q tests/test_admin_dashboard.py` which passed (1 passed) with warnings about SQLAlchemy legacy `.get()` usage.
- Verified the new dashboard template renders the OCR chart, summary, recent errors and stuck items blocks in the test HTML output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebdb68cab8832e8416b5da62d94906)