### PR TITLE
Adicionar permissões de boletim ao catálogo e sincronização

### DIFF
--- a/core/enums.py
+++ b/core/enums.py
@@ -68,6 +68,11 @@ class Permissao(Enum):
     ARTIGO_OCR_REPROCESSAR = "artigo_ocr_reprocessar"
     ARTIGO_EXCLUIR_DEFINITIVO = "artigo_excluir_definitivo"
 
+    # --- boletim ---
+    BOLETIM_VISUALIZAR = "boletim_visualizar"
+    BOLETIM_BUSCAR = "boletim_buscar"
+    BOLETIM_GERENCIAR = "boletim_gerenciar"
+
 
 class OSStatus(Enum):
     """Status possíveis de uma Ordem de Serviço."""

--- a/core/permission_catalog.py
+++ b/core/permission_catalog.py
@@ -18,11 +18,18 @@ class PermissionCatalogItem:
     nome: str
 
 
+FRIENDLY_NAMES: dict[str, str] = {
+    Permissao.BOLETIM_VISUALIZAR.value: "Boletim visualizar",
+    Permissao.BOLETIM_BUSCAR.value: "Boletim buscar",
+    Permissao.BOLETIM_GERENCIAR.value: "Boletim gerenciar",
+}
+
+
 CATALOG: tuple[PermissionCatalogItem, ...] = (
     *(
         PermissionCatalogItem(
             codigo=permission.value,
-            nome=permission.value.replace("_", " ").capitalize(),
+            nome=FRIENDLY_NAMES.get(permission.value, permission.value.replace("_", " ").capitalize()),
         )
         for permission in Permissao
     ),

--- a/migrations/versions/5d2a9c7e1f44_seed_boletim_permissions.py
+++ b/migrations/versions/5d2a9c7e1f44_seed_boletim_permissions.py
@@ -1,0 +1,44 @@
+"""seed boletim permissions
+
+Revision ID: 5d2a9c7e1f44
+Revises: bb1d9e24176f
+Create Date: 2026-04-29 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '5d2a9c7e1f44'
+down_revision = 'bb1d9e24176f'
+branch_labels = None
+depends_on = None
+
+
+PERMISSIONS = (
+    ("boletim_visualizar", "Boletim visualizar"),
+    ("boletim_buscar", "Boletim buscar"),
+    ("boletim_gerenciar", "Boletim gerenciar"),
+)
+
+
+def upgrade():
+    connection = op.get_bind()
+    for codigo, nome in PERMISSIONS:
+        exists = connection.execute(
+            sa.text("SELECT 1 FROM funcao WHERE codigo = :codigo LIMIT 1"),
+            {"codigo": codigo},
+        ).first()
+        if not exists:
+            connection.execute(
+                sa.text("INSERT INTO funcao (codigo, nome) VALUES (:codigo, :nome)"),
+                {"codigo": codigo, "nome": nome},
+            )
+
+
+def downgrade():
+    connection = op.get_bind()
+    codes = [codigo for codigo, _ in PERMISSIONS]
+    connection.execute(
+        sa.text("DELETE FROM funcao WHERE codigo = ANY(:codes)"),
+        {"codes": codes},
+    )

--- a/migrations/versions/5d2a9c7e1f44_seed_boletim_permissions.py
+++ b/migrations/versions/5d2a9c7e1f44_seed_boletim_permissions.py
@@ -1,7 +1,7 @@
 """seed boletim permissions
 
 Revision ID: 5d2a9c7e1f44
-Revises: bb1d9e24176f
+Revises: 7f1a9b2c3d4e
 Create Date: 2026-04-29 00:00:00.000000
 """
 
@@ -9,7 +9,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = '5d2a9c7e1f44'
-down_revision = 'bb1d9e24176f'
+down_revision = '7f1a9b2c3d4e'
 branch_labels = None
 depends_on = None
 

--- a/tests/test_permission_sync.py
+++ b/tests/test_permission_sync.py
@@ -149,3 +149,22 @@ def test_sync_permission_catalog_contains_artigo_excluir_definitivo(app_ctx):
     perm = Funcao.query.filter_by(codigo="artigo_excluir_definitivo").one_or_none()
     assert perm is not None
     assert perm.managed_by_system is True
+
+
+def test_sync_permission_catalog_contains_boletim_permissions(app_ctx):
+    result = sync_permission_catalog(db.session)
+    db.session.commit()
+
+    assert result.created == len(CATALOG)
+
+    expected = {
+        "boletim_visualizar": "Boletim visualizar",
+        "boletim_buscar": "Boletim buscar",
+        "boletim_gerenciar": "Boletim gerenciar",
+    }
+
+    for codigo, nome in expected.items():
+        perm = Funcao.query.filter_by(codigo=codigo).one_or_none()
+        assert perm is not None
+        assert perm.nome == nome
+        assert perm.managed_by_system is True


### PR DESCRIPTION
### Motivation
- Introduzir permissões relacionadas a boletim para permitir controle de visualização, busca e gerenciamento no sistema. 
- Expor nomes amigáveis no catálogo para apresentar rótulos claros nas interfaces e sincronizador. 
- Garantir que as permissões existam no banco via migration de seed idempotente para ambientes novos ou já existentes. 
- Atualizar os testes de sincronização para cobrir os novos códigos e evitar regressões. 

### Description
- Adiciona os códigos `BOLETIM_VISUALIZAR`, `BOLETIM_BUSCAR` e `BOLETIM_GERENCIAR` ao enum `Permissao` em `core/enums.py`. 
- Introduz o dicionário `FRIENDLY_NAMES` em `core/permission_catalog.py` e passa a usar esse mapa ao construir o `CATALOG` para fornecer nomes amigáveis explícitos. 
- Cria a migration de seed `migrations/versions/5d2a9c7e1f44_seed_boletim_permissions.py` que insere de forma idempotente as permissões na tabela `funcao` no `upgrade()` e remove-as no `downgrade()`. 
- Expande `tests/test_permission_sync.py` com `test_sync_permission_catalog_contains_boletim_permissions` para validar presença, nome e `managed_by_system=True` das novas permissões. 

### Testing
- Executado `pytest -q tests/test_permission_sync.py` e todos os testes passaram (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f232ceedf0832e8b13452e4f4cd361)