### PR TITLE
Add ArticleDeletionAudit and log audit on permanent article deletion

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -8,9 +8,9 @@ except ImportError:
     from core.database import db
 
 try:
-    from ..core.models import Article, Attachment, Comment, Notification, User, RevisionRequest, ArtigoTipo, ArtigoArea, ArtigoSistema
+    from ..core.models import Article, Attachment, Comment, Notification, User, RevisionRequest, ArtigoTipo, ArtigoArea, ArtigoSistema, ArticleDeletionAudit
 except ImportError:
-    from core.models import Article, Attachment, Comment, Notification, User, RevisionRequest, ArtigoTipo, ArtigoArea, ArtigoSistema
+    from core.models import Article, Attachment, Comment, Notification, User, RevisionRequest, ArtigoTipo, ArtigoArea, ArtigoSistema, ArticleDeletionAudit
 
 try:
     from ..core.enums import ArticleStatus, ArticleVisibility, Permissao
@@ -525,6 +525,17 @@ def excluir_artigo_definitivo(artigo_id):
         return redirect(url_for('artigo', artigo_id=artigo_id))
 
     try:
+        db.session.add(
+            ArticleDeletionAudit(
+                article_id=artigo.id,
+                article_title=artigo.titulo,
+                deleted_by_user_id=user.id,
+                deleted_at=datetime.now(timezone.utc),
+                attachment_count=attachments_count,
+                reason=motivo,
+                request_id=getattr(g, "request_correlation_id", None),
+            )
+        )
         db.session.delete(artigo)
         db.session.commit()
         flash(f'Artigo excluído definitivamente com sucesso. {attachments_count} anexo(s) removido(s).', 'success')

--- a/core/models.py
+++ b/core/models.py
@@ -494,6 +494,24 @@ class OCRReprocessAudit(db.Model):
     def __repr__(self):
         return f"<OCRReprocessAudit attachment_id={self.attachment_id} scope={self.trigger_scope}>"
 
+
+class ArticleDeletionAudit(db.Model):
+    __tablename__ = 'article_deletion_audit'
+
+    id = db.Column(db.Integer, primary_key=True)
+    article_id = db.Column(db.Integer, nullable=False, index=True)
+    article_title = db.Column(db.String(200), nullable=False)
+    deleted_by_user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    deleted_at = db.Column(db.DateTime(timezone=True), nullable=False, index=True, server_default=func.now())
+    attachment_count = db.Column(db.Integer, nullable=False, default=0, server_default='0')
+    reason = db.Column(db.Text, nullable=False)
+    request_id = db.Column(db.String(255), nullable=True)
+
+    deleted_by = db.relationship('User')
+
+    def __repr__(self):
+        return f"<ArticleDeletionAudit article_id={self.article_id} deleted_by={self.deleted_by_user_id}>"
+
 class Notification(db.Model):
     __tablename__ = 'notification'
     id = db.Column(db.Integer, primary_key=True)

--- a/migrations/versions/8c4d2e1f9a77_add_article_deletion_audit_table.py
+++ b/migrations/versions/8c4d2e1f9a77_add_article_deletion_audit_table.py
@@ -1,7 +1,7 @@
 """add article deletion audit table
 
 Revision ID: 8c4d2e1f9a77
-Revises: c7a1d9e6b2f4
+Revises: 9f7a1b2c3d4e
 Create Date: 2026-04-28 00:00:00.000000
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '8c4d2e1f9a77'
-down_revision = 'c7a1d9e6b2f4'
+down_revision = '9f7a1b2c3d4e'
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/8c4d2e1f9a77_add_article_deletion_audit_table.py
+++ b/migrations/versions/8c4d2e1f9a77_add_article_deletion_audit_table.py
@@ -1,0 +1,40 @@
+"""add article deletion audit table
+
+Revision ID: 8c4d2e1f9a77
+Revises: c7a1d9e6b2f4
+Create Date: 2026-04-28 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '8c4d2e1f9a77'
+down_revision = 'c7a1d9e6b2f4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'article_deletion_audit',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('article_id', sa.Integer(), nullable=False),
+        sa.Column('article_title', sa.String(length=200), nullable=False),
+        sa.Column('deleted_by_user_id', sa.Integer(), nullable=False),
+        sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('attachment_count', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('reason', sa.Text(), nullable=False),
+        sa.Column('request_id', sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(['deleted_by_user_id'], ['user.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_article_deletion_audit_article_id'), 'article_deletion_audit', ['article_id'], unique=False)
+    op.create_index(op.f('ix_article_deletion_audit_deleted_at'), 'article_deletion_audit', ['deleted_at'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_article_deletion_audit_deleted_at'), table_name='article_deletion_audit')
+    op.drop_index(op.f('ix_article_deletion_audit_article_id'), table_name='article_deletion_audit')
+    op.drop_table('article_deletion_audit')

--- a/tests/test_article_delete_definitivo.py
+++ b/tests/test_article_delete_definitivo.py
@@ -1,5 +1,5 @@
 from app import app, db
-from core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User, Article, Attachment
+from core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User, Article, Attachment, ArticleDeletionAudit
 from core.enums import ArticleStatus
 
 
@@ -89,10 +89,22 @@ def test_excluir_definitivo_sucesso(client):
         db.session.add(Attachment(article_id=aid, filename='a.pdf', mime_type='application/pdf', content=None))
         db.session.commit()
 
-    resp = client.post(f'/artigo/{aid}/excluir-definitivo', data={'motivo': 'duplicado', 'confirmacao': 'Titulo Sucesso'}, follow_redirects=True)
+    resp = client.post(
+        f'/artigo/{aid}/excluir-definitivo',
+        headers={'X-Request-ID': 'req-del-1'},
+        data={'motivo': 'duplicado', 'confirmacao': 'Titulo Sucesso'},
+        follow_redirects=True,
+    )
     assert resp.status_code == 200
     with app.app_context():
         assert Article.query.get(aid) is None
+        audit = ArticleDeletionAudit.query.filter_by(article_id=aid).first()
+        assert audit is not None
+        assert audit.article_title == 'Titulo Sucesso'
+        assert audit.attachment_count == 1
+        assert audit.reason == 'duplicado'
+        assert audit.request_id == 'req-del-1'
+        assert audit.deleted_at is not None
 
 
 def test_excluir_definitivo_erro_transacional(client, monkeypatch):


### PR DESCRIPTION
### Motivation
- Persist a tamper-evident audit record whenever an article is permanently deleted to record who deleted it, when, why, and attachment count.
- Ensure the deletion audit includes a consistent UTC timestamp and optional request correlation id for traceability.

### Description
- Added `ArticleDeletionAudit` model in `core/models.py` with columns `article_id`, `article_title`, `deleted_by_user_id`, `deleted_at`, `attachment_count`, `reason` and optional `request_id`, plus a relationship to `User`.
- Created Alembic migration `migrations/versions/8c4d2e1f9a77_add_article_deletion_audit_table.py` to create the `article_deletion_audit` table and indexes on `article_id` and `deleted_at`.
- Updated the permanent delete endpoint in `blueprints/articles.py` to `db.session.add(...)` the audit entry before `db.session.delete(artigo)` and to use `datetime.now(timezone.utc)` and `g.request_correlation_id` for the `deleted_at` and `request_id` values respectively.
- Extended `tests/test_article_delete_definitivo.py` to send a request id header and assert the audit row is persisted with expected `article_title`, `attachment_count`, `reason`, `request_id` and `deleted_at`.

### Testing
- Ran `pytest -q tests/test_article_delete_definitivo.py tests/test_article_logging.py` and the test suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12cf3f51c832e9d69d0ababfc9865)