### PR TITLE
Padroniza estilos de botões na tela de artigo

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -260,6 +260,46 @@
   background-color: var(--bg-hover-subtle);
 }
 
+/* Padronização visual de botões (UX) */
+.btn-app-primary {
+  background-color: #0d6efd;
+  border-color: #0d6efd;
+  color: #fff;
+}
+
+.btn-app-primary:hover,
+.btn-app-primary:focus {
+  background-color: #0b5ed7;
+  border-color: #0a58ca;
+  color: #fff;
+}
+
+.btn-app-secondary {
+  background-color: transparent;
+  border: 1px solid #6c757d;
+  color: #6c757d;
+}
+
+.btn-app-secondary:hover,
+.btn-app-secondary:focus {
+  background-color: #6c757d;
+  border-color: #6c757d;
+  color: #fff;
+}
+
+.btn-app-danger {
+  background-color: #dc3545;
+  border-color: #dc3545;
+  color: #fff;
+}
+
+.btn-app-danger:hover,
+.btn-app-danger:focus {
+  background-color: #bb2d3b;
+  border-color: #b02a37;
+  color: #fff;
+}
+
 /* Espaçamento opt-in para cards específicos */
 .card-screen-spacing {
   margin-bottom: 2rem;

--- a/templates/artigos/artigo.html
+++ b/templates/artigos/artigo.html
@@ -82,7 +82,7 @@
                 {% if can_reprocess_ocr and ext == 'pdf' %}
                 <div class="px-2 pb-2">
                   <form method="post" action="{{ url_for('admin_bp.admin_reprocess_ocr_attachment', attachment_id=att.id) }}" class="mt-1">
-                    <button type="submit" class="btn btn-sm btn-outline-warning w-100">Reprocessar OCR</button>
+                    <button type="submit" class="btn btn-sm btn-app-secondary w-100">Reprocessar OCR</button>
                   </form>
                 </div>
                 {% endif %}
@@ -146,19 +146,19 @@
         <div class="mt-4">
           {% if can_reprocess_ocr and artigo.attachments and artigo.attachments.count() > 0 %}
           <form method="post" action="{{ url_for('admin_bp.admin_reprocess_ocr_article', article_id=artigo.id) }}" class="d-inline">
-            <button type="submit" class="btn btn-outline-warning">
+            <button type="submit" class="btn btn-app-secondary">
               Reprocessar OCR deste artigo
             </button>
           </form>
           {% endif %}
           {% if can_edit_article %}
-          <a href="{{ url_for('editar_artigo', artigo_id=artigo.id) }}" class="btn btn-primary">
+          <a href="{{ url_for('editar_artigo', artigo_id=artigo.id) }}" class="btn btn-app-primary">
             Editar
           </a>
           {% endif %}
 
         {% if session.get('username') and artigo.status == ArticleStatus.APROVADO %}
-        <a href="{{ url_for('solicitar_revisao', artigo_id=artigo.id) }}" class="btn btn-warning text-dark">
+        <a href="{{ url_for('solicitar_revisao', artigo_id=artigo.id) }}" class="btn btn-app-secondary">
           Solicitar Revisão
         </a>
         {% endif %}
@@ -169,11 +169,11 @@
           style="position:absolute; bottom:10px; right:10px; cursor:pointer; font-size:1.3rem;"
         ></i>
         {% endif %}
-        <a href="{{ url_for('meus_artigos') }}" class="btn btn-outline-secondary ms-1">
+        <a href="{{ url_for('meus_artigos') }}" class="btn btn-app-secondary ms-1">
           Voltar para Meus Artigos
         </a>
         {% if can_delete_definitive %}
-        <button type="button" class="btn btn-danger ms-1" data-bs-toggle="modal" data-bs-target="#deleteDefinitiveModal">
+        <button type="button" class="btn btn-app-danger ms-1" data-bs-toggle="modal" data-bs-target="#deleteDefinitiveModal">
           Excluir definitivamente
         </button>
         {% endif %}
@@ -219,8 +219,8 @@
           </div>
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
-          <button type="submit" class="btn btn-danger">Confirmar exclusão definitiva</button>
+          <button type="button" class="btn btn-app-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="submit" class="btn btn-app-danger">Confirmar exclusão definitiva</button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
### Motivation
- Unificar aparência dos botões na interface para reduzir inconsistência visual e deixar clara a hierarquia de ações (primária, secundária, crítica). 
- Focar principalmente na tela de artigo onde existiam variações (fundo, outline, cores diferentes) que prejudicavam a experiência do usuário.

### Description
- Adiciona classes semânticas globais de botão em `static/css/custom.css`: `btn-app-primary`, `btn-app-secondary` e `btn-app-danger` com estados `:hover`/`:focus` e cores definidas. 
- Substitui classes Bootstrap/inline existentes na página de artigo por essas classes em `templates/artigos/artigo.html` para os controles de OCR, editar, solicitar revisão, voltar e exclusão definitiva (incluindo botões do modal). 
- Alteração é apenas de CSS e markup das templates, sem lógica backend modificada.

### Testing
- Nenhum teste automatizado foi executado para esta alteração; mudança focada em estilo/markup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24372e2b4832eb62fb1636b5a6078)