### PR TITLE
Adicionar reprocesso administrativo de OCR com permissão dedicada e auditoria

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -45,9 +45,9 @@ except ImportError:  # pragma: no cover
     )
 
 try:
-    from ..core.enums import ArticleStatus
+    from ..core.enums import ArticleStatus, Permissao
 except ImportError:
-    from core.enums import ArticleStatus
+    from core.enums import ArticleStatus, Permissao
 
 try:
     from ..core.decorators import admin_required
@@ -62,6 +62,7 @@ try:
         user_can_edit_article,
         user_can_approve_article,
         user_can_review_article,
+        log_article_event,
     )
 except ImportError:  # pragma: no cover
     from core.utils import (
@@ -72,6 +73,19 @@ except ImportError:  # pragma: no cover
         user_can_edit_article,
         user_can_approve_article,
         user_can_review_article,
+        log_article_event,
+    )
+try:
+    from ..core.services.ocr_queue import (
+        OCR_STATUS_BAIXO_APROVEITAMENTO,
+        OCR_STATUS_ERRO,
+        mark_attachment_for_reprocess,
+    )
+except ImportError:  # pragma: no cover
+    from core.services.ocr_queue import (
+        OCR_STATUS_BAIXO_APROVEITAMENTO,
+        OCR_STATUS_ERRO,
+        mark_attachment_for_reprocess,
     )
 
 import json
@@ -102,6 +116,54 @@ def _request_correlation_id():
         or request.environ.get('HTTP_X_REQUEST_ID')
         or request.environ.get('HTTP_X_CORRELATION_ID')
     )
+
+
+def _can_reprocess_ocr(user) -> bool:
+    if not user:
+        return False
+    return user.has_permissao('admin') or user.has_permissao(Permissao.ARTIGO_OCR_REPROCESSAR.value)
+
+
+def _eligible_ocr_attachment_query():
+    return Attachment.query.filter(
+        or_(
+            Attachment.mime_type == 'application/pdf',
+            Attachment.filename.ilike('%.pdf'),
+        )
+    )
+
+
+def _reprocess_attachments(attachments, *, actor: User, trigger_scope: str, success_message: str):
+    if not attachments:
+        flash('Nenhum anexo elegível para reprocesso foi encontrado.', 'info')
+        return redirect(request.referrer or url_for('admin_bp.admin_dashboard'))
+
+    for attachment in attachments:
+        mark_attachment_for_reprocess(
+            attachment,
+            triggered_by_user_id=actor.id,
+            trigger_scope=trigger_scope,
+        )
+        log_article_event(
+            app.logger,
+            "ocr_reprocess_requested",
+            user_id=actor.id,
+            route=request.path,
+            action=trigger_scope,
+            article_id=attachment.article_id,
+            attachment_id=attachment.id,
+            filename=attachment.filename,
+            file_size=None,
+            mime_type=attachment.mime_type,
+            ocr_status=attachment.ocr_status,
+            attempt=attachment.ocr_attempts,
+            progress_id=None,
+            correlation_id=_request_correlation_id(),
+        )
+
+    db.session.commit()
+    flash(f'{success_message} ({len(attachments)} anexo(s) reenfileirado(s)).', 'success')
+    return redirect(request.referrer or url_for('admin_bp.admin_dashboard'))
 
 # ROTAS DE ADMINISTRAÇÃO (NOVA SEÇÃO - ADICIONE AS ROTAS DO ADMIN AQUI)
 # -------------------------------------------------------------------------
@@ -196,6 +258,7 @@ def admin_dashboard():
         .all()
     )
 
+    current_user = _current_user()
     return render_template(
         "admin/dashboard.html",
         user_total=user_total,
@@ -212,6 +275,83 @@ def admin_dashboard():
         ocr_latest_errors=ocr_latest_errors,
         ocr_stuck_processing_items=ocr_stuck_processing_items,
         processing_stuck_threshold_minutes=processing_stuck_threshold_minutes,
+        can_reprocess_ocr=_can_reprocess_ocr(current_user),
+    )
+
+
+@admin_bp.route('/admin/ocr/reprocess/attachment/<int:attachment_id>', methods=['POST'])
+def admin_reprocess_ocr_attachment(attachment_id):
+    user = _current_user()
+    if not _can_reprocess_ocr(user):
+        flash('Permissão negada para reprocessar OCR.', 'danger')
+        return redirect(url_for('meus_artigos'))
+
+    attachment = _eligible_ocr_attachment_query().filter(Attachment.id == attachment_id).one_or_none()
+    if not attachment:
+        flash('Anexo não encontrado ou não elegível para OCR.', 'warning')
+        return redirect(request.referrer or url_for('admin_bp.admin_dashboard'))
+
+    return _reprocess_attachments(
+        [attachment],
+        actor=user,
+        trigger_scope='attachment',
+        success_message='Reprocesso do anexo solicitado com sucesso',
+    )
+
+
+@admin_bp.route('/admin/ocr/reprocess/article/<int:article_id>', methods=['POST'])
+def admin_reprocess_ocr_article(article_id):
+    user = _current_user()
+    if not _can_reprocess_ocr(user):
+        flash('Permissão negada para reprocessar OCR.', 'danger')
+        return redirect(url_for('meus_artigos'))
+
+    attachments = _eligible_ocr_attachment_query().filter(Attachment.article_id == article_id).all()
+    return _reprocess_attachments(
+        attachments,
+        actor=user,
+        trigger_scope='article',
+        success_message='Reprocesso por artigo solicitado com sucesso',
+    )
+
+
+@admin_bp.route('/admin/ocr/reprocess/errors', methods=['POST'])
+def admin_reprocess_ocr_errors():
+    user = _current_user()
+    if not _can_reprocess_ocr(user):
+        flash('Permissão negada para reprocessar OCR.', 'danger')
+        return redirect(url_for('meus_artigos'))
+
+    attachments = (
+        _eligible_ocr_attachment_query()
+        .filter(Attachment.ocr_status == OCR_STATUS_ERRO)
+        .all()
+    )
+    return _reprocess_attachments(
+        attachments,
+        actor=user,
+        trigger_scope='errors',
+        success_message='Reprocesso de anexos com erro solicitado com sucesso',
+    )
+
+
+@admin_bp.route('/admin/ocr/reprocess/low-yield', methods=['POST'])
+def admin_reprocess_ocr_low_yield():
+    user = _current_user()
+    if not _can_reprocess_ocr(user):
+        flash('Permissão negada para reprocessar OCR.', 'danger')
+        return redirect(url_for('meus_artigos'))
+
+    attachments = (
+        _eligible_ocr_attachment_query()
+        .filter(Attachment.ocr_status == OCR_STATUS_BAIXO_APROVEITAMENTO)
+        .all()
+    )
+    return _reprocess_attachments(
+        attachments,
+        actor=user,
+        trigger_scope='low_yield',
+        success_message='Reprocesso de anexos com baixo aproveitamento solicitado com sucesso',
     )
 
 @admin_bp.route('/admin/instituicoes', methods=['GET', 'POST'])

--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -477,11 +477,18 @@ def artigo(artigo_id):
         return redirect(url_for('meus_artigos'))
 
     arquivos = json.loads(artigo.arquivos or '[]')
+    can_reprocess_ocr = bool(
+        user and (
+            user.has_permissao('admin')
+            or user.has_permissao(Permissao.ARTIGO_OCR_REPROCESSAR.value)
+        )
+    )
     return render_template(
         'artigos/artigo.html',
         artigo=artigo,
         arquivos=arquivos,
-        can_edit_article=user_can_edit_article(user, artigo)
+        can_edit_article=user_can_edit_article(user, artigo),
+        can_reprocess_ocr=can_reprocess_ocr,
     )
 
 @articles_bp.route("/artigo/<int:artigo_id>/editar", methods=["GET", "POST"], endpoint='editar_artigo')

--- a/core/enums.py
+++ b/core/enums.py
@@ -65,6 +65,7 @@ class Permissao(Enum):
     # --- taxonomia de artigos ---
     ARTIGO_TIPO_GERENCIAR = "artigo_tipo_gerenciar"
     ARTIGO_AREA_GERENCIAR = "artigo_area_gerenciar"
+    ARTIGO_OCR_REPROCESSAR = "artigo_ocr_reprocessar"
 
 
 class OSStatus(Enum):

--- a/core/models.py
+++ b/core/models.py
@@ -462,9 +462,37 @@ class Attachment(db.Model):
     created_at = db.Column(db.DateTime(timezone=True), server_default=func.now(), nullable=False)
 
     article = db.relationship('Article', back_populates='attachments')
+    reprocess_audits = db.relationship(
+        'OCRReprocessAudit',
+        back_populates='attachment',
+        lazy='dynamic',
+        cascade='all, delete-orphan',
+    )
 
     def __repr__(self):
         return f"<Attachment {self.filename} for article_id={self.article_id}>"
+
+
+class OCRReprocessAudit(db.Model):
+    __tablename__ = 'ocr_reprocess_audit'
+
+    id = db.Column(db.Integer, primary_key=True)
+    attachment_id = db.Column(db.Integer, db.ForeignKey('attachment.id', ondelete='CASCADE'), nullable=False)
+    article_id = db.Column(db.Integer, db.ForeignKey('article.id', ondelete='CASCADE'), nullable=False)
+    triggered_by_user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    trigger_scope = db.Column(db.String(32), nullable=False)
+    previous_status = db.Column(db.String(32), nullable=True)
+    new_status = db.Column(db.String(32), nullable=False, default='pendente', server_default='pendente')
+    attempts_before = db.Column(db.Integer, nullable=False, default=0, server_default='0')
+    attempts_after = db.Column(db.Integer, nullable=False, default=0, server_default='0')
+    triggered_at = db.Column(db.DateTime(timezone=True), nullable=False, server_default=func.now())
+
+    attachment = db.relationship('Attachment', back_populates='reprocess_audits')
+    article = db.relationship('Article')
+    triggered_by = db.relationship('User')
+
+    def __repr__(self):
+        return f"<OCRReprocessAudit attachment_id={self.attachment_id} scope={self.trigger_scope}>"
 
 class Notification(db.Model):
     __tablename__ = 'notification'

--- a/core/services/ocr_queue.py
+++ b/core/services/ocr_queue.py
@@ -9,11 +9,11 @@ from flask import current_app
 
 try:
     from ..database import db
-    from ..models import Attachment
+    from ..models import Attachment, OCRReprocessAudit
     from ..utils import extract_text, log_article_event, log_article_exception
 except ImportError:  # pragma: no cover
     from core.database import db
-    from core.models import Attachment
+    from core.models import Attachment, OCRReprocessAudit
     from core.utils import extract_text, log_article_event, log_article_exception
 
 OCR_STATUS_PENDENTE = "pendente"
@@ -52,6 +52,32 @@ def enqueue_attachment_for_ocr(attachment: Attachment) -> None:
     attachment.ocr_char_count = None
     attachment.ocr_processing_time_seconds = None
     attachment.ocr_confidence_score = None
+
+
+def mark_attachment_for_reprocess(
+    attachment: Attachment,
+    *,
+    triggered_by_user_id: int,
+    trigger_scope: str,
+) -> None:
+    previous_status = attachment.ocr_status
+    attempts_before = int(attachment.ocr_attempts or 0)
+
+    enqueue_attachment_for_ocr(attachment)
+    attachment.ocr_attempts = attempts_before + 1
+    attachment.ocr_last_attempt_at = datetime.now(timezone.utc)
+
+    audit = OCRReprocessAudit(
+        attachment_id=attachment.id,
+        article_id=attachment.article_id,
+        triggered_by_user_id=triggered_by_user_id,
+        trigger_scope=trigger_scope,
+        previous_status=previous_status,
+        new_status=OCR_STATUS_PENDENTE,
+        attempts_before=attempts_before,
+        attempts_after=attachment.ocr_attempts,
+    )
+    db.session.add(audit)
 
 
 def _recover_stuck_processing(stuck_timeout_minutes: int) -> int:

--- a/migrations/versions/c7a1d9e6b2f4_add_ocr_reprocess_audit_table.py
+++ b/migrations/versions/c7a1d9e6b2f4_add_ocr_reprocess_audit_table.py
@@ -1,0 +1,46 @@
+"""add ocr reprocess audit table
+
+Revision ID: c7a1d9e6b2f4
+Revises: fb34c1d2e3a4
+Create Date: 2026-04-25 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c7a1d9e6b2f4'
+down_revision = 'fb34c1d2e3a4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'ocr_reprocess_audit',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('attachment_id', sa.Integer(), nullable=False),
+        sa.Column('article_id', sa.Integer(), nullable=False),
+        sa.Column('triggered_by_user_id', sa.Integer(), nullable=False),
+        sa.Column('trigger_scope', sa.String(length=32), nullable=False),
+        sa.Column('previous_status', sa.String(length=32), nullable=True),
+        sa.Column('new_status', sa.String(length=32), nullable=False, server_default='pendente'),
+        sa.Column('attempts_before', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('attempts_after', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('triggered_at', sa.DateTime(timezone=True), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.ForeignKeyConstraint(['article_id'], ['article.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['attachment_id'], ['attachment.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['triggered_by_user_id'], ['user.id']),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_ocr_reprocess_audit_attachment_id'), 'ocr_reprocess_audit', ['attachment_id'], unique=False)
+    op.create_index(op.f('ix_ocr_reprocess_audit_article_id'), 'ocr_reprocess_audit', ['article_id'], unique=False)
+    op.create_index(op.f('ix_ocr_reprocess_audit_triggered_at'), 'ocr_reprocess_audit', ['triggered_at'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_ocr_reprocess_audit_triggered_at'), table_name='ocr_reprocess_audit')
+    op.drop_index(op.f('ix_ocr_reprocess_audit_article_id'), table_name='ocr_reprocess_audit')
+    op.drop_index(op.f('ix_ocr_reprocess_audit_attachment_id'), table_name='ocr_reprocess_audit')
+    op.drop_table('ocr_reprocess_audit')

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -61,6 +61,15 @@
                         <p class="mb-1"><strong>Total elegível:</strong> {{ ocr_total_eligible }}</p>
                         <p class="mb-1"><strong>Média de caracteres:</strong> {{ ocr_avg_char_count }}</p>
                         <p class="mb-0"><strong>Média de processamento (s):</strong> {{ ocr_avg_processing_seconds }}</p>
+                        {% if can_reprocess_ocr %}
+                        <hr>
+                        <form method="post" action="{{ url_for('admin_bp.admin_reprocess_ocr_errors') }}" class="mb-2">
+                            <button type="submit" class="btn btn-sm btn-outline-warning w-100">Reprocessar todos com erro</button>
+                        </form>
+                        <form method="post" action="{{ url_for('admin_bp.admin_reprocess_ocr_low_yield') }}">
+                            <button type="submit" class="btn btn-sm btn-outline-warning w-100">Reprocessar baixo aproveitamento</button>
+                        </form>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/templates/artigos/artigo.html
+++ b/templates/artigos/artigo.html
@@ -79,6 +79,13 @@
                     <div class="attachment-details"><span class="attachment-kind">{{ "Imagem" if ext in ["jpg","jpeg","png","gif","webp"] else "Documento" }}</span></div>
                   </div>
                 </a>
+                {% if can_reprocess_ocr and ext == 'pdf' %}
+                <div class="px-2 pb-2">
+                  <form method="post" action="{{ url_for('admin_bp.admin_reprocess_ocr_attachment', attachment_id=att.id) }}" class="mt-1">
+                    <button type="submit" class="btn btn-sm btn-outline-warning w-100">Reprocessar OCR</button>
+                  </form>
+                </div>
+                {% endif %}
                 {% if ext == 'pdf' and not att.content %}
                 <i class="bi bi-exclamation-circle-fill text-warning position-absolute"
                   style="top: 8px; right: 8px; z-index: 5; font-size: 1.1rem;"
@@ -137,6 +144,13 @@
 
         {# Botões de ação #}
         <div class="mt-4">
+          {% if can_reprocess_ocr and artigo.attachments and artigo.attachments.count() > 0 %}
+          <form method="post" action="{{ url_for('admin_bp.admin_reprocess_ocr_article', article_id=artigo.id) }}" class="d-inline">
+            <button type="submit" class="btn btn-outline-warning">
+              Reprocessar OCR deste artigo
+            </button>
+          </form>
+          {% endif %}
           {% if can_edit_article %}
           <a href="{{ url_for('editar_artigo', artigo_id=artigo.id) }}" class="btn btn-primary">
             Editar

--- a/tests/test_admin_ocr_reprocess.py
+++ b/tests/test_admin_ocr_reprocess.py
@@ -1,0 +1,170 @@
+from core.database import db
+from core.models import (
+    Article,
+    Attachment,
+    Celula,
+    Estabelecimento,
+    Funcao,
+    Instituicao,
+    OCRReprocessAudit,
+    Setor,
+    User,
+)
+from core.permission_catalog import CATALOG_BY_CODE
+
+
+def _login_with_permissions(client, permissions):
+    inst = Instituicao(codigo='INSTOCR', nome='Instituição OCR')
+    db.session.add(inst)
+    db.session.flush()
+
+    est = Estabelecimento(codigo='ESTOCR', nome_fantasia='Est OCR', instituicao_id=inst.id)
+    db.session.add(est)
+    db.session.flush()
+
+    setor = Setor(nome='Setor OCR', estabelecimento_id=est.id)
+    db.session.add(setor)
+    db.session.flush()
+
+    cel = Celula(nome='Célula OCR', estabelecimento_id=est.id, setor_id=setor.id)
+    db.session.add(cel)
+    db.session.flush()
+
+    user = User(
+        username='ocr_user',
+        email='ocr_user@test.local',
+        estabelecimento_id=est.id,
+        setor_id=setor.id,
+        celula_id=cel.id,
+    )
+    user.set_password('x')
+    db.session.add(user)
+    db.session.flush()
+
+    for codigo in permissions:
+        funcao = Funcao.query.filter_by(codigo=codigo).first()
+        if not funcao:
+            funcao = Funcao(codigo=codigo, nome=codigo)
+            db.session.add(funcao)
+            db.session.flush()
+        user.permissoes_personalizadas.append(funcao)
+
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess['user_id'] = user.id
+        sess['username'] = user.username
+
+    return user
+
+
+def _criar_artigo_com_anexos(user, status_pdf='erro'):
+    artigo = Article(titulo='Artigo OCR', texto='Texto', user_id=user.id, celula_id=user.celula_id)
+    db.session.add(artigo)
+    db.session.flush()
+
+    anexo_pdf = Attachment(
+        article_id=artigo.id,
+        filename='arquivo.pdf',
+        mime_type='application/pdf',
+        ocr_status=status_pdf,
+        ocr_attempts=2,
+    )
+    anexo_txt = Attachment(
+        article_id=artigo.id,
+        filename='arquivo.txt',
+        mime_type='text/plain',
+        ocr_status='nao_aplicavel',
+        ocr_attempts=0,
+    )
+    db.session.add_all([anexo_pdf, anexo_txt])
+    db.session.commit()
+    return artigo, anexo_pdf, anexo_txt
+
+
+def test_permission_catalog_includes_artigo_ocr_reprocessar(app_ctx):
+    assert 'artigo_ocr_reprocessar' in CATALOG_BY_CODE
+
+
+def test_admin_reprocess_attachment_requires_permission(client):
+    user = _login_with_permissions(client, [])
+    _, anexo_pdf, _ = _criar_artigo_com_anexos(user)
+
+    resp = client.post(f'/admin/ocr/reprocess/attachment/{anexo_pdf.id}', follow_redirects=False)
+
+    assert resp.status_code == 302
+    assert '/meus-artigos' in resp.headers['Location']
+
+
+def test_admin_reprocess_attachment_updates_state_attempt_and_audit(client):
+    user = _login_with_permissions(client, ['artigo_ocr_reprocessar'])
+    _, anexo_pdf, _ = _criar_artigo_com_anexos(user)
+
+    resp = client.post(f'/admin/ocr/reprocess/attachment/{anexo_pdf.id}', follow_redirects=False)
+
+    assert resp.status_code == 302
+    db.session.refresh(anexo_pdf)
+    assert anexo_pdf.ocr_status == 'pendente'
+    assert anexo_pdf.ocr_attempts == 3
+
+    auditoria = OCRReprocessAudit.query.filter_by(attachment_id=anexo_pdf.id).one()
+    assert auditoria.triggered_by_user_id == user.id
+    assert auditoria.trigger_scope == 'attachment'
+    assert auditoria.previous_status == 'erro'
+    assert auditoria.new_status == 'pendente'
+    assert auditoria.attempts_before == 2
+    assert auditoria.attempts_after == 3
+
+
+def test_admin_reprocess_article_reprocesses_only_pdf_attachments(client):
+    user = _login_with_permissions(client, ['admin'])
+    artigo, anexo_pdf, anexo_txt = _criar_artigo_com_anexos(user, status_pdf='baixo_aproveitamento')
+
+    resp = client.post(f'/admin/ocr/reprocess/article/{artigo.id}', follow_redirects=False)
+
+    assert resp.status_code == 302
+    db.session.refresh(anexo_pdf)
+    db.session.refresh(anexo_txt)
+    assert anexo_pdf.ocr_status == 'pendente'
+    assert anexo_pdf.ocr_attempts == 3
+    assert anexo_txt.ocr_status == 'nao_aplicavel'
+    assert anexo_txt.ocr_attempts == 0
+
+
+def test_admin_reprocess_bulk_by_status(client):
+    user = _login_with_permissions(client, ['artigo_ocr_reprocessar'])
+
+    artigo_erro = Article(titulo='Artigo erro', texto='Texto', user_id=user.id, celula_id=user.celula_id)
+    artigo_baixo = Article(titulo='Artigo baixo', texto='Texto', user_id=user.id, celula_id=user.celula_id)
+    db.session.add_all([artigo_erro, artigo_baixo])
+    db.session.flush()
+
+    anexo_erro = Attachment(
+        article_id=artigo_erro.id,
+        filename='erro.pdf',
+        mime_type='application/pdf',
+        ocr_status='erro',
+        ocr_attempts=1,
+    )
+    anexo_baixo = Attachment(
+        article_id=artigo_baixo.id,
+        filename='baixo.pdf',
+        mime_type='application/pdf',
+        ocr_status='baixo_aproveitamento',
+        ocr_attempts=4,
+    )
+    db.session.add_all([anexo_erro, anexo_baixo])
+    db.session.commit()
+
+    resp_erro = client.post('/admin/ocr/reprocess/errors', follow_redirects=False)
+    resp_baixo = client.post('/admin/ocr/reprocess/low-yield', follow_redirects=False)
+
+    assert resp_erro.status_code == 302
+    assert resp_baixo.status_code == 302
+
+    db.session.refresh(anexo_erro)
+    db.session.refresh(anexo_baixo)
+    assert anexo_erro.ocr_status == 'pendente'
+    assert anexo_erro.ocr_attempts == 2
+    assert anexo_baixo.ocr_status == 'pendente'
+    assert anexo_baixo.ocr_attempts == 5


### PR DESCRIPTION
### Motivation
- Fornecer controles administrativos para reenfileirar anexos para OCR em vários escopos (por anexo, por artigo, todos com `erro`, todos com `baixo_aproveitamento`).
- Garantir que apenas usuários com permissão específica possam iniciar reprocessos e que a ação não execute OCR síncrono na requisição administrativa.
- Rastrear quem iniciou o reprocesso e quando, para auditoria e observabilidade.

### Description
- Adiciona a permissão `ARTIGO_OCR_REPROCESSAR` (código `artigo_ocr_reprocessar`) ao enum de permissões (`core/enums.py`).
- Introduz o modelo `OCRReprocessAudit` e a relação `Attachment.reprocess_audits` para registrar trilhas de auditoria (`core/models.py`) e cria a migration Alembic correspondente (`migrations/versions/c7a1d9e6b2f4_add_ocr_reprocess_audit_table.py`).
- Implementa `mark_attachment_for_reprocess(...)` em `core/services/ocr_queue.py` que faz a transição para `pendente`, incrementa `ocr_attempts` e cria o registro de auditoria sem executar OCR imediatamente.
- Adiciona endpoints administrativos em `blueprints/admin.py` para reprocessar por anexo, por artigo e em lote por status (`/admin/ocr/reprocess/...`), inclui verificações de permissão (`admin` ou `artigo_ocr_reprocessar`) e emite evento observável `ocr_reprocess_requested` via `log_article_event`.
- Mostra botões de reprocesso no detalhe do artigo (`templates/artigos/artigo.html`) e ações em lote no dashboard admin (`templates/admin/dashboard.html`), respeitando a permissão do usuário; e atualiza `blueprints/articles.py` para expor a flag `can_reprocess_ocr` ao template.
- Adiciona testes `tests/test_admin_ocr_reprocess.py` cobrindo presença no catálogo, controle de acesso, mudança de estado, incremento de tentativas e criação de auditoria para os fluxos implementados.

### Testing
- Novo conjunto de testes criado em `tests/test_admin_ocr_reprocess.py` que valida catálogo, bloqueio por permissão, reprocesso por anexo/artigo e reprocesso em lote; estes testes foram executados localmente.
- Executei `pytest -q tests/test_admin_ocr_reprocess.py tests/test_permission_sync.py tests/test_ocr_queue.py` e todos os testes passaram com sucesso (`16 passed`) (foram exibidos avisos, sem falhas).
- As alterações incluem uma migration Alembic para adicionar a tabela de auditoria, que deve ser aplicada em ambientes de banco de dados com `flask db upgrade` antes do uso em produção.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe0739498832ea541d736d49c7210)