### PR TITLE
feat: adicionar painel OCR expansível por anexo PDF

### DIFF
--- a/templates/artigos/artigo.html
+++ b/templates/artigos/artigo.html
@@ -39,12 +39,7 @@
 
           {# Anexos com aviso para PDFs não pesquisáveis #}
           {% if artigo.attachments %}
-          <h5 class="d-flex align-items-center">
-            Anexos
-            <i class="bi bi-info-circle ms-1 text-secondary" data-bs-toggle="tooltip" data-bs-placement="top"
-              title="PDFs escaneados ou PDFs de imagem podem não ter o texto totalmente extraído, apenas algumas palavras-chave">
-            </i>
-          </h5>
+          <h5 class="d-flex align-items-center">Anexos</h5>
           <div class="row g-3">
             {% for att in artigo.attachments %}
             {% set fname = att.filename %}
@@ -59,6 +54,7 @@
             } %}
             {% set att_ocr_status = (att.ocr_status or '')|lower %}
             {% set ocr_status_data = ocr_status_map.get(att_ocr_status) %}
+            {% set ocr_panel_id = 'ocr-info-' ~ att.id %}
             <div class="col-12 col-sm-6 col-md-4 col-lg-3 attachment-card">
               <div class="card h-100 shadow-sm position-relative">
                 <a href="{{ url_for('uploaded_file', filename=fname) }}" class="text-decoration-none text-reset"
@@ -102,6 +98,30 @@
                   <form method="post" action="{{ url_for('admin_bp.admin_reprocess_ocr_attachment', attachment_id=att.id) }}" class="mt-1">
                     <button type="submit" class="btn btn-sm btn-app btn-app-secondary w-100"><i class="bi bi-arrow-repeat" aria-hidden="true"></i> Reprocessar OCR</button>
                   </form>
+                </div>
+                {% endif %}
+                {% if ext == 'pdf' %}
+                <div class="px-2 pb-2">
+                  <button
+                    type="button"
+                    class="btn btn-sm btn-outline-secondary w-100 d-flex align-items-center justify-content-center gap-1"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#{{ ocr_panel_id }}"
+                    aria-expanded="false"
+                    aria-controls="{{ ocr_panel_id }}"
+                    aria-label="Exibir informações de OCR do anexo {{ original_name }}">
+                    <i class="bi bi-info-circle" aria-hidden="true"></i>
+                    Detalhes do OCR
+                  </button>
+                  <div class="collapse mt-2" id="{{ ocr_panel_id }}">
+                    <div class="border rounded p-2 small bg-light">
+                      <div><strong>Caracteres OCR:</strong> {{ att.ocr_char_count if att.ocr_char_count is not none else '—' }}</div>
+                      <div><strong>Páginas OCR:</strong> {{ att.ocr_page_count if att.ocr_page_count is not none else '—' }}</div>
+                      <div><strong>Páginas com sucesso:</strong> {{ att.ocr_pages_success if att.ocr_pages_success is not none else '—' }}</div>
+                      <div><strong>Páginas com falha:</strong> {{ att.ocr_pages_failed if att.ocr_pages_failed is not none else '—' }}</div>
+                      <div><strong>Tentativas OCR:</strong> {{ att.ocr_attempts if att.ocr_attempts is not none else '—' }}</div>
+                    </div>
+                  </div>
                 </div>
                 {% endif %}
                 {% if ext == 'pdf' and not att.content %}


### PR DESCRIPTION
### Motivation
- Tornar as informações de OCR acessíveis por anexo em vez de depender de um tooltip genérico no cabeçalho da seção de anexos.
- Permitir que usuários visualizem métricas de OCR (quando disponíveis) diretamente no card do PDF sem navegação adicional.

### Description
- Remove o tooltip genérico do cabeçalho de anexos e ajusta o título para `Anexos` no template `templates/artigos/artigo.html`.
- Adiciona, em cada card de anexo PDF, um botão que abre/fecha um painel inline usando `collapse` do Bootstrap dentro do próprio card.
- Exibe os campos `ocr_char_count`, `ocr_page_count`, `ocr_pages_success`, `ocr_pages_failed` e `ocr_attempts` no painel com fallback amigável `—` quando o valor for nulo.
- Garante IDs únicos por anexo usando `ocr-info-{{ att.id }}` e preserva atributos de acessibilidade no botão (`aria-expanded`, `aria-controls`, `aria-label`).

### Testing
- Executado `git diff` na mudança de `templates/artigos/artigo.html` para revisar o patch e a verificação retornou o diff esperado (sucesso).
- Executado `git add` e `git commit -m "feat: adicionar painel OCR expansível por anexo PDF"` e o commit foi criado com sucesso.
- Inspecionado o arquivo com `nl -ba templates/artigos/artigo.html | sed -n '34,150p'` para validar a posição das alterações e a saída confirmou as linhas inseridas (sucesso).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24e001848832e86a94ac7a78f9d07)