### PR TITLE
Search: use `Attachment.ocr_text` with OCR-status filtering and FTS indexes

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -948,8 +948,9 @@ def pesquisar():
     area_id = request.args.get('area_id', type=int)
     sistema_id = request.args.get('sistema_id', type=int)
     bind = db.session.get_bind()
+    is_postgresql = bool(bind and bind.dialect.name == "postgresql")
     supports_unaccent = False
-    if bind and bind.dialect.name == "postgresql":
+    if is_postgresql:
         try:
             supports_unaccent = bool(
                 db.session.execute(
@@ -958,6 +959,7 @@ def pesquisar():
             )
         except Exception:
             supports_unaccent = False
+    searchable_ocr_statuses = ("concluido", "baixo_aproveitamento")
     query = Article.query.filter(
         Article.status.in_([ArticleStatus.APROVADO, ArticleStatus.EM_REVISAO])
     )
@@ -976,19 +978,24 @@ def pesquisar():
 
         tokens = [term] if exact else [t for t in term.split() if t]
 
-        if supports_unaccent:
+        if is_postgresql:
             for token in tokens:
                 like = f"%{token}%"
                 normalized_token = strip_accents(token)
                 like_unaccent = f"%{normalized_token}%"
+                ts_query = func.plainto_tsquery('portuguese', token)
+                attachment_text_fts = func.to_tsvector('portuguese', func.coalesce(Attachment.ocr_text, ''))
+                article_text_fts = func.to_tsvector('portuguese', func.coalesce(Article.texto, ''))
                 sub = (
                     db.session.query(Attachment.article_id)
                     .filter(
+                        Attachment.ocr_status.in_(searchable_ocr_statuses),
                         or_(
                             Attachment.filename.ilike(like),
-                            func.coalesce(Attachment.ocr_text, Attachment.content).ilike(like),
-                            func.unaccent(Attachment.filename).ilike(like_unaccent),
-                            func.unaccent(func.coalesce(Attachment.ocr_text, Attachment.content)).ilike(like_unaccent),
+                            Attachment.ocr_text.ilike(like),
+                            attachment_text_fts.op('@@')(ts_query),
+                            func.unaccent(Attachment.filename).ilike(like_unaccent) if supports_unaccent else text("FALSE"),
+                            func.unaccent(func.coalesce(Attachment.ocr_text, '')).ilike(like_unaccent) if supports_unaccent else text("FALSE"),
                         )
                     )
                     .scalar_subquery()
@@ -998,8 +1005,9 @@ def pesquisar():
                     or_(
                         Article.titulo.ilike(like),
                         Article.texto.ilike(like),
-                        func.unaccent(Article.titulo).ilike(like_unaccent),
-                        func.unaccent(Article.texto).ilike(like_unaccent),
+                        article_text_fts.op('@@')(ts_query),
+                        func.unaccent(Article.titulo).ilike(like_unaccent) if supports_unaccent else text("FALSE"),
+                        func.unaccent(Article.texto).ilike(like_unaccent) if supports_unaccent else text("FALSE"),
                         Article.id.in_(sub)
                     )
                 )
@@ -1013,7 +1021,7 @@ def pesquisar():
 
     artigos = query.order_by(Article.created_at.desc()).all()
 
-    if q and not supports_unaccent:
+    if q and not is_postgresql:
         def matches(article):
             def norm(value: str) -> str:
                 return strip_accents(value or "").lower()
@@ -1022,7 +1030,8 @@ def pesquisar():
                 t = norm(token)
                 fields = [article.titulo, article.texto]
                 for att in getattr(article, 'attachments', []) or []:
-                    fields.extend([att.filename, att.ocr_text or att.content])
+                    if att.ocr_status in searchable_ocr_statuses and att.ocr_text:
+                        fields.extend([att.filename, att.ocr_text])
                 return any(t in norm(f) for f in fields if f is not None)
 
             return all(token_found(tok) for tok in tokens)

--- a/migrations/versions/fb34c1d2e3a4_add_fts_indexes_for_article_and_attachment_ocr.py
+++ b/migrations/versions/fb34c1d2e3a4_add_fts_indexes_for_article_and_attachment_ocr.py
@@ -1,0 +1,48 @@
+"""add fts indexes for article text and attachment ocr text
+
+Revision ID: fb34c1d2e3a4
+Revises: fa23b0c1c9d0
+Create Date: 2026-04-24 00:00:00.000000
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'fb34c1d2e3a4'
+down_revision = 'fa23b0c1c9d0'
+branch_labels = None
+depends_on = None
+
+
+def _is_postgresql() -> bool:
+    bind = op.get_bind()
+    return bool(bind and bind.dialect.name == 'postgresql')
+
+
+def upgrade():
+    if not _is_postgresql():
+        return
+
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_attachment_ocr_text_fts
+        ON attachment
+        USING GIN (to_tsvector('portuguese', coalesce(ocr_text, '')));
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_article_texto_fts
+        ON article
+        USING GIN (to_tsvector('portuguese', coalesce(texto, '')));
+        """
+    )
+
+
+def downgrade():
+    if not _is_postgresql():
+        return
+
+    op.execute("DROP INDEX IF EXISTS ix_article_texto_fts;")
+    op.execute("DROP INDEX IF EXISTS ix_attachment_ocr_text_fts;")

--- a/migrations/versions/fb34c1d2e3a4_add_fts_indexes_for_article_and_attachment_ocr.py
+++ b/migrations/versions/fb34c1d2e3a4_add_fts_indexes_for_article_and_attachment_ocr.py
@@ -1,7 +1,7 @@
 """add fts indexes for article text and attachment ocr text
 
 Revision ID: fb34c1d2e3a4
-Revises: fa23b0c1c9d0
+Revises: c8d9e0f1a2b3
 Create Date: 2026-04-24 00:00:00.000000
 """
 
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'fb34c1d2e3a4'
-down_revision = 'fa23b0c1c9d0'
+down_revision = 'c8d9e0f1a2b3'
 branch_labels = None
 depends_on = None
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -21,7 +21,8 @@ def client(app_ctx):
         db.session.add(art)
         db.session.flush()
         att = Attachment(article_id=art.id, filename='dom_casmurro.pdf',
-                         mime_type='application/pdf', content='Dom Casmurro')
+                         mime_type='application/pdf', content='Dom Casmurro',
+                         ocr_text='Dom Casmurro', ocr_status='concluido')
         db.session.add(att)
         db.session.commit()
         with app_ctx.test_client() as client:
@@ -74,3 +75,82 @@ def test_search_includes_articles_in_review_without_revision_request_details(cli
     assert b'Artigo em revis' in resp.data
     assert b'Solicita' not in resp.data
     assert b'Ajustar fluxo da se' not in resp.data
+
+
+def test_search_ignores_pending_and_error_ocr_status(client):
+    with app.app_context():
+        art_pending = Article(
+            titulo='Pendente OCR',
+            texto='Texto base',
+            status=ArticleStatus.APROVADO,
+            user_id=client.user.id,
+            celula_id=client.user.celula_id
+        )
+        db.session.add(art_pending)
+        db.session.flush()
+        db.session.add(
+            Attachment(
+                article_id=art_pending.id,
+                filename='anexo_pendente.pdf',
+                mime_type='application/pdf',
+                ocr_text='frase_unica_pendente',
+                ocr_status='pendente'
+            )
+        )
+
+        art_error = Article(
+            titulo='Erro OCR',
+            texto='Texto base',
+            status=ArticleStatus.APROVADO,
+            user_id=client.user.id,
+            celula_id=client.user.celula_id
+        )
+        db.session.add(art_error)
+        db.session.flush()
+        db.session.add(
+            Attachment(
+                article_id=art_error.id,
+                filename='anexo_erro.pdf',
+                mime_type='application/pdf',
+                ocr_text='frase_unica_erro',
+                ocr_status='erro'
+            )
+        )
+        db.session.commit()
+
+    login(client)
+    resp_pending = client.get('/pesquisar', query_string={'q': 'frase_unica_pendente'})
+    assert resp_pending.status_code == 200
+    assert b'Pendente OCR' not in resp_pending.data
+
+    resp_error = client.get('/pesquisar', query_string={'q': 'frase_unica_erro'})
+    assert resp_error.status_code == 200
+    assert b'Erro OCR' not in resp_error.data
+
+
+def test_search_includes_concluded_or_low_yield_ocr_status(client):
+    with app.app_context():
+        art_low = Article(
+            titulo='Baixo aproveitamento OCR',
+            texto='Texto base',
+            status=ArticleStatus.APROVADO,
+            user_id=client.user.id,
+            celula_id=client.user.celula_id
+        )
+        db.session.add(art_low)
+        db.session.flush()
+        db.session.add(
+            Attachment(
+                article_id=art_low.id,
+                filename='anexo_baixo.pdf',
+                mime_type='application/pdf',
+                ocr_text='frase_unica_baixo_aproveitamento',
+                ocr_status='baixo_aproveitamento'
+            )
+        )
+        db.session.commit()
+
+    login(client)
+    resp = client.get('/pesquisar', query_string={'q': 'frase_unica_baixo_aproveitamento'})
+    assert resp.status_code == 200
+    assert b'Baixo aproveitamento OCR' in resp.data


### PR DESCRIPTION
### Motivation
- Align search logic to the official OCR field so attachment searches rely on `Attachment.ocr_text` instead of the legacy `content` fallback. 
- Exclude attachments whose OCR is not ready or failed from being matched by OCR text to avoid noisy/incorrect results. 
- Keep articles searchable by `titulo` and `texto` even when OCR is not available for their attachments. 
- Improve performance for long text fields by leveraging PostgreSQL full-text search where available.

### Description
- Updated `blueprints/articles.py` (`pesquisar`) to use `Attachment.ocr_text` as the canonical OCR source and to restrict attachment-based matches to OCR statuses `("concluido", "baixo_aproveitamento")`.
- Preserved non-OCR fallback: article title and body (`Article.titulo`, `Article.texto`) remain searchable and the non-Postgres in-memory path still checks attachments but only when `ocr_status` is eligible and `ocr_text` exists.
- For PostgreSQL, added FTS queries using `to_tsvector` + `plainto_tsquery` for `Article.texto` and `Attachment.ocr_text` to reduce reliance on `ILIKE` for large text columns and added guarded `text()` fallbacks for unaccent checks.
- Added an Alembic migration `migrations/versions/fb34c1d2e3a4_add_fts_indexes_for_article_and_attachment_ocr.py` that creates GIN FTS indexes for `article.texto` and `attachment.ocr_text`, and is no-op on non-Postgres dialects.
- Extended `tests/test_search.py` to cover OCR status scenarios (pending/error should be ignored; `concluido` and `baixo_aproveitamento` should match) and updated the fixture attachment to include `ocr_text`/`ocr_status`.

### Testing
- Ran `pytest -q tests/test_search.py` and all tests passed (`5 passed`).
- The new migration is guarded and only executes on PostgreSQL to avoid side effects on other DB drivers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebdc749370832e957907649d84e9b2)