### PR TITLE
Handle null user in article authorization helpers and add tests

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -534,6 +534,9 @@ def user_can_edit_article(user, article):
     except ImportError:  # pragma: no cover - fallback for direct execution
         from core.models import Article
 
+    if user is None:
+        return False
+
     if not isinstance(article, Article):
         return False
 
@@ -574,6 +577,9 @@ def user_can_approve_article(user, article):
         from .models import Article  # type: ignore  # pragma: no cover
     except ImportError:  # pragma: no cover - fallback for direct execution
         from core.models import Article
+
+    if user is None:
+        return False
 
     if not isinstance(article, Article):
         return False
@@ -617,6 +623,9 @@ def user_can_review_article(user, article):
     except ImportError:  # pragma: no cover - fallback for direct execution
         from core.models import Article
 
+    if user is None:
+        return False
+
     if not isinstance(article, Article):
         return False
 
@@ -657,6 +666,9 @@ def user_can_view_article(user, article):
         from .enums import ArticleVisibility
     except ImportError:  # pragma: no cover - fallback for direct execution
         from core.enums import ArticleVisibility
+
+    if user is None:
+        return False
 
     if not isinstance(article, Article):
         return False

--- a/tests/test_article_permissions.py
+++ b/tests/test_article_permissions.py
@@ -4,6 +4,12 @@ import pytest
 from app import app, db
 from core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User, Article, ArticleStatus
 from core.enums import Permissao
+from core.utils import (
+    user_can_edit_article,
+    user_can_approve_article,
+    user_can_review_article,
+    user_can_view_article,
+)
 
 @pytest.fixture
 def client(app_ctx):
@@ -74,3 +80,64 @@ def test_aprovacao_requires_permission(client):
     login_user(client, [Permissao.ARTIGO_APROVAR_CELULA])
     resp = client.get('/aprovacao')
     assert resp.status_code == 200
+
+
+class _EmptyRelation:
+    def filter_by(self, **kwargs):
+        return self
+
+    def count(self):
+        return 0
+
+    def all(self):
+        return []
+
+
+class _FakeUser:
+    def __init__(self, perms=None, user_id=123):
+        self._perms = set(perms or [])
+        self.id = user_id
+        self.estabelecimento = None
+        self.celula = None
+        self.setor = None
+        self.setor_id = None
+        self.celula_id = None
+        self.extra_setores = _EmptyRelation()
+        self.extra_celulas = _EmptyRelation()
+
+    def has_permissao(self, code):
+        return code in self._perms
+
+
+def _build_article(author_id=999):
+    return Article(titulo='Art', texto='Texto', status=ArticleStatus.APROVADO, user_id=author_id)
+
+
+@pytest.mark.parametrize(
+    "checker",
+    [
+        user_can_edit_article,
+        user_can_approve_article,
+        user_can_review_article,
+        user_can_view_article,
+    ],
+)
+def test_user_none_returns_false_without_exception(checker):
+    article = _build_article()
+    assert checker(None, article) is False
+
+
+def test_valid_user_permissions_keep_current_behavior():
+    article = _build_article(author_id=999)
+    admin = _FakeUser(perms={'admin'}, user_id=123)
+
+    assert user_can_edit_article(admin, article) is True
+    assert user_can_review_article(admin, article) is True
+    assert user_can_view_article(admin, article) is True
+    assert user_can_approve_article(admin, article) is True
+
+
+def test_pesquisar_filter_with_none_user_does_not_raise_exception():
+    articles = [_build_article(author_id=1), _build_article(author_id=2)]
+    filtered = [a for a in articles if user_can_view_article(None, a)]
+    assert filtered == []


### PR DESCRIPTION
### Motivation
- Prevent `AttributeError` and unsafe attribute access when authorization helpers are invoked with a null/expired session `user` (e.g. during list filtering in `/pesquisar`).
- Ensure filtering patterns like `[a for a in artigos if user_can_view_article(user, a)]` are safe when `user` may be `None`.

### Description
- Added an early `if user is None: return False` guard to `user_can_edit_article`, `user_can_approve_article`, `user_can_review_article`, and `user_can_view_article` in `core/utils.py` to short-circuit when `user` is null. 
- Preserved existing permission logic and ordering for valid `user` objects so behavior for authenticated users is unchanged. 
- Added unit tests in `tests/test_article_permissions.py` that import the four checkers and include `_EmptyRelation` and `_FakeUser` helpers to exercise permission checks without DB relations. 
- Tests cover: parameterized check that `checker(None, article)` returns `False`, that an admin-like fake user still passes the permission checks, and that a `/pesquisar`-style filter using `user_can_view_article(None, ...)` returns an empty list without raising.

### Testing
- Ran `pytest -q tests/test_article_permissions.py`, which completed successfully with all tests passing (`8 passed`).
- No other automated test failures were observed when running the tests above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f121dde11c832e98624eeb05b79b5f)