### PR TITLE
Add Boletim model with OCR fields and Alembic migration

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -291,6 +291,7 @@ class User(db.Model):
     
     # Relacionamentos existentes (verifique se os back_populates/backrefs estão corretos com seus outros modelos)
     articles = db.relationship('Article', back_populates='author', lazy='dynamic', cascade='all, delete-orphan')
+    boletins = db.relationship('Boletim', back_populates='autor', lazy='dynamic', cascade='all, delete-orphan')
     revision_requests = db.relationship('RevisionRequest', foreign_keys='RevisionRequest.user_id', back_populates='user', lazy='dynamic', cascade='all, delete-orphan')
     notifications = db.relationship('Notification', back_populates='user', lazy='dynamic', cascade='all, delete-orphan')
     comments = db.relationship('Comment', foreign_keys='Comment.user_id', back_populates='autor', lazy='dynamic', cascade='all, delete-orphan')
@@ -471,6 +472,40 @@ class Attachment(db.Model):
 
     def __repr__(self):
         return f"<Attachment {self.filename} for article_id={self.article_id}>"
+
+
+class Boletim(db.Model):
+    __tablename__ = 'boletim'
+
+    id = db.Column(db.Integer, primary_key=True)
+    titulo = db.Column(db.String(255), nullable=False, index=True)
+    data_boletim = db.Column(db.Date, nullable=False, index=True)
+    arquivo = db.Column(db.String(512), nullable=False)
+    created_at = db.Column(db.DateTime(timezone=True), nullable=False, server_default=func.now())
+    created_by = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+
+    ocr_status = db.Column(db.String(32), nullable=False, default='nao_aplicavel', server_default='nao_aplicavel')
+    ocr_text = db.Column(db.Text, nullable=True)
+    ocr_processed_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    ocr_error_message = db.Column(db.Text, nullable=True)
+    ocr_page_count = db.Column(db.Integer, nullable=True)
+    ocr_pages_success = db.Column(db.Integer, nullable=True)
+    ocr_pages_failed = db.Column(db.Integer, nullable=True)
+    ocr_char_count = db.Column(db.Integer, nullable=True)
+    ocr_attempts = db.Column(db.Integer, nullable=False, default=0, server_default='0')
+    ocr_last_attempt_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    ocr_confidence_score = db.Column(db.Float, nullable=True)
+    ocr_engine = db.Column(db.String(64), nullable=True)
+    ocr_processing_time_seconds = db.Column(db.Float, nullable=True)
+    ocr_requested_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    ocr_started_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    ocr_finished_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    ocr_last_error = db.Column(db.Text, nullable=True)
+
+    autor = db.relationship('User', foreign_keys=[created_by], back_populates='boletins')
+
+    def __repr__(self):
+        return f"<Boletim {self.titulo}>"
 
 
 class OCRReprocessAudit(db.Model):

--- a/migrations/versions/7f1a9b2c3d4e_add_boletim_table.py
+++ b/migrations/versions/7f1a9b2c3d4e_add_boletim_table.py
@@ -1,0 +1,71 @@
+"""add boletim table with ocr fields and fts index
+
+Revision ID: 7f1a9b2c3d4e
+Revises: 2aa4d61d9b20
+Create Date: 2026-04-29 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '7f1a9b2c3d4e'
+down_revision = '2aa4d61d9b20'
+branch_labels = None
+depends_on = None
+
+
+def _is_postgresql() -> bool:
+    bind = op.get_bind()
+    return bool(bind and bind.dialect.name == 'postgresql')
+
+
+def upgrade():
+    op.create_table(
+        'boletim',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('titulo', sa.String(length=255), nullable=False),
+        sa.Column('data_boletim', sa.Date(), nullable=False),
+        sa.Column('arquivo', sa.String(length=512), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('created_by', sa.Integer(), sa.ForeignKey('user.id'), nullable=False),
+        sa.Column('ocr_status', sa.String(length=32), nullable=False, server_default='nao_aplicavel'),
+        sa.Column('ocr_text', sa.Text(), nullable=True),
+        sa.Column('ocr_processed_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('ocr_error_message', sa.Text(), nullable=True),
+        sa.Column('ocr_page_count', sa.Integer(), nullable=True),
+        sa.Column('ocr_pages_success', sa.Integer(), nullable=True),
+        sa.Column('ocr_pages_failed', sa.Integer(), nullable=True),
+        sa.Column('ocr_char_count', sa.Integer(), nullable=True),
+        sa.Column('ocr_attempts', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('ocr_last_attempt_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('ocr_confidence_score', sa.Float(), nullable=True),
+        sa.Column('ocr_engine', sa.String(length=64), nullable=True),
+        sa.Column('ocr_processing_time_seconds', sa.Float(), nullable=True),
+        sa.Column('ocr_requested_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('ocr_started_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('ocr_finished_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('ocr_last_error', sa.Text(), nullable=True),
+    )
+
+    op.create_index('ix_boletim_titulo', 'boletim', ['titulo'])
+    op.create_index('ix_boletim_data_boletim', 'boletim', ['data_boletim'])
+
+    if _is_postgresql():
+        op.execute(
+            """
+            CREATE INDEX IF NOT EXISTS ix_boletim_ocr_text_fts
+            ON boletim
+            USING GIN (to_tsvector('portuguese', coalesce(ocr_text, '')));
+            """
+        )
+
+
+def downgrade():
+    if _is_postgresql():
+        op.execute("DROP INDEX IF EXISTS ix_boletim_ocr_text_fts;")
+
+    op.drop_index('ix_boletim_data_boletim', table_name='boletim')
+    op.drop_index('ix_boletim_titulo', table_name='boletim')
+    op.drop_table('boletim')


### PR DESCRIPTION
### Motivation
- Introduzir um model dedicado para boletins (`boletim`) com metadados (título, data, arquivo, autor e timestamps) para armazenar PDFs de boletim separadamente de `Article`. 
- Reaproveitar o contrato de OCR já existente usado em `Attachment` para permitir processamento OCR consistente sobre boletins. 
- Garantir buscas textuais por OCR (FTS) e não adicionar nenhum campo de fluxo de aprovação ou status de artigo ao novo model ou migration.

### Description
- Adiciona `Boletim` em `core/models.py` com `__tablename__ = 'boletim'` e colunas `id`, `titulo`, `data_boletim`, `arquivo`, `created_at` e `created_by` (FK para `user.id`).
- Reutiliza os campos de OCR do padrão de anexos dentro de `Boletim` (`ocr_status`, `ocr_text`, timestamps, métricas e tentativas) e cria o relacionamento `autor = relationship('User', ...)` juntamente com `User.boletins` no lado inverso, sem qualquer relação com `Article`.
- Cria migration Alembic `migrations/versions/7f1a9b2c3d4e_add_boletim_table.py` que cria a tabela `boletim`, adiciona índices simples em `titulo` e `data_boletim`, e cria um índice GIN/FTS em PostgreSQL sobre `ocr_text`.
- Implementa rollback completo na migration removendo o índice FTS (se PostgreSQL), os índices simples e a tabela `boletim`.

### Testing
- Validated syntax by running `python -m py_compile core/models.py migrations/versions/7f1a9b2c3d4e_add_boletim_table.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22e1c3354832ebe5b871d394e3de0)