### PR TITLE
Harden article deletion: cascade FKs, remove uploaded files, structured logging and tests

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -521,10 +521,69 @@ def excluir_artigo_definitivo(artigo_id):
     attachments_count = len(attachments)
     has_critical_link = any((att.ocr_status or '').strip().lower() == 'processando' for att in attachments)
     if has_critical_link:
+        log_article_event(
+            app.logger,
+            "article_delete_blocked_critical_consistency",
+            level=30,
+            article_id=artigo.id,
+            user_id=user.id,
+            reason='ocr_processing_in_progress',
+            attachment_count=attachments_count,
+            correlation_id=getattr(g, "request_correlation_id", None),
+        )
         flash('Exclusão bloqueada: o artigo possui anexo com processamento OCR em andamento.', 'danger')
         return redirect(url_for('artigo', artigo_id=artigo_id))
 
     try:
+        upload_folder = app.config.get('UPLOAD_FOLDER')
+        for attachment in attachments:
+            filename = (attachment.filename or '').strip()
+            if not filename:
+                log_article_event(
+                    app.logger,
+                    "article_attachment_missing_filename",
+                    level=30,
+                    article_id=artigo.id,
+                    user_id=user.id,
+                    attachment_id=attachment.id,
+                    correlation_id=getattr(g, "request_correlation_id", None),
+                )
+                continue
+
+            file_path = os.path.join(upload_folder, filename) if upload_folder else filename
+            try:
+                os.remove(file_path)
+                log_article_event(
+                    app.logger,
+                    "article_attachment_file_deleted",
+                    article_id=artigo.id,
+                    user_id=user.id,
+                    attachment_id=attachment.id,
+                    filename=filename,
+                    correlation_id=getattr(g, "request_correlation_id", None),
+                )
+            except FileNotFoundError:
+                log_article_event(
+                    app.logger,
+                    "article_attachment_file_not_found_during_delete",
+                    level=30,
+                    article_id=artigo.id,
+                    user_id=user.id,
+                    attachment_id=attachment.id,
+                    filename=filename,
+                    correlation_id=getattr(g, "request_correlation_id", None),
+                )
+            except OSError:
+                log_article_exception(
+                    app.logger,
+                    "article_attachment_file_delete_error",
+                    article_id=artigo.id,
+                    user_id=user.id,
+                    attachment_id=attachment.id,
+                    filename=filename,
+                    correlation_id=getattr(g, "request_correlation_id", None),
+                )
+
         db.session.add(
             ArticleDeletionAudit(
                 article_id=artigo.id,

--- a/core/models.py
+++ b/core/models.py
@@ -409,7 +409,7 @@ class Article(db.Model):
 class RevisionRequest(db.Model):
     __tablename__ = 'revision_request'
     id = db.Column(db.Integer, primary_key=True)
-    artigo_id = db.Column(db.Integer, db.ForeignKey('article.id'), nullable=False)
+    artigo_id = db.Column(db.Integer, db.ForeignKey('article.id', ondelete='CASCADE'), nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False) # Usuário que solicitou a revisão
     comentario = db.Column(db.Text, nullable=False)
     created_at = db.Column(db.DateTime(timezone=True), server_default=func.now(), nullable=True) # Conforme migration
@@ -423,7 +423,7 @@ class RevisionRequest(db.Model):
 class Comment(db.Model):
     __tablename__ = "comment" # Comentários feitos durante o fluxo de aprovação
     id = db.Column(db.Integer, primary_key=True)
-    artigo_id = db.Column(db.Integer, db.ForeignKey("article.id"), nullable=False)
+    artigo_id = db.Column(db.Integer, db.ForeignKey("article.id", ondelete='CASCADE'), nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False) # Usuário responsável pelo comentário
     texto = db.Column(db.Text, nullable=False)
     created_at = db.Column(db.DateTime(timezone=True), server_default=func.now(), nullable=True) # Conforme migration

--- a/migrations/versions/2aa4d61d9b20_add_cascade_on_article_history_fks.py
+++ b/migrations/versions/2aa4d61d9b20_add_cascade_on_article_history_fks.py
@@ -1,0 +1,58 @@
+"""add cascade on article history fks
+
+Revision ID: 2aa4d61d9b20
+Revises: 8c4d2e1f9a77
+Create Date: 2026-04-28 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2aa4d61d9b20'
+down_revision = '8c4d2e1f9a77'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('revision_request') as batch_op:
+        batch_op.drop_constraint('revision_request_artigo_id_fkey', type_='foreignkey')
+        batch_op.create_foreign_key(
+            'revision_request_artigo_id_fkey',
+            'article',
+            ['artigo_id'],
+            ['id'],
+            ondelete='CASCADE',
+        )
+
+    with op.batch_alter_table('comment') as batch_op:
+        batch_op.drop_constraint('comment_artigo_id_fkey', type_='foreignkey')
+        batch_op.create_foreign_key(
+            'comment_artigo_id_fkey',
+            'article',
+            ['artigo_id'],
+            ['id'],
+            ondelete='CASCADE',
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('comment') as batch_op:
+        batch_op.drop_constraint('comment_artigo_id_fkey', type_='foreignkey')
+        batch_op.create_foreign_key(
+            'comment_artigo_id_fkey',
+            'article',
+            ['artigo_id'],
+            ['id'],
+        )
+
+    with op.batch_alter_table('revision_request') as batch_op:
+        batch_op.drop_constraint('revision_request_artigo_id_fkey', type_='foreignkey')
+        batch_op.create_foreign_key(
+            'revision_request_artigo_id_fkey',
+            'article',
+            ['artigo_id'],
+            ['id'],
+        )

--- a/tests/test_article_delete_definitivo.py
+++ b/tests/test_article_delete_definitivo.py
@@ -1,5 +1,7 @@
+import os
+
 from app import app, db
-from core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User, Article, Attachment, ArticleDeletionAudit
+from core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User, Article, Attachment, ArticleDeletionAudit, Comment, RevisionRequest, OCRReprocessAudit
 from core.enums import ArticleStatus
 
 
@@ -125,3 +127,63 @@ def test_excluir_definitivo_erro_transacional(client, monkeypatch):
     monkeypatch.setattr(db.session, 'commit', original_commit)
     with app.app_context():
         assert Article.query.get(aid) is not None
+
+
+def test_excluir_definitivo_remove_historicos_e_arquivo_fisico(client, tmp_path):
+    _login(client, perms=['artigo_excluir_definitivo'])
+    app.config['UPLOAD_FOLDER'] = str(tmp_path)
+    with app.app_context():
+        aid = _create_article('Titulo Completo')
+        attachment = Attachment(article_id=aid, filename='hist.pdf', mime_type='application/pdf', content=None)
+        db.session.add(attachment)
+        db.session.flush()
+        db.session.add(Comment(artigo_id=aid, user_id=1, texto='coment'))
+        db.session.add(RevisionRequest(artigo_id=aid, user_id=1, comentario='rev'))
+        db.session.add(
+            OCRReprocessAudit(
+                attachment_id=attachment.id,
+                article_id=aid,
+                triggered_by_user_id=1,
+                trigger_scope='single',
+                new_status='pendente',
+            )
+        )
+        db.session.commit()
+
+    filepath = tmp_path / 'hist.pdf'
+    filepath.write_bytes(b'pdf')
+    assert filepath.exists()
+
+    resp = client.post(
+        f'/artigo/{aid}/excluir-definitivo',
+        data={'motivo': 'cleanup', 'confirmacao': 'Titulo Completo'},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assert not filepath.exists()
+    with app.app_context():
+        assert Article.query.get(aid) is None
+        assert Attachment.query.filter_by(article_id=aid).count() == 0
+        assert Comment.query.filter_by(artigo_id=aid).count() == 0
+        assert RevisionRequest.query.filter_by(artigo_id=aid).count() == 0
+        assert OCRReprocessAudit.query.filter_by(article_id=aid).count() == 0
+
+
+def test_excluir_definitivo_arquivo_faltando_logado_sem_quebrar_consistencia(client, tmp_path, caplog):
+    _login(client, perms=['artigo_excluir_definitivo'])
+    app.config['UPLOAD_FOLDER'] = str(tmp_path)
+    with app.app_context():
+        aid = _create_article('Titulo Missing File')
+        db.session.add(Attachment(article_id=aid, filename='nao-existe.pdf', mime_type='application/pdf', content=None))
+        db.session.commit()
+
+    resp = client.post(
+        f'/artigo/{aid}/excluir-definitivo',
+        data={'motivo': 'cleanup', 'confirmacao': 'Titulo Missing File'},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        assert Article.query.get(aid) is None
+        assert Attachment.query.filter_by(article_id=aid).count() == 0
+    assert any('article_attachment_file_not_found_during_delete' in message for message in caplog.messages)


### PR DESCRIPTION
### Motivation
- Ensure historical records linked to an `Article` are removed by the DB when an article is deleted and prevent orphaned rows in history tables. 
- Remove associated physical files from the uploads folder on definitive article delete and handle missing/unremovable files without breaking DB consistency. 
- Keep deletion as a transactional operation and emit structured logs for observability when consistency rules block or fail deletions. 

### Description
- Added `ondelete='CASCADE'` to `RevisionRequest.artigo_id` and `Comment.artigo_id` in `core/models.py` so historical entities cascade at the DB level. 
- Added an Alembic migration `migrations/versions/2aa4d61d9b20_add_cascade_on_article_history_fks.py` to drop/recreate the foreign keys for `revision_request.artigo_id` and `comment.artigo_id` with `ON DELETE CASCADE`. 
- Enhanced the definitive delete endpoint (`/artigo/<id>/excluir-definitivo` in `blueprints/articles.py`) to: delete files from the configured `UPLOAD_FOLDER` for each `Attachment.filename`, log structured events (`article_delete_blocked_critical_consistency`, `article_attachment_file_deleted`, `article_attachment_file_not_found_during_delete`, `article_attachment_file_delete_error`), and retain the existing transactional commit/rollback behavior when failures occur. 
- Updated logging calls to use numeric log level where appropriate and to attach correlation id from `g.request_correlation_id`. 
- Added tests in `tests/test_article_delete_definitivo.py` to cover physical file deletion, cascade removal of `Attachment`, `Comment`, `RevisionRequest`, and `OCRReprocessAudit`, and behavior when the physical file is missing (asserting DB consistency and that the not-found event is logged). 

### Testing
- Ran `pytest -q tests/test_article_delete_definitivo.py` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12f2fac10832ea667313bc0efd4cb)