### PR TITLE
Bloqueia exclusão definitiva de artigo com vínculo crítico de processo

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash, session, jsonify, current_app as app, g
-from sqlalchemy import or_, func, text
+from sqlalchemy import or_, func, text, and_
 import re
 
 try:
@@ -8,9 +8,9 @@ except ImportError:
     from core.database import db
 
 try:
-    from ..core.models import Article, Attachment, Comment, Notification, User, RevisionRequest, ArtigoTipo, ArtigoArea, ArtigoSistema, ArticleDeletionAudit
+    from ..core.models import Article, Attachment, Comment, Notification, User, RevisionRequest, ArtigoTipo, ArtigoArea, ArtigoSistema, ArticleDeletionAudit, ProcessoEtapa, Processo, processo_etapa_article
 except ImportError:
-    from core.models import Article, Attachment, Comment, Notification, User, RevisionRequest, ArtigoTipo, ArtigoArea, ArtigoSistema, ArticleDeletionAudit
+    from core.models import Article, Attachment, Comment, Notification, User, RevisionRequest, ArtigoTipo, ArtigoArea, ArtigoSistema, ArticleDeletionAudit, ProcessoEtapa, Processo, processo_etapa_article
 
 try:
     from ..core.enums import ArticleStatus, ArticleVisibility, Permissao
@@ -533,6 +533,37 @@ def excluir_artigo_definitivo(artigo_id):
         )
         flash('Exclusão bloqueada: o artigo possui anexo com processamento OCR em andamento.', 'danger')
         return redirect(url_for('artigo', artigo_id=artigo_id))
+
+    etapa_critica = (
+        db.session.query(ProcessoEtapa)
+        .join(processo_etapa_article, processo_etapa_article.c.etapa_id == ProcessoEtapa.id)
+        .join(Processo, Processo.id == ProcessoEtapa.processo_id)
+        .filter(
+            and_(
+                processo_etapa_article.c.article_id == artigo.id,
+                Processo.ativo.is_(True),
+                ProcessoEtapa.tipos_os.any(obrigatorio_preenchimento=True),
+            )
+        )
+        .order_by(Processo.nome.asc(), ProcessoEtapa.ordem.asc(), ProcessoEtapa.nome.asc())
+        .first()
+    )
+    if etapa_critica:
+        log_article_event(
+            app.logger,
+            "article_delete_blocked_critical_process_link",
+            level=30,
+            article_id=artigo.id,
+            user_id=user.id,
+            correlation_id=getattr(g, "request_correlation_id", None),
+        )
+        processo_nome = etapa_critica.processo.nome if etapa_critica.processo else etapa_critica.processo_id
+        flash(
+            f"Exclusão bloqueada: artigo vinculado à etapa crítica '{etapa_critica.nome}' do processo '{processo_nome}'.",
+            'danger',
+        )
+        return redirect(url_for('artigo', artigo_id=artigo_id))
+
 
     try:
         upload_folder = app.config.get('UPLOAD_FOLDER')

--- a/core/models.py
+++ b/core/models.py
@@ -591,6 +591,13 @@ class ProcessoEtapa(db.Model):
     artigos = db.relationship(
         'Article', secondary='processo_etapa_article', lazy='dynamic')
 
+
+
+    def is_critical_for_article_deletion(self):
+        processo_ativo = bool(self.processo and self.processo.ativo)
+        possui_tipo_os_obrigatorio = self.tipos_os.filter_by(obrigatorio_preenchimento=True).count() > 0
+        return processo_ativo and possui_tipo_os_obrigatorio
+
     def __repr__(self):
         return f"<ProcessoEtapa {self.nome} ({self.ordem})>"
 

--- a/tests/test_article_delete_definitivo.py
+++ b/tests/test_article_delete_definitivo.py
@@ -1,7 +1,7 @@
 import os
 
 from app import app, db
-from core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User, Article, Attachment, ArticleDeletionAudit, Comment, RevisionRequest, OCRReprocessAudit
+from core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User, Article, Attachment, ArticleDeletionAudit, Comment, RevisionRequest, OCRReprocessAudit, Processo, ProcessoEtapa, TipoOS
 from core.enums import ArticleStatus
 
 
@@ -187,3 +187,72 @@ def test_excluir_definitivo_arquivo_faltando_logado_sem_quebrar_consistencia(cli
         assert Article.query.get(aid) is None
         assert Attachment.query.filter_by(article_id=aid).count() == 0
     assert any('article_attachment_file_not_found_during_delete' in message for message in caplog.messages)
+
+
+def _vincular_artigo_a_etapa(article_id, *, processo_ativo=True, tipo_os_obrigatorio=True):
+    processo = Processo(nome='Proc Critico' if processo_ativo else 'Proc Inativo', ativo=processo_ativo)
+    db.session.add(processo)
+    db.session.flush()
+
+    etapa = ProcessoEtapa(processo_id=processo.id, nome='Etapa X', ordem=1)
+    db.session.add(etapa)
+    db.session.flush()
+
+    tipo_os = TipoOS(nome='Tipo OS X', obrigatorio_preenchimento=tipo_os_obrigatorio)
+    db.session.add(tipo_os)
+    db.session.flush()
+
+    etapa.tipos_os.append(tipo_os)
+    artigo = Article.query.get(article_id)
+    etapa.artigos.append(artigo)
+    db.session.commit()
+
+
+def test_excluir_definitivo_com_vinculo_processo_nao_critico_permite(client):
+    _login(client, perms=['artigo_excluir_definitivo'])
+    with app.app_context():
+        aid = _create_article('Titulo Nao Critico')
+        _vincular_artigo_a_etapa(aid, processo_ativo=False, tipo_os_obrigatorio=True)
+
+    resp = client.post(
+        f'/artigo/{aid}/excluir-definitivo',
+        data={'motivo': 'cleanup', 'confirmacao': 'Titulo Nao Critico'},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        assert Article.query.get(aid) is None
+
+
+def test_excluir_definitivo_com_vinculo_processo_ativo_sem_tipo_obrigatorio_permite(client):
+    _login(client, perms=['artigo_excluir_definitivo'])
+    with app.app_context():
+        aid = _create_article('Titulo Sem Obrigatorio')
+        _vincular_artigo_a_etapa(aid, processo_ativo=True, tipo_os_obrigatorio=False)
+
+    resp = client.post(
+        f'/artigo/{aid}/excluir-definitivo',
+        data={'motivo': 'cleanup', 'confirmacao': 'Titulo Sem Obrigatorio'},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        assert Article.query.get(aid) is None
+
+
+def test_excluir_definitivo_com_vinculo_critico_bloqueia(client):
+    _login(client, perms=['artigo_excluir_definitivo'])
+    with app.app_context():
+        aid = _create_article('Titulo Critico')
+        _vincular_artigo_a_etapa(aid, processo_ativo=True, tipo_os_obrigatorio=True)
+
+    resp = client.post(
+        f'/artigo/{aid}/excluir-definitivo',
+        data={'motivo': 'cleanup', 'confirmacao': 'Titulo Critico'},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assert b'Etapa X' in resp.data
+    assert b'Proc Critico' in resp.data
+    with app.app_context():
+        assert Article.query.get(aid) is not None


### PR DESCRIPTION
### Motivation
- Definir regra de "processo crítico" no domínio e evitar remoção acidental de artigos que estão vinculados a etapas que exigem preenchimento de OS em processos ativos.

### Description
- Adicionei o método `is_critical_for_article_deletion` em `ProcessoEtapa` (`core/models.py`) que considera crítica a etapa pertencente a `Processo` ativo e com pelo menos um `TipoOS.obrigatorio_preenchimento=True`.
- No endpoint `POST /artigo/<id>/excluir-definitivo` (`blueprints/articles.py`) passei a consultar vínculos via `processo_etapa_article` + `ProcessoEtapa`/`Processo` antes de excluir e bloquear a operação quando houver vínculo crítico, exibindo mensagem com nome da etapa e do processo; o bloqueio existente para anexos em OCR "processando" foi mantido.
- Atualizei imports e uso de `and_` para compor a consulta e incluí `ProcessoEtapa`, `Processo` e `processo_etapa_article` onde necessário.
- Acrescentei testes em `tests/test_article_delete_definitivo.py` que criam vínculos e cobrem os cenários permitido/não permitido (processo inativo, sem tipo OS obrigatório, e vínculo crítico).

### Testing
- Executei `pytest -q tests/test_article_delete_definitivo.py` e a suíte passou com sucesso (`10 passed`).
- Os novos testes confirmam que exclusão é permitida quando o vínculo não é crítico e que é bloqueada quando o vínculo é crítico.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21762129c832e8af584d567ac8350)