### PR TITLE
Adiciona módulo de boletins com rotas, permissões e templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -220,18 +220,21 @@ try:
     from .blueprints.admin import admin_bp
     from .blueprints.auth import auth_bp
     from .blueprints.articles import articles_bp
+    from .blueprints.boletins import boletins_bp
 except ImportError:  # pragma: no cover - fallback for direct execution
     from blueprints.admin import admin_bp
     from blueprints.auth import auth_bp
     from blueprints.articles import articles_bp
+    from blueprints.boletins import boletins_bp
 
 
 app.register_blueprint(admin_bp)
 app.register_blueprint(auth_bp)
 app.register_blueprint(articles_bp)
+app.register_blueprint(boletins_bp)
 
 for rule in list(app.url_map.iter_rules()):
-    if rule.endpoint.startswith('admin_bp.') or rule.endpoint.startswith('auth_bp.') or rule.endpoint.startswith('articles_bp.'):
+    if rule.endpoint.startswith('admin_bp.') or rule.endpoint.startswith('auth_bp.') or rule.endpoint.startswith('articles_bp.') or rule.endpoint.startswith('boletins_bp.'):
         app.add_url_rule(
             rule.rule,
             endpoint=rule.endpoint.split('.',1)[-1],

--- a/blueprints/boletins.py
+++ b/blueprints/boletins.py
@@ -1,0 +1,172 @@
+from datetime import datetime
+import os
+import uuid
+
+from flask import Blueprint, current_app as app, flash, redirect, render_template, request, session, url_for
+from sqlalchemy import or_
+from werkzeug.utils import secure_filename
+
+try:
+    from ..core.database import db
+    from ..core.models import Boletim, User
+    from ..core.services.ocr_queue import enqueue_boletim_for_ocr
+except ImportError:  # pragma: no cover
+    from core.database import db
+    from core.models import Boletim, User
+    from core.services.ocr_queue import enqueue_boletim_for_ocr
+
+boletins_bp = Blueprint('boletins_bp', __name__)
+
+
+def _require_permission(permission_name: str, redirect_endpoint: str = 'pagina_inicial'):
+    if 'user_id' not in session:
+        flash('Por favor, faça login.', 'warning')
+        return None, redirect(url_for('login'))
+
+    user = User.query.get(session['user_id'])
+    if not user or not user.has_permissao(permission_name):
+        flash('Permissão negada.', 'danger')
+        return None, redirect(url_for(redirect_endpoint))
+    return user, None
+
+
+def _ocr_status_badge(status: str) -> str:
+    map_css = {
+        'concluido': 'success',
+        'pendente': 'warning',
+        'processando': 'info',
+        'erro': 'danger',
+        'baixo_aproveitamento': 'secondary',
+        'nao_aplicavel': 'light',
+    }
+    return map_css.get((status or '').lower(), 'dark')
+
+
+@boletins_bp.route('/boletins', methods=['GET'], endpoint='boletins_listar')
+def listar_boletins():
+    user, denied = _require_permission('boletim_visualizar')
+    if denied:
+        return denied
+
+    boletins = Boletim.query.order_by(Boletim.data_boletim.desc(), Boletim.id.desc()).all()
+    return render_template(
+        'boletins/listagem.html',
+        boletins=boletins,
+        can_manage=user.has_permissao('boletim_gerenciar'),
+        badge_for=_ocr_status_badge,
+    )
+
+
+@boletins_bp.route('/boletins/novo', methods=['GET', 'POST'], endpoint='boletins_novo')
+def novo_boletim():
+    user, denied = _require_permission('boletim_gerenciar', redirect_endpoint='boletins_listar')
+    if denied:
+        return denied
+
+    if request.method == 'POST':
+        titulo = (request.form.get('titulo') or '').strip()
+        data_raw = (request.form.get('data_boletim') or '').strip()
+        arquivo = request.files.get('arquivo')
+
+        if not titulo or not data_raw or not arquivo or not arquivo.filename:
+            flash('Título, data e arquivo PDF são obrigatórios.', 'warning')
+            return render_template('boletins/novo.html')
+
+        if not arquivo.filename.lower().endswith('.pdf'):
+            flash('Envie apenas arquivo PDF.', 'warning')
+            return render_template('boletins/novo.html')
+
+        try:
+            data_boletim = datetime.strptime(data_raw, '%Y-%m-%d').date()
+        except ValueError:
+            flash('Data inválida.', 'warning')
+            return render_template('boletins/novo.html')
+
+        filename = f"{uuid.uuid4().hex}_{secure_filename(arquivo.filename)}"
+        dest = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+        arquivo.save(dest)
+
+        boletim = Boletim(titulo=titulo, data_boletim=data_boletim, arquivo=filename, created_by=user.id)
+        db.session.add(boletim)
+        enqueue_boletim_for_ocr(boletim)
+        db.session.commit()
+        flash('Boletim cadastrado com sucesso.', 'success')
+        return redirect(url_for('boletins_visualizar', id=boletim.id))
+
+    return render_template('boletins/novo.html')
+
+
+@boletins_bp.route('/boletins/<int:id>', methods=['GET'], endpoint='boletins_visualizar')
+def visualizar_boletim(id: int):
+    user, denied = _require_permission('boletim_visualizar', redirect_endpoint='boletins_listar')
+    if denied:
+        return denied
+
+    boletim = Boletim.query.get_or_404(id)
+    return render_template('boletins/visualizar.html', boletim=boletim, can_manage=user.has_permissao('boletim_gerenciar'))
+
+
+@boletins_bp.route('/boletins/buscar', methods=['GET'], endpoint='boletins_buscar')
+def buscar_boletins():
+    user, denied = _require_permission('boletim_buscar', redirect_endpoint='boletins_listar')
+    if denied:
+        return denied
+
+    termo = (request.args.get('q') or '').strip()
+    query = Boletim.query
+    if termo:
+        like = f"%{termo}%"
+        query = query.filter(or_(Boletim.titulo.ilike(like), Boletim.ocr_text.ilike(like)))
+
+    boletins = query.order_by(Boletim.data_boletim.desc(), Boletim.id.desc()).all()
+    return render_template('boletins/busca.html', boletins=boletins, termo=termo, can_manage=user.has_permissao('boletim_gerenciar'))
+
+
+@boletins_bp.route('/boletins/<int:id>/editar', methods=['GET', 'POST'], endpoint='boletins_editar')
+def editar_boletim(id: int):
+    _, denied = _require_permission('boletim_gerenciar', redirect_endpoint='boletins_listar')
+    if denied:
+        return denied
+
+    boletim = Boletim.query.get_or_404(id)
+    if request.method == 'POST':
+        boletim.titulo = (request.form.get('titulo') or boletim.titulo).strip() or boletim.titulo
+        data_raw = (request.form.get('data_boletim') or '').strip()
+        if data_raw:
+            try:
+                boletim.data_boletim = datetime.strptime(data_raw, '%Y-%m-%d').date()
+            except ValueError:
+                flash('Data inválida.', 'warning')
+                return render_template('boletins/novo.html', boletim=boletim, modo_edicao=True)
+
+        db.session.commit()
+        flash('Boletim atualizado.', 'success')
+        return redirect(url_for('boletins_visualizar', id=boletim.id))
+
+    return render_template('boletins/novo.html', boletim=boletim, modo_edicao=True)
+
+
+@boletins_bp.route('/boletins/<int:id>/reprocessar-ocr', methods=['POST'], endpoint='boletins_reprocessar_ocr')
+def reprocessar_ocr_boletim(id: int):
+    _, denied = _require_permission('boletim_gerenciar', redirect_endpoint='boletins_listar')
+    if denied:
+        return denied
+
+    boletim = Boletim.query.get_or_404(id)
+    enqueue_boletim_for_ocr(boletim)
+    db.session.commit()
+    flash('OCR reenfileirado para processamento.', 'success')
+    return redirect(url_for('boletins_visualizar', id=id))
+
+
+@boletins_bp.route('/boletins/<int:id>/excluir', methods=['POST'], endpoint='boletins_excluir')
+def excluir_boletim(id: int):
+    _, denied = _require_permission('boletim_gerenciar', redirect_endpoint='boletins_listar')
+    if denied:
+        return denied
+
+    boletim = Boletim.query.get_or_404(id)
+    db.session.delete(boletim)
+    db.session.commit()
+    flash('Boletim excluído com sucesso.', 'success')
+    return redirect(url_for('boletins_listar'))

--- a/templates/boletins/busca.html
+++ b/templates/boletins/busca.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+  <h1>Buscar boletins</h1>
+  <form method="get" class="mb-3">
+    <input class="form-control" type="text" name="q" placeholder="Título ou texto OCR" value="{{ termo or '' }}">
+  </form>
+  <ul class="list-group">
+    {% for b in boletins %}
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <a href="{{ url_for('boletins_visualizar', id=b.id) }}">{{ b.titulo }}</a>
+        <span class="text-muted">{{ b.data_boletim.strftime('%d/%m/%Y') }}</span>
+      </li>
+    {% else %}
+      <li class="list-group-item">Nenhum resultado.</li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/templates/boletins/listagem.html
+++ b/templates/boletins/listagem.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block title %}Boletins{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h1>Boletins</h1>
+    {% if can_manage %}<a class="btn btn-primary" href="{{ url_for('boletins_novo') }}">Novo boletim</a>{% endif %}
+  </div>
+  <table class="table table-striped">
+    <thead><tr><th>ID</th><th>Título</th><th>Data</th><th>Status OCR</th><th>Ações</th></tr></thead>
+    <tbody>
+      {% for b in boletins %}
+      <tr>
+        <td>{{ b.id }}</td><td>{{ b.titulo }}</td><td>{{ b.data_boletim.strftime('%d/%m/%Y') }}</td>
+        <td><span class="badge bg-{{ badge_for(b.ocr_status) }}">{{ b.ocr_status }}</span></td>
+        <td>
+          <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('boletins_visualizar', id=b.id) }}">Abrir</a>
+          {% if can_manage %}
+          <a class="btn btn-sm btn-outline-primary" href="{{ url_for('boletins_editar', id=b.id) }}">Editar</a>
+          <form class="d-inline" method="post" action="{{ url_for('boletins_reprocessar_ocr', id=b.id) }}"><button class="btn btn-sm btn-outline-warning">Reprocessar OCR</button></form>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/templates/boletins/novo.html
+++ b/templates/boletins/novo.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+  <h1>{{ 'Editar boletim' if modo_edicao else 'Novo boletim' }}</h1>
+  <form method="post" enctype="multipart/form-data">
+    <div class="mb-3"><label>Título</label><input class="form-control" name="titulo" value="{{ boletim.titulo if boletim else '' }}" required></div>
+    <div class="mb-3"><label>Data</label><input type="date" class="form-control" name="data_boletim" value="{{ boletim.data_boletim.strftime('%Y-%m-%d') if boletim else '' }}" required></div>
+    {% if not modo_edicao %}<div class="mb-3"><label>PDF</label><input type="file" name="arquivo" accept="application/pdf" class="form-control" required></div>{% endif %}
+    <button class="btn btn-primary" type="submit">Salvar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/boletins/visualizar.html
+++ b/templates/boletins/visualizar.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+  <h1>{{ boletim.titulo }}</h1>
+  <p><strong>Data:</strong> {{ boletim.data_boletim.strftime('%d/%m/%Y') }}</p>
+  <p><strong>Status OCR:</strong> {{ boletim.ocr_status }}</p>
+  <p><a class="btn btn-outline-secondary" href="{{ url_for('uploaded_file', filename=boletim.arquivo) }}" target="_blank">Abrir PDF</a></p>
+  {% if can_manage %}
+  <a class="btn btn-primary" href="{{ url_for('boletins_editar', id=boletim.id) }}">Editar</a>
+  <form method="post" class="d-inline" action="{{ url_for('boletins_reprocessar_ocr', id=boletim.id) }}"><button class="btn btn-warning">Reprocessar OCR</button></form>
+  <form method="post" class="d-inline" action="{{ url_for('boletins_excluir', id=boletim.id) }}" onsubmit="return confirm('Excluir boletim?');"><button class="btn btn-danger">Excluir</button></form>
+  {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
### Motivation
- Fornecer gerenciamento de boletins (upload PDF, OCR, busca e CRUD básico) integrado ao sistema com controle de permissões por backend.
- Expor interface mínima para listar, criar, editar, visualizar, buscar, reenfileirar OCR e excluir boletins.

### Description
- Adiciona `blueprints/boletins.py` com blueprint `boletins_bp` e rotas: `GET /boletins`, `GET|POST /boletins/novo`, `GET /boletins/<id>`, `GET /boletins/buscar`, `GET|POST /boletins/<id>/editar`, `POST /boletins/<id>/reprocessar-ocr` e `POST /boletins/<id>/excluir` e validação de permissão via helper `_require_permission` usando `boletim_visualizar`, `boletim_buscar` e `boletim_gerenciar`.
- Implementa upload de PDF em criação (salva em `app.config['UPLOAD_FOLDER']`), validação de extensão, parsing de data e enfileiramento para OCR via `enqueue_boletim_for_ocr` além de reprocessamento manual.
- Registra o blueprint em `app.py` e inclui o prefixo `boletins_bp.` no loop que cria aliases de endpoint, seguindo o padrão existente.
- Cria templates `templates/boletins/listagem.html`, `templates/boletins/novo.html`, `templates/boletins/visualizar.html` e `templates/boletins/busca.html`, com badge visual de status OCR e ocultação dos botões de gestão no UI quando o usuário não tem `boletim_gerenciar` (com validação também no backend).

### Testing
- Executado `python -m py_compile app.py blueprints/boletins.py` para verificação estática de sintaxe e compilação, que concluiu com sucesso.
- Verificadas renderizações básicas de templates e presença das rotas através de inspeção estática do código (compilação e leitura dos arquivos gerados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f234bad94c832e98a0f1a0975df65a)