### PR TITLE
Navegação e atalho de busca de boletins com controle de permissão

### DIFF
--- a/blueprints/boletins.py
+++ b/blueprints/boletins.py
@@ -66,6 +66,7 @@ def listar_boletins():
         'boletins/listagem.html',
         boletins=boletins,
         can_manage=user.has_permissao('boletim_gerenciar'),
+        can_search=user.has_permissao('boletim_buscar'),
         badge_for=_ocr_status_badge,
     )
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -396,6 +396,13 @@
                         </a>
                     </li>
                     {% endif %}
+                    {% if current_user.is_authenticated and (current_user.has_permissao('boletim_buscar') or current_user.has_permissao('admin')) %}
+                    <li class="nav-item">
+                        <a class="nav-link {{ 'active' if current_endpoint == 'boletins_buscar' else '' }}" href="{{ url_for('boletins_buscar') }}">
+                            <i class="bi bi-search me-2"></i> Pesquisar boletins
+                        </a>
+                    </li>
+                    {% endif %}
 
                     <li class="nav-item">
                         <a class="nav-link d-flex justify-content-between align-items-center {{ 'active' if biblioteca_active else '' }} {{ 'collapsed' if not biblioteca_active }}"

--- a/templates/boletins/listagem.html
+++ b/templates/boletins/listagem.html
@@ -4,7 +4,10 @@
 <div class="container mt-4">
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h1>Boletins</h1>
-    {% if can_manage %}<a class="btn btn-primary" href="{{ url_for('boletins_novo') }}">Novo boletim</a>{% endif %}
+    <div class="d-flex gap-2">
+      {% if can_search %}<a class="btn btn-outline-secondary" href="{{ url_for('boletins_buscar') }}">Buscar</a>{% endif %}
+      {% if can_manage %}<a class="btn btn-primary" href="{{ url_for('boletins_novo') }}">Novo boletim</a>{% endif %}
+    </div>
   </div>
   <table class="table table-striped">
     <thead><tr><th>ID</th><th>Título</th><th>Data</th><th>Status OCR</th><th>Ações</th></tr></thead>

--- a/tests/test_boletins_busca.py
+++ b/tests/test_boletins_busca.py
@@ -74,3 +74,25 @@ def test_busca_boletim_sem_permissao(client):
 
     assert resp.status_code == 200
     assert b'Permiss' in resp.data
+
+
+def test_listagem_exibe_atalho_buscar_com_permissao(client):
+    with app.app_context():
+        _setup_user(client, ['boletim_buscar', 'boletim_visualizar'])
+
+    resp = client.get('/boletins')
+
+    assert resp.status_code == 200
+    assert b'Pesquisar boletins' in resp.data
+    assert b'>Buscar<' in resp.data
+
+
+def test_listagem_oculta_atalho_buscar_sem_permissao(client):
+    with app.app_context():
+        _setup_user(client, ['boletim_visualizar'])
+
+    resp = client.get('/boletins')
+
+    assert resp.status_code == 200
+    assert b'Pesquisar boletins' not in resp.data
+    assert b'>Buscar<' not in resp.data


### PR DESCRIPTION
### Motivation
- Permitir que usuários com permissão de busca acessem a funcionalidade de pesquisa de boletins a partir da UI, mantendo o backend bloqueando acesso direto para quem não tem permissão.
- Manter consistência visual com os demais controles do módulo Boletins usando as classes Bootstrap já em uso.

### Description
- Adiciona item de menu lateral `Pesquisar boletins` em `templates/base.html`, exibido apenas para usuários com `current_user.has_permissao('boletim_buscar')` ou `admin`, e marcado ativo quando a rota é `boletins_buscar`.
- Insere botão/atalho `Buscar` no cabeçalho da listagem em `templates/boletins/listagem.html`, usando a classe `btn btn-outline-secondary` e apontando para `url_for('boletins_buscar')`, controlado pela flag `can_search`.
- Atualiza a view `listar_boletins` em `blueprints/boletins.py` para passar `can_search=user.has_permissao('boletim_buscar')` ao template; a autorização backend para `boletins_buscar` permanece intacta em `buscar_boletins`.
- Adiciona testes em `tests/test_boletins_busca.py` que verificam a presença do link/menu e do botão na listagem quando o usuário tem `boletim_buscar` e a ausência quando não tem.

### Testing
- Rodei `pytest -q tests/test_boletins_busca.py` e todos os testes passaram (`5 passed`).
- Os testes cobrem: busca por título e OCR, bloqueio sem permissão e visibilidade/ocultação dos atalhos de busca conforme a permissão `boletim_buscar`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24e100ee4832ea284dcd93ac51d97)