### PR TITLE
Implementa busca de boletins com FTS, fallback ILIKE e paginação

### DIFF
--- a/blueprints/boletins.py
+++ b/blueprints/boletins.py
@@ -3,8 +3,9 @@ import os
 import uuid
 
 from flask import Blueprint, current_app as app, flash, redirect, render_template, request, session, url_for
-from sqlalchemy import or_
+from sqlalchemy import and_, func, or_, text
 from werkzeug.utils import secure_filename
+import unicodedata
 
 try:
     from ..core.database import db
@@ -113,13 +114,63 @@ def buscar_boletins():
         return denied
 
     termo = (request.args.get('q') or '').strip()
+    page = request.args.get('page', 1, type=int)
+    per_page = min(max(request.args.get('per_page', 20, type=int), 1), 100)
+
+    bind = db.session.get_bind()
+    is_postgresql = bool(bind and bind.dialect.name == 'postgresql')
+    supports_unaccent = False
+    if is_postgresql:
+        try:
+            supports_unaccent = bool(
+                db.session.execute(
+                    text("SELECT 1 FROM pg_extension WHERE extname='unaccent'")
+                ).scalar()
+            )
+        except Exception:
+            supports_unaccent = False
+
+    def _strip_accents(value: str) -> str:
+        normalized = unicodedata.normalize('NFD', value or '')
+        return ''.join(ch for ch in normalized if unicodedata.category(ch) != 'Mn')
+
     query = Boletim.query
     if termo:
-        like = f"%{termo}%"
-        query = query.filter(or_(Boletim.titulo.ilike(like), Boletim.ocr_text.ilike(like)))
+        tokens = [t for t in termo.split() if t]
+        if is_postgresql:
+            for token in tokens:
+                like = f"%{token}%"
+                conditions = [
+                    Boletim.titulo.ilike(like),
+                    Boletim.ocr_text.ilike(like),
+                    func.to_tsvector('portuguese', func.coalesce(Boletim.titulo, '') + text("' '") + func.coalesce(Boletim.ocr_text, '')).op('@@')(func.plainto_tsquery('portuguese', token)),
+                ]
+                if supports_unaccent:
+                    like_unaccent = f"%{_strip_accents(token)}%"
+                    conditions.extend([
+                        func.unaccent(Boletim.titulo).ilike(like_unaccent),
+                        func.unaccent(func.coalesce(Boletim.ocr_text, '')).ilike(like_unaccent),
+                    ])
+                query = query.filter(or_(*conditions))
+        else:
+            for token in tokens:
+                normalized_token = _strip_accents(token).lower()
+                query = query.filter(
+                    or_(
+                        func.lower(Boletim.titulo).ilike(f"%{normalized_token}%"),
+                        func.lower(func.coalesce(Boletim.ocr_text, '')).ilike(f"%{normalized_token}%"),
+                    )
+                )
 
-    boletins = query.order_by(Boletim.data_boletim.desc(), Boletim.id.desc()).all()
-    return render_template('boletins/busca.html', boletins=boletins, termo=termo, can_manage=user.has_permissao('boletim_gerenciar'))
+    pagination = query.order_by(Boletim.data_boletim.desc(), Boletim.created_at.desc()).paginate(page=page, per_page=per_page, error_out=False)
+    return render_template(
+        'boletins/busca.html',
+        boletins=pagination.items,
+        termo=termo,
+        can_manage=user.has_permissao('boletim_gerenciar'),
+        pagination=pagination,
+        per_page=per_page,
+    )
 
 
 @boletins_bp.route('/boletins/<int:id>/editar', methods=['GET', 'POST'], endpoint='boletins_editar')

--- a/migrations/versions/aa91c3d7e5f1_add_boletim_fts_index.py
+++ b/migrations/versions/aa91c3d7e5f1_add_boletim_fts_index.py
@@ -1,7 +1,7 @@
 """add boletim fts index
 
 Revision ID: aa91c3d7e5f1
-Revises: c7a1d9e6b2f4
+Revises: 5d2a9c7e1f44
 Create Date: 2026-04-29 00:00:00.000000
 """
 
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'aa91c3d7e5f1'
-down_revision = 'c7a1d9e6b2f4'
+down_revision = '5d2a9c7e1f44'
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/aa91c3d7e5f1_add_boletim_fts_index.py
+++ b/migrations/versions/aa91c3d7e5f1_add_boletim_fts_index.py
@@ -1,0 +1,38 @@
+"""add boletim fts index
+
+Revision ID: aa91c3d7e5f1
+Revises: c7a1d9e6b2f4
+Create Date: 2026-04-29 00:00:00.000000
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'aa91c3d7e5f1'
+down_revision = 'c7a1d9e6b2f4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    if bind.dialect.name == 'postgresql':
+        op.execute(
+            """
+            CREATE INDEX IF NOT EXISTS ix_boletim_tsv_titulo_ocr
+            ON boletim
+            USING GIN (
+                to_tsvector(
+                    'portuguese',
+                    coalesce(titulo, '') || ' ' || coalesce(ocr_text, '')
+                )
+            )
+            """
+        )
+
+
+def downgrade():
+    bind = op.get_bind()
+    if bind.dialect.name == 'postgresql':
+        op.execute("DROP INDEX IF EXISTS ix_boletim_tsv_titulo_ocr")

--- a/templates/boletins/busca.html
+++ b/templates/boletins/busca.html
@@ -4,7 +4,15 @@
   <h1>Buscar boletins</h1>
   <form method="get" class="mb-3">
     <input class="form-control" type="text" name="q" placeholder="Título ou texto OCR" value="{{ termo or '' }}">
-  </form>
+    <div class="mt-2 d-flex gap-2 align-items-center">
+    <label for="per_page" class="form-label mb-0">Por página:</label>
+    <select id="per_page" name="per_page" class="form-select w-auto" onchange="this.form.submit()">
+      {% for option in [10, 20, 50, 100] %}
+        <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
+      {% endfor %}
+    </select>
+  </div>
+</form>
   <ul class="list-group">
     {% for b in boletins %}
       <li class="list-group-item d-flex justify-content-between align-items-center">
@@ -15,5 +23,18 @@
       <li class="list-group-item">Nenhum resultado.</li>
     {% endfor %}
   </ul>
+{% if pagination and pagination.pages > 1 %}
+<nav class="mt-3" aria-label="Paginação">
+  <ul class="pagination">
+    <li class="page-item {% if not pagination.has_prev %}disabled{% endif %}">
+      <a class="page-link" href="{{ url_for('boletins_buscar', q=termo, per_page=per_page, page=pagination.prev_num) }}">Anterior</a>
+    </li>
+    <li class="page-item disabled"><span class="page-link">Página {{ pagination.page }} de {{ pagination.pages }}</span></li>
+    <li class="page-item {% if not pagination.has_next %}disabled{% endif %}">
+      <a class="page-link" href="{{ url_for('boletins_buscar', q=termo, per_page=per_page, page=pagination.next_num) }}">Próxima</a>
+    </li>
+  </ul>
+</nav>
+{% endif %}
 </div>
 {% endblock %}

--- a/tests/test_boletins_busca.py
+++ b/tests/test_boletins_busca.py
@@ -1,0 +1,76 @@
+from datetime import date
+
+from app import app, db
+from core.models import Boletim, Celula, Estabelecimento, Funcao, Instituicao, Setor, User
+
+
+def _grant_permissions(user, permissions):
+    for codigo in permissions:
+        funcao = Funcao.query.filter_by(codigo=codigo).first()
+        if not funcao:
+            funcao = Funcao(codigo=codigo, nome=codigo)
+            db.session.add(funcao)
+            db.session.flush()
+        user.permissoes_personalizadas.append(funcao)
+
+
+def _setup_user(client, permissions):
+    inst = Instituicao(codigo='IBUSCA', nome='Inst Busca')
+    est = Estabelecimento(codigo='EBUSCA', nome_fantasia='Est Busca', instituicao=inst)
+    setor = Setor(nome='Setor Busca', estabelecimento=est)
+    cel = Celula(nome='Celula Busca', estabelecimento=est, setor=setor)
+    db.session.add_all([inst, est, setor, cel])
+    db.session.flush()
+
+    user = User(username='busca_user', email='busca@test.local', estabelecimento=est, setor=setor, celula=cel)
+    user.set_password('123')
+    db.session.add(user)
+    db.session.flush()
+
+    _grant_permissions(user, permissions)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess['user_id'] = user.id
+        sess['username'] = user.username
+
+    return user
+
+
+def _create_boletim(user, titulo, ocr_text, data):
+    boletim = Boletim(titulo=titulo, ocr_text=ocr_text, arquivo=f'{titulo}.pdf', data_boletim=data, created_by=user.id)
+    db.session.add(boletim)
+    db.session.commit()
+    return boletim
+
+
+def test_busca_boletim_match_titulo(client):
+    with app.app_context():
+        user = _setup_user(client, ['boletim_buscar', 'boletim_visualizar'])
+        _create_boletim(user, 'Comunicado Geral de RH', 'Texto irrelevante', date(2026, 1, 1))
+
+    resp = client.get('/boletins/buscar', query_string={'q': 'Comunicado'})
+
+    assert resp.status_code == 200
+    assert b'Comunicado Geral de RH' in resp.data
+
+
+def test_busca_boletim_match_ocr(client):
+    with app.app_context():
+        user = _setup_user(client, ['boletim_buscar', 'boletim_visualizar'])
+        _create_boletim(user, 'Atualização Financeira', 'Processo de faturamento consolidado', date(2026, 1, 2))
+
+    resp = client.get('/boletins/buscar', query_string={'q': 'faturamento'})
+
+    assert resp.status_code == 200
+    assert b'Atualiza' in resp.data
+
+
+def test_busca_boletim_sem_permissao(client):
+    with app.app_context():
+        _setup_user(client, ['boletim_visualizar'])
+
+    resp = client.get('/boletins/buscar', follow_redirects=True)
+
+    assert resp.status_code == 200
+    assert b'Permiss' in resp.data


### PR DESCRIPTION
### Motivation

- Permitir busca por `titulo` e texto extraído por OCR (`ocr_text`) nos boletins para melhorar a localizabilidade de conteúdo publicado.
- Aproveitar Full Text Search do PostgreSQL para buscas mais precisas e eficientes quando disponível, mantendo compatibilidade com SQLite/testes.
- Fornecer paginação e ordenação estável (`data_boletim desc`, `created_at desc`) para grandes volumes de boletins.
- Garantir controle de acesso e UX consistente com verificação de permissão `boletim_buscar`.

### Description

- Atualiza a rota de busca em `blueprints/boletins.py` adicionando tokenização do termo, detecção de PostgreSQL, uso de `to_tsvector(...).op('@@')(plainto_tsquery(...))` para FTS e checagem opcional de `unaccent` via consulta a `pg_extension`.
- Implementa fallback simples para ambientes sem FTS usando comparações `ILIKE` (normalização por acentos quando necessário) e busca case-insensitive por tokens.
- Adiciona paginação (`page`, `per_page` com limite entre 1 e 100) e ordenação por `data_boletim desc, created_at desc` usando o `paginate` do SQLAlchemy/Flask-SQLAlchemy.
- Atualiza `templates/boletins/busca.html` para incluir seletor `per_page` e navegação de páginas (Anterior/Próxima).
- Cria migration `migrations/versions/aa91c3d7e5f1_add_boletim_fts_index.py` que adiciona condicionalmente um índice GIN `to_tsvector('portuguese', coalesce(titulo, '') || ' ' || coalesce(ocr_text, ''))` quando o banco é PostgreSQL.
- Adiciona testes em `tests/test_boletins_busca.py` cobrindo busca por título, busca por OCR e comportamento quando o usuário não tem a permissão `boletim_buscar`.

### Testing

- Executado `pytest -q tests/test_boletins_busca.py` e todos os testes do arquivo passaram (`3 passed`).
- Testes foram executados em ambiente de teste com SQLite em memória (fallback ILIKE) para validar compatibilidade quando FTS não está disponível.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f235d838cc832ea5a5e65d10c03a2a)