### PR TITLE
Ajusta bloqueio de reprocessamento OCR para anexos em processamento

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -291,6 +291,10 @@ def admin_reprocess_ocr_attachment(attachment_id):
         flash('Anexo não encontrado ou não elegível para OCR.', 'warning')
         return redirect(request.referrer or url_for('admin_bp.admin_dashboard'))
 
+    if (attachment.ocr_status or '').strip().lower() == OCR_STATUS_PROCESSANDO:
+        flash('OCR deste anexo já está em processamento.', 'info')
+        return redirect(request.referrer or url_for('admin_bp.admin_dashboard'))
+
     return _reprocess_attachments(
         [attachment],
         actor=user,

--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -79,12 +79,14 @@ try:
     from ..core.services.ocr_queue import (
         OCR_STATUS_BAIXO_APROVEITAMENTO,
         OCR_STATUS_ERRO,
+        OCR_STATUS_PROCESSANDO,
         mark_attachment_for_reprocess,
     )
 except ImportError:  # pragma: no cover
     from core.services.ocr_queue import (
         OCR_STATUS_BAIXO_APROVEITAMENTO,
         OCR_STATUS_ERRO,
+        OCR_STATUS_PROCESSANDO,
         mark_attachment_for_reprocess,
     )
 

--- a/templates/artigos/artigo.html
+++ b/templates/artigos/artigo.html
@@ -55,6 +55,7 @@
             {% set att_ocr_status = (att.ocr_status or '')|lower %}
             {% set ocr_status_data = ocr_status_map.get(att_ocr_status) %}
             {% set ocr_panel_id = 'ocr-info-' ~ att.id %}
+            {% set is_processing = (att.ocr_status or '').lower() == 'processando' %}
             <div class="col-12 col-sm-6 col-md-4 col-lg-3 attachment-card">
               <div class="card h-100 shadow-sm position-relative">
                 <a href="{{ url_for('uploaded_file', filename=fname) }}" class="text-decoration-none text-reset"
@@ -95,9 +96,20 @@
                 </a>
                 {% if can_reprocess_ocr and ext == 'pdf' %}
                 <div class="px-2 pb-2">
+                  {% if is_processing %}
+                  <button
+                    type="button"
+                    class="btn btn-sm btn-app btn-app-secondary w-100 opacity-50"
+                    disabled
+                    title="OCR em processamento"
+                    aria-disabled="true">
+                    <i class="bi bi-arrow-repeat" aria-hidden="true"></i> Reprocessar OCR
+                  </button>
+                  {% else %}
                   <form method="post" action="{{ url_for('admin_bp.admin_reprocess_ocr_attachment', attachment_id=att.id) }}" class="mt-1">
                     <button type="submit" class="btn btn-sm btn-app btn-app-secondary w-100"><i class="bi bi-arrow-repeat" aria-hidden="true"></i> Reprocessar OCR</button>
                   </form>
+                  {% endif %}
                 </div>
                 {% endif %}
                 {% if ext == 'pdf' %}


### PR DESCRIPTION
### Motivation
- Evitar tentativas duplicadas de reenfileirar OCR e cliques inválidos quando um anexo já está com o OCR em execução (`processando`).
- Fornecer feedback visual claro na interface e proteger também o endpoint backend contra requeues concorrentes.

### Description
- Adiciona a variável Jinja `is_processing = (att.ocr_status or '').lower() == 'processando'` no template `templates/artigos/artigo.html` por anexo para detectar o estado de OCR. 
- Quando `is_processing` é verdadeiro, o template renderiza um botão de reprocesso desabilitado com `disabled`, `aria-disabled="true"`, estilo visual (`opacity-50`) e `title="OCR em processamento"`, evitando a renderização do `<form>` de submit ativo nesse caso. 
- Inclui validação defensiva no endpoint `admin_reprocess_ocr_attachment` em `blueprints/admin.py` que rejeita a requisição com um `flash` informativo se `attachment.ocr_status` já for `processando`.

### Testing
- Nenhum teste automatizado foi executado nesta alteração; as mudanças foram verificadas via inspeção do diff e validação local dos arquivos alterados (`git diff`) e commit (`git commit`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f251d4e040832e9e44d1f09209e337)