### PR TITLE
Introduce standardized `.btn-app` styles and apply to article actions UI

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -260,6 +260,76 @@
   background-color: var(--bg-hover-subtle);
 }
 
+/* Padronização visual de botões (UX) */
+.btn-app {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.9rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+  line-height: 1.2;
+  border-radius: 0.375rem;
+}
+
+.btn-app-primary {
+  background-color: #0d6efd;
+  border-color: #0d6efd;
+  color: #fff;
+}
+
+.btn-app-primary:hover,
+.btn-app-primary:focus {
+  background-color: #0b5ed7;
+  border-color: #0a58ca;
+  color: #fff;
+}
+
+.btn-app-secondary {
+  background-color: #e9eef5;
+  border: 1px solid #7a8594;
+  color: #344054;
+}
+
+.btn-app-secondary:hover,
+.btn-app-secondary:focus {
+  background-color: #d8e0ea;
+  border-color: #667085;
+  color: #1f2937;
+}
+
+[data-bs-theme="dark"] .btn-app-secondary {
+  background-color: rgba(148, 163, 184, 0.24);
+  border-color: rgba(203, 213, 225, 0.48);
+  color: #e5e7eb;
+}
+
+[data-bs-theme="dark"] .btn-app-secondary:hover,
+[data-bs-theme="dark"] .btn-app-secondary:focus {
+  background-color: rgba(148, 163, 184, 0.34);
+  border-color: rgba(226, 232, 240, 0.66);
+  color: #fff;
+}
+
+.btn-app-danger {
+  background-color: #dc3545;
+  border-color: #dc3545;
+  color: #fff;
+}
+
+.btn-app-danger:hover,
+.btn-app-danger:focus {
+  background-color: #bb2d3b;
+  border-color: #b02a37;
+  color: #fff;
+}
+
+.article-actions-group {
+  border-top: 1px solid var(--border-default);
+  padding-top: 0.75rem;
+}
+
 /* Espaçamento opt-in para cards específicos */
 .card-screen-spacing {
   margin-bottom: 2rem;

--- a/templates/artigos/artigo.html
+++ b/templates/artigos/artigo.html
@@ -82,7 +82,7 @@
                 {% if can_reprocess_ocr and ext == 'pdf' %}
                 <div class="px-2 pb-2">
                   <form method="post" action="{{ url_for('admin_bp.admin_reprocess_ocr_attachment', attachment_id=att.id) }}" class="mt-1">
-                    <button type="submit" class="btn btn-sm btn-outline-warning w-100">Reprocessar OCR</button>
+                    <button type="submit" class="btn btn-sm btn-app btn-app-secondary w-100"><i class="bi bi-arrow-repeat" aria-hidden="true"></i> Reprocessar OCR</button>
                   </form>
                 </div>
                 {% endif %}
@@ -145,21 +145,25 @@
         {# Botões de ação #}
         <div class="mt-4">
           {% if can_reprocess_ocr and artigo.attachments and artigo.attachments.count() > 0 %}
-          <form method="post" action="{{ url_for('admin_bp.admin_reprocess_ocr_article', article_id=artigo.id) }}" class="d-inline">
-            <button type="submit" class="btn btn-outline-warning">
-              Reprocessar OCR deste artigo
-            </button>
-          </form>
+          <div class="article-actions-group mb-3">
+            <small class="text-muted d-block mb-2">Ações de OCR</small>
+            <form method="post" action="{{ url_for('admin_bp.admin_reprocess_ocr_article', article_id=artigo.id) }}" class="d-inline">
+              <button type="submit" class="btn btn-app btn-app-primary">
+                <i class="bi bi-arrow-repeat" aria-hidden="true"></i> Reprocessar OCR deste artigo
+              </button>
+            </form>
+          </div>
           {% endif %}
+          <div class="article-actions-group d-flex flex-wrap gap-2">
           {% if can_edit_article %}
-          <a href="{{ url_for('editar_artigo', artigo_id=artigo.id) }}" class="btn btn-primary">
-            Editar
+          <a href="{{ url_for('editar_artigo', artigo_id=artigo.id) }}" class="btn btn-app btn-app-primary">
+            <i class="bi bi-pencil-square" aria-hidden="true"></i> Editar
           </a>
           {% endif %}
 
         {% if session.get('username') and artigo.status == ArticleStatus.APROVADO %}
-        <a href="{{ url_for('solicitar_revisao', artigo_id=artigo.id) }}" class="btn btn-warning text-dark">
-          Solicitar Revisão
+        <a href="{{ url_for('solicitar_revisao', artigo_id=artigo.id) }}" class="btn btn-app btn-app-secondary">
+          <i class="bi bi-chat-left-text" aria-hidden="true"></i> Solicitar Revisão
         </a>
         {% endif %}
         {% if artigo.status == ArticleStatus.APROVADO %}
@@ -169,14 +173,15 @@
           style="position:absolute; bottom:10px; right:10px; cursor:pointer; font-size:1.3rem;"
         ></i>
         {% endif %}
-        <a href="{{ url_for('meus_artigos') }}" class="btn btn-outline-secondary ms-1">
-          Voltar para Meus Artigos
+        <a href="{{ url_for('meus_artigos') }}" class="btn btn-app btn-app-secondary">
+          <i class="bi bi-arrow-left" aria-hidden="true"></i> Voltar para Meus Artigos
         </a>
         {% if can_delete_definitive %}
-        <button type="button" class="btn btn-danger ms-1" data-bs-toggle="modal" data-bs-target="#deleteDefinitiveModal">
-          Excluir definitivamente
+        <button type="button" class="btn btn-app btn-app-danger" data-bs-toggle="modal" data-bs-target="#deleteDefinitiveModal">
+          <i class="bi bi-trash3" aria-hidden="true"></i> Excluir definitivamente
         </button>
         {% endif %}
+      </div>
       </div>
 
       </div> {# .card-body #}
@@ -219,8 +224,8 @@
           </div>
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
-          <button type="submit" class="btn btn-danger">Confirmar exclusão definitiva</button>
+          <button type="button" class="btn btn-app btn-app-secondary" data-bs-dismiss="modal"><i class="bi bi-x-circle" aria-hidden="true"></i> Cancelar</button>
+          <button type="submit" class="btn btn-app btn-app-danger"><i class="bi bi-check-circle" aria-hidden="true"></i> Confirmar exclusão definitiva</button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
### Motivation
- Provide a consistent, application-level visual style for action buttons on the article detail page to improve UX and visual hierarchy.
- Group OCR-related and article actions to make intent clearer and reduce visual clutter.

### Description
- Added new button utility styles in `static/css/custom.css`: `btn-app`, `btn-app-primary`, `btn-app-secondary`, `btn-app-danger`, and `article-actions-group` to standardize padding, spacing, colors, hover/focus states and dark-theme adjustments.
- Updated `templates/artigos/artigo.html` to replace default Bootstrap buttons with the new `btn-app` variants and added iconography using Bootstrap Icons (e.g. `bi-arrow-repeat`, `bi-pencil-square`, `bi-chat-left-text`, `bi-arrow-left`, `bi-trash3`, `bi-x-circle`, `bi-check-circle`).
- Grouped OCR actions into a dedicated block and added `.article-actions-group` wrappers for better separation and spacing of action sets.
- Updated modal action buttons in the delete confirmation modal to use the new `btn-app` classes and icons.

### Testing
- No automated tests were added or modified for this change and no automated test suite was run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24372e2b4832eb62fb1636b5a6078)