### PR TITLE
Ajusta permissões e adiciona item de navegação “Boletins”

### DIFF
--- a/blueprints/boletins.py
+++ b/blueprints/boletins.py
@@ -31,6 +31,18 @@ def _require_permission(permission_name: str, redirect_endpoint: str = 'pagina_i
     return user, None
 
 
+def _require_any_permission(permission_names: tuple[str, ...], redirect_endpoint: str = 'pagina_inicial'):
+    if 'user_id' not in session:
+        flash('Por favor, faça login.', 'warning')
+        return None, redirect(url_for('login'))
+
+    user = User.query.get(session['user_id'])
+    if not user or not any(user.has_permissao(p) for p in permission_names):
+        flash('Permissão negada.', 'danger')
+        return None, redirect(url_for(redirect_endpoint))
+    return user, None
+
+
 def _ocr_status_badge(status: str) -> str:
     map_css = {
         'concluido': 'success',
@@ -45,7 +57,7 @@ def _ocr_status_badge(status: str) -> str:
 
 @boletins_bp.route('/boletins', methods=['GET'], endpoint='boletins_listar')
 def listar_boletins():
-    user, denied = _require_permission('boletim_visualizar')
+    user, denied = _require_any_permission(('boletim_visualizar', 'boletim_buscar'))
     if denied:
         return denied
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -388,6 +388,15 @@
                         'artigo',
                         'editar_artigo'
                     ] %}
+                    {% set boletins_active = current_endpoint in ['boletins_listar', 'boletins_buscar', 'boletins_visualizar', 'boletins_novo', 'boletins_editar'] %}
+                    {% if current_user.is_authenticated and (current_user.has_permissao('boletim_visualizar') or current_user.has_permissao('boletim_buscar')) %}
+                    <li class="nav-item">
+                        <a class="nav-link {{ 'active' if boletins_active else '' }}" href="{{ url_for('boletins_listar') }}">
+                            <i class="bi bi-journal-richtext me-2"></i> Boletins
+                        </a>
+                    </li>
+                    {% endif %}
+
                     <li class="nav-item">
                         <a class="nav-link d-flex justify-content-between align-items-center {{ 'active' if biblioteca_active else '' }} {{ 'collapsed' if not biblioteca_active }}"
                         data-bs-toggle="collapse" href="#collapseBiblioteca" role="button"


### PR DESCRIPTION
### Motivation
- Expor o link de acesso à área de boletins na sidebar apenas quando o usuário tiver permissão de leitura adequada. 
- Evitar inconsistência entre o que a UI mostra (botão/rota) e o que o backend permite acessar diretamente por URL. 
- Manter a criação/edição de boletins restrita a quem tem permissão de gerenciamento.

### Description
- Adiciona o item de navegação “Boletins” em `templates/base.html`, visível somente para usuários autenticados com `boletim_visualizar` ou `boletim_buscar` e com estado ativo para endpoints da área de boletins. 
- Introduz a função auxiliar `_require_any_permission(permission_names: tuple[str, ...])` em `blueprints/boletins.py` para validar múltiplas permissões de leitura em conjunto. 
- Altera a rota de listagem `/boletins` para usar `_require_any_permission(('boletim_visualizar', 'boletim_buscar'))`, permitindo acesso quando o usuário tiver ao menos uma das permissões de leitura. 
- Mantém a exibição do botão “Novo boletim” condicionada a `boletim_gerenciar` na tela de listagem (sem alteração funcional nessa template de listagem). 

### Testing
- Executado `pytest -q tests/test_boletins_busca.py tests/test_permission_sync.py`. 
- Resultado: todos os testes automatizados relacionados passaram (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f237ddf5a8832ea8e4885bc95edf40)