### PR TITLE
Corrige sessão inválida na rota /pesquisar

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -1040,6 +1040,12 @@ def pesquisar():
 
     # Filtra conforme visibilidade
     user = User.query.filter_by(username=session['username']).first()
+    if user is None:
+        session.pop('username', None)
+        session.pop('user_id', None)
+        flash('Sua sessão expirou ou é inválida. Faça login novamente.', 'warning')
+        return redirect(url_for('login'))
+
     artigos = [a for a in artigos if user_can_view_article(user, a)]
 
     # formata datas para o fuso local


### PR DESCRIPTION
### Motivation
- Evitar exceções e comportamento incorreto quando a sessão contém um `username` obsoleto ou inválido ao acessar a rota de pesquisa. 
- Melhorar a experiência removendo dados de sessão inválidos e forçando novo login quando necessário.

### Description
- Adiciona verificação explícita `if user is None` logo após `User.query.filter_by(username=session['username']).first()` na função `pesquisar`. 
- Remove as chaves de sessão `username` e `user_id` quando o usuário não for encontrado, registra um `flash` informando que a sessão expirou e redireciona para `url_for('login')`. 
- Garante que o filtro de visibilidade `artigos = [a for a in artigos if user_can_view_article(user, a)]` só seja executado com um `user` válido. 
- Modificação aplicada em `blueprints/articles.py` (rota `pesquisar`).

### Testing
- Verificação de sintaxe com `python -m py_compile blueprints/articles.py` que foi executada com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1211ccec8832ea898237c917b3c3c)