### PR TITLE
Emit article_hard_delete and article_hard_delete_blocked events with full context and tests

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -526,17 +526,21 @@ def excluir_artigo_definitivo(artigo_id):
     _revision_requests = artigo.revision_requests.all()
     _comments = artigo.comments.all()
     attachments_count = len(attachments)
+    correlation_id = getattr(g, "request_correlation_id", None)
+    route = request.path
     has_critical_link = any((att.ocr_status or '').strip().lower() == 'processando' for att in attachments)
     if has_critical_link:
         log_article_event(
             app.logger,
-            "article_delete_blocked_critical_consistency",
+            "article_hard_delete_blocked",
             level=30,
             article_id=artigo.id,
+            article_title=artigo.titulo,
             user_id=user.id,
             reason='ocr_processing_in_progress',
+            route=route,
             attachment_count=attachments_count,
-            correlation_id=getattr(g, "request_correlation_id", None),
+            correlation_id=correlation_id,
         )
         flash('Exclusão bloqueada: o artigo possui anexo com processamento OCR em andamento.', 'danger')
         return redirect(url_for('artigo', artigo_id=artigo_id))
@@ -558,11 +562,15 @@ def excluir_artigo_definitivo(artigo_id):
     if etapa_critica:
         log_article_event(
             app.logger,
-            "article_delete_blocked_critical_process_link",
+            "article_hard_delete_blocked",
             level=30,
             article_id=artigo.id,
+            article_title=artigo.titulo,
             user_id=user.id,
-            correlation_id=getattr(g, "request_correlation_id", None),
+            reason='critical_process_link',
+            route=route,
+            attachment_count=attachments_count,
+            correlation_id=correlation_id,
         )
         processo_nome = etapa_critica.processo.nome if etapa_critica.processo else etapa_critica.processo_id
         flash(
@@ -584,7 +592,7 @@ def excluir_artigo_definitivo(artigo_id):
                     article_id=artigo.id,
                     user_id=user.id,
                     attachment_id=attachment.id,
-                    correlation_id=getattr(g, "request_correlation_id", None),
+                    correlation_id=correlation_id,
                 )
                 continue
 
@@ -598,7 +606,7 @@ def excluir_artigo_definitivo(artigo_id):
                     user_id=user.id,
                     attachment_id=attachment.id,
                     filename=filename,
-                    correlation_id=getattr(g, "request_correlation_id", None),
+                    correlation_id=correlation_id,
                 )
             except FileNotFoundError:
                 log_article_event(
@@ -609,7 +617,7 @@ def excluir_artigo_definitivo(artigo_id):
                     user_id=user.id,
                     attachment_id=attachment.id,
                     filename=filename,
-                    correlation_id=getattr(g, "request_correlation_id", None),
+                    correlation_id=correlation_id,
                 )
             except OSError:
                 log_article_exception(
@@ -619,7 +627,7 @@ def excluir_artigo_definitivo(artigo_id):
                     user_id=user.id,
                     attachment_id=attachment.id,
                     filename=filename,
-                    correlation_id=getattr(g, "request_correlation_id", None),
+                    correlation_id=correlation_id,
                 )
 
         db.session.add(
@@ -635,6 +643,17 @@ def excluir_artigo_definitivo(artigo_id):
         )
         db.session.delete(artigo)
         db.session.commit()
+        log_article_event(
+            app.logger,
+            "article_hard_delete",
+            user_id=user.id,
+            article_id=artigo.id,
+            article_title=artigo.titulo,
+            attachment_count=attachments_count,
+            reason=motivo,
+            route=route,
+            correlation_id=correlation_id,
+        )
         flash(f'Artigo excluído definitivamente com sucesso. {attachments_count} anexo(s) removido(s).', 'success')
         return redirect(url_for('meus_artigos'))
     except Exception:

--- a/core/utils.py
+++ b/core/utils.py
@@ -72,6 +72,9 @@ def build_article_log_context(
     attempt: int | None = None,
     progress_id: str | None = None,
     correlation_id: str | None = None,
+    article_title: str | None = None,
+    attachment_count: int | None = None,
+    reason: str | None = None,
 ) -> dict[str, Any]:
     """Monta payload de contexto padronizado para logs de artigo/anexo/OCR."""
     return {
@@ -87,6 +90,9 @@ def build_article_log_context(
         "attempt": attempt,
         "progress_id": progress_id,
         "correlation_id": correlation_id,
+        "article_title": article_title,
+        "attachment_count": attachment_count,
+        "reason": reason,
     }
 
 

--- a/tests/test_article_logging.py
+++ b/tests/test_article_logging.py
@@ -1,7 +1,8 @@
 from io import BytesIO
 
 from app import app, db
-from core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User
+from core.enums import ArticleStatus
+from core.models import Instituicao, Estabelecimento, Setor, Celula, Funcao, User, Article, Attachment
 
 
 import pytest
@@ -17,11 +18,14 @@ def client(app_ctx):
         db.session.add_all([inst, est, setor, cel])
         db.session.commit()
 
-        func = Funcao.query.filter_by(codigo='artigo_criar').first()
-        if not func:
-            func = Funcao(codigo='artigo_criar', nome='artigo_criar')
-            db.session.add(func)
-            db.session.flush()
+        funcoes = []
+        for codigo in ('artigo_criar', 'artigo_excluir_definitivo'):
+            func = Funcao.query.filter_by(codigo=codigo).first()
+            if not func:
+                func = Funcao(codigo=codigo, nome=codigo)
+                db.session.add(func)
+                db.session.flush()
+            funcoes.append(func)
 
         user = User(
             username='logger_user',
@@ -31,7 +35,8 @@ def client(app_ctx):
             setor_id=setor.id,
             celula_id=cel.id,
         )
-        user.permissoes_personalizadas.append(func)
+        for func in funcoes:
+            user.permissoes_personalizadas.append(func)
         db.session.add(user)
         db.session.commit()
         uid = user.id
@@ -87,3 +92,71 @@ def test_articles_propagam_x_request_id_no_response(client):
     response = client.get('/upload-progress/abc', headers={'X-Request-ID': 'corr-xyz'})
     assert response.status_code == 200
     assert response.headers.get('X-Request-ID') == 'corr-xyz'
+
+
+def test_excluir_definitivo_emite_evento_hard_delete_com_contexto(monkeypatch, client):
+    eventos = []
+
+    def _fake_log_article_event(_logger, event, **context):
+        eventos.append((event, context))
+
+    monkeypatch.setattr('blueprints.articles.log_article_event', _fake_log_article_event)
+
+    with app.app_context():
+        user = User.query.filter_by(username='logger_user').first()
+        artigo = Article(titulo='Delete me', texto='x', status=ArticleStatus.RASCUNHO, user_id=user.id)
+        db.session.add(artigo)
+        db.session.commit()
+        aid = artigo.id
+
+    response = client.post(
+        f'/artigo/{aid}/excluir-definitivo',
+        headers={'X-Request-ID': 'req-hard-del-1'},
+        data={'motivo': 'duplicado', 'confirmacao': 'Delete me'},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    hard_delete_ctx = next(ctx for nome, ctx in eventos if nome == 'article_hard_delete')
+    assert hard_delete_ctx['user_id'] is not None
+    assert hard_delete_ctx['article_id'] == aid
+    assert hard_delete_ctx['article_title'] == 'Delete me'
+    assert hard_delete_ctx['attachment_count'] == 0
+    assert hard_delete_ctx['reason'] == 'duplicado'
+    assert hard_delete_ctx['route'] == f'/artigo/{aid}/excluir-definitivo'
+    assert hard_delete_ctx['correlation_id'] == 'req-hard-del-1'
+
+
+def test_excluir_definitivo_bloqueado_emite_evento_com_contexto(monkeypatch, client):
+    eventos = []
+
+    def _fake_log_article_event(_logger, event, **context):
+        eventos.append((event, context))
+
+    monkeypatch.setattr('blueprints.articles.log_article_event', _fake_log_article_event)
+
+    with app.app_context():
+        user = User.query.filter_by(username='logger_user').first()
+        artigo = Article(titulo='Blocked delete', texto='x', status=ArticleStatus.RASCUNHO, user_id=user.id)
+        db.session.add(artigo)
+        db.session.flush()
+        db.session.add(Attachment(article_id=artigo.id, filename='lock.pdf', mime_type='application/pdf', ocr_status='processando'))
+        db.session.commit()
+        aid = artigo.id
+
+    response = client.post(
+        f'/artigo/{aid}/excluir-definitivo',
+        headers={'X-Request-ID': 'req-hard-del-2'},
+        data={'motivo': 'higienizacao', 'confirmacao': 'Blocked delete'},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    blocked_ctx = next(ctx for nome, ctx in eventos if nome == 'article_hard_delete_blocked')
+    assert blocked_ctx['user_id'] is not None
+    assert blocked_ctx['article_id'] == aid
+    assert blocked_ctx['article_title'] == 'Blocked delete'
+    assert blocked_ctx['attachment_count'] == 1
+    assert blocked_ctx['reason'] == 'ocr_processing_in_progress'
+    assert blocked_ctx['route'] == f'/artigo/{aid}/excluir-definitivo'
+    assert blocked_ctx['correlation_id'] == 'req-hard-del-2'


### PR DESCRIPTION
### Motivation
- Ensure the definitive article deletion flow emits a dedicated, fully contextual event for successful hard deletes (`article_hard_delete`).
- Ensure attempts blocked by critical conditions emit a distinct blocked event (`article_hard_delete_blocked`) so blocking reasons are auditable.
- Keep using the existing logging utilities so the application's configured handlers persist logs to the backend unchanged (`log_article_event` / `log_article_exception`).

### Description
- Capture `route` and `correlation_id` once in the delete flow and reuse them for all emitted events in `blueprints/articles.py`.
- Emit `article_hard_delete_blocked` with context (`user_id`, `article_id`, `article_title`, `attachment_count`, `reason`, `route`, `correlation_id`) for OCR-processing and critical-process-link blocks.
- Emit `article_hard_delete` after a successful commit with context (`user_id`, `article_id`, `article_title`, `attachment_count`, `reason`, `route`, `correlation_id`).
- Keep calling `log_article_event` and `log_article_exception` with `app.logger` so application logging handlers continue to persist logs.
- Add/adjust tests in `tests/test_article_logging.py` to validate emission and full context of `article_hard_delete` and `article_hard_delete_blocked` and to ensure the test user has the `artigo_excluir_definitivo` permission.

### Testing
- Ran `pytest -q tests/test_article_logging.py` and all tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21a1102fc832eb0e6f4165f821f3d)