### PR TITLE
Add accessible confirmation modal for permanent article deletion (conditional button)

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -483,12 +483,19 @@ def artigo(artigo_id):
             or user.has_permissao(Permissao.ARTIGO_OCR_REPROCESSAR.value)
         )
     )
+    can_delete_definitive = bool(
+        user and (
+            user.has_permissao('admin')
+            or user.has_permissao(Permissao.ARTIGO_EXCLUIR_DEFINITIVO.value)
+        )
+    )
     return render_template(
         'artigos/artigo.html',
         artigo=artigo,
         arquivos=arquivos,
         can_edit_article=user_can_edit_article(user, artigo),
         can_reprocess_ocr=can_reprocess_ocr,
+        can_delete_definitive=can_delete_definitive,
     )
 
 

--- a/templates/artigos/artigo.html
+++ b/templates/artigos/artigo.html
@@ -172,6 +172,11 @@
         <a href="{{ url_for('meus_artigos') }}" class="btn btn-outline-secondary ms-1">
           Voltar para Meus Artigos
         </a>
+        {% if can_delete_definitive %}
+        <button type="button" class="btn btn-danger ms-1" data-bs-toggle="modal" data-bs-target="#deleteDefinitiveModal">
+          Excluir definitivamente
+        </button>
+        {% endif %}
       </div>
 
       </div> {# .card-body #}
@@ -179,6 +184,49 @@
   </div> {# .col #}
 </div> {# .row #}
 </div>
+
+{% if can_delete_definitive %}
+<div class="modal fade" id="deleteDefinitiveModal" tabindex="-1" aria-labelledby="deleteDefinitiveModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" action="{{ url_for('excluir_artigo_definitivo', artigo_id=artigo.id) }}" id="deleteDefinitiveForm" novalidate>
+        <div class="modal-header">
+          <h5 class="modal-title" id="deleteDefinitiveModalLabel">Excluir artigo definitivamente</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+        </div>
+        <div class="modal-body">
+          {% if csrf_token is defined %}
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          {% endif %}
+          <div class="alert alert-danger" role="alert">
+            <strong>Atenção:</strong> essa ação é irreversível e removerá o artigo e seus anexos permanentemente.
+          </div>
+
+          <div class="mb-3">
+            <label for="motivoExclusao" class="form-label">Motivo da exclusão definitiva</label>
+            <textarea class="form-control" id="motivoExclusao" name="motivo" rows="3" required aria-describedby="motivoErro"></textarea>
+            <div id="motivoErro" class="invalid-feedback">Informe o motivo da exclusão definitiva.</div>
+          </div>
+
+          <div class="mb-3">
+            <label for="confirmacaoExclusao" class="form-label">
+              Confirme digitando <strong>CONFIRMAR</strong> ou o título exato do artigo
+            </label>
+            <input type="text" class="form-control" id="confirmacaoExclusao" name="confirmacao" required aria-describedby="confirmacaoErro">
+            <div id="confirmacaoErro" class="invalid-feedback">
+              Digite CONFIRMAR ou exatamente: "{{ artigo.titulo }}".
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="submit" class="btn btn-danger">Confirmar exclusão definitiva</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endif %}
 {% endblock %}
 {% block extra_js %}
 <script>
@@ -192,6 +240,45 @@
     } else {
       console.warn('Função markNotificationAsReadMatchingUrl não encontrada em main.js.');
     }
+
+    const deleteModal = document.getElementById('deleteDefinitiveModal');
+    const deleteForm = document.getElementById('deleteDefinitiveForm');
+    if (!deleteModal || !deleteForm) return;
+
+    const motivoEl = document.getElementById('motivoExclusao');
+    const confirmacaoEl = document.getElementById('confirmacaoExclusao');
+    const tituloArtigo = "{{ artigo.titulo|e }}";
+
+    deleteModal.addEventListener('shown.bs.modal', function () {
+      motivoEl.focus();
+    });
+
+    deleteForm.addEventListener('submit', function (event) {
+      const motivo = (motivoEl.value || '').trim();
+      const confirmacao = (confirmacaoEl.value || '').trim();
+      const confirmacaoValida = confirmacao === 'CONFIRMAR' || confirmacao === tituloArtigo;
+
+      motivoEl.classList.remove('is-invalid');
+      confirmacaoEl.classList.remove('is-invalid');
+
+      let hasError = false;
+      if (!motivo) {
+        motivoEl.classList.add('is-invalid');
+        hasError = true;
+      }
+
+      if (!confirmacaoValida) {
+        confirmacaoEl.classList.add('is-invalid');
+        hasError = true;
+      }
+
+      if (hasError) {
+        event.preventDefault();
+        event.stopPropagation();
+        const firstInvalid = deleteForm.querySelector('.is-invalid');
+        if (firstInvalid) firstInvalid.focus();
+      }
+    });
   });
 </script>
 {% endblock %}

--- a/tests/test_article_delete_definitivo.py
+++ b/tests/test_article_delete_definitivo.py
@@ -64,6 +64,27 @@ def test_excluir_definitivo_sem_permissao(client):
     assert b'Permiss' in resp.data
 
 
+def test_botao_excluir_definitivo_visibilidade_condicional(client):
+    _login(client, username='u_del', perms=[])
+    with app.app_context():
+        aid = _create_article('Sem Permissao')
+    sem_permissao = client.get(f'/artigo/{aid}')
+    assert b'Excluir definitivamente' not in sem_permissao.data
+
+    with app.app_context():
+        user = User.query.filter_by(username='u_del').first()
+        permissao = Funcao.query.filter_by(codigo='artigo_excluir_definitivo').first()
+        if not permissao:
+            permissao = Funcao(codigo='artigo_excluir_definitivo', nome='artigo_excluir_definitivo')
+            db.session.add(permissao)
+            db.session.flush()
+        user.permissoes_personalizadas.append(permissao)
+        db.session.commit()
+
+    com_permissao = client.get(f'/artigo/{aid}')
+    assert b'Excluir definitivamente' in com_permissao.data
+
+
 def test_excluir_definitivo_confirmacao_invalida(client):
     _login(client, perms=['artigo_excluir_definitivo'])
     with app.app_context():


### PR DESCRIPTION
### Motivation
- Prevent accidental permanent deletion by showing the destructive action only to authorized users and requiring an explicit, accessible confirmation with reason and text confirmation.

### Description
- Add `can_delete_definitive` in `blueprints/articles.py` and pass it to the article template when the current user is `admin` or has `Permissao.ARTIGO_EXCLUIR_DEFINITIVO`.
- Update `templates/artigos/artigo.html` to render the red `Excluir definitivamente` button only when `can_delete_definitive` is true and to include a modal form that posts to `excluir_artigo_definitivo` with CSRF support if `csrf_token` is available.
- Implement modal contents: irreversibility alert, required `motivo` textarea with label and `invalid-feedback`, required `confirmacao` text input that must be `CONFIRMAR` or the exact article title, and ensure focus management for accessibility.
- Add client-side validation script to focus the first invalid field and show visible error messages; keep backend validations intact.
- Add integration test `test_botao_excluir_definitivo_visibilidade_condicional` in `tests/test_article_delete_definitivo.py` to assert the button visibility is conditional on the permission, and adjust the test to grant the permission to the existing test user.

### Testing
- Ran `pytest -q tests/test_article_delete_definitivo.py` after changes, and the file tests passed (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f219064e18832ebc62a07536d27a05)