### PR TITLE
Adiciona badge de status OCR em anexos PDF do template de artigo

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -910,3 +910,38 @@
 .required-field:focus {
   border-left-color: var(--bs-danger);
 }
+
+.ocr-status-badge {
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.ocr-status-pendente {
+  background-color: #6c757d;
+  color: #fff;
+}
+
+.ocr-status-processando {
+  background-color: #0d6efd;
+  color: #fff;
+}
+
+.ocr-status-concluido {
+  background-color: #198754;
+  color: #fff;
+}
+
+.ocr-status-erro {
+  background-color: #dc3545;
+  color: #fff;
+}
+
+.ocr-status-baixo-aproveitamento {
+  background-color: #ffc107;
+  color: #212529;
+}
+
+.ocr-status-desconhecido {
+  background-color: #6c757d;
+  color: #fff;
+}

--- a/templates/artigos/artigo.html
+++ b/templates/artigos/artigo.html
@@ -50,6 +50,15 @@
             {% set fname = att.filename %}
             {% set ext = fname.split('.')[-1].lower() %}
             {% set original_name = fname.split('_', 1)[1] if '_' in fname else fname %}
+            {% set ocr_status_map = {
+              'pendente': {'label': 'Pendente', 'class': 'ocr-status-pendente'},
+              'processando': {'label': 'Processando', 'class': 'ocr-status-processando'},
+              'concluido': {'label': 'Concluído', 'class': 'ocr-status-concluido'},
+              'erro': {'label': 'Erro', 'class': 'ocr-status-erro'},
+              'baixo_aproveitamento': {'label': 'Baixo aproveitamento', 'class': 'ocr-status-baixo-aproveitamento'}
+            } %}
+            {% set att_ocr_status = (att.ocr_status or '')|lower %}
+            {% set ocr_status_data = ocr_status_map.get(att_ocr_status) %}
             <div class="col-12 col-sm-6 col-md-4 col-lg-3 attachment-card">
               <div class="card h-100 shadow-sm position-relative">
                 <a href="{{ url_for('uploaded_file', filename=fname) }}" class="text-decoration-none text-reset"
@@ -77,6 +86,15 @@
                   <div class="card-body p-2 attachment-meta">
                     <div class="attachment-name" title="{{ original_name }}">{{ original_name }}</div>
                     <div class="attachment-details"><span class="attachment-kind">{{ "Imagem" if ext in ["jpg","jpeg","png","gif","webp"] else "Documento" }}</span></div>
+                    {% if ext == 'pdf' %}
+                    <div class="mt-1">
+                      {% if ocr_status_data %}
+                      <span class="badge ocr-status-badge {{ ocr_status_data.class }}">OCR: {{ ocr_status_data.label }}</span>
+                      {% else %}
+                      <span class="badge ocr-status-badge ocr-status-desconhecido">OCR: Não informado</span>
+                      {% endif %}
+                    </div>
+                    {% endif %}
                   </div>
                 </a>
                 {% if can_reprocess_ocr and ext == 'pdf' %}


### PR DESCRIPTION
### Motivation
- Mostrar visualmente o status do processamento OCR para arquivos PDF anexados a artigos, sem interferir em anexos não-PDF.
- Garantir cores específicas para cada estado OCR (pendente, processando, concluido, erro, baixo_aproveitamento) conforme padrão de produto.

### Description
- Adiciona mapeamento local Jinja em `templates/artigos/artigo.html` para associar cada status OCR a um rótulo legível e a uma classe CSS.
- Renderiza no card do anexo, apenas para `ext == 'pdf'`, um badge no formato `OCR: <Status>` com fallback `OCR: Não informado` quando o status for desconhecido ou ausente.
- Inclui classes CSS dedicadas em `static/css/custom.css` para as cores exatas solicitadas (cinza, azul, verde, vermelho e amarelo) e uma classe de fallback.
- Mantém anexos não-PDF sem ruído visual, exibindo o badge somente em PDFs e preservando os controles existentes de reprocessamento OCR.

### Testing
- Revisei as alterações do template e do CSS por diff e inspeção direta dos arquivos modificados; as renderizações condicionais foram verificadas no template.
- Validei que o badge só é inserido quando `ext == 'pdf'` e que existe fallback para status desconhecido; nenhuma suíte automatizada foi executada para este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24c8c52ac832e9ef4e5a9abf26bb2)