### PR TITLE
Atualiza template de busca de boletins para layout tabular

### DIFF
--- a/blueprints/boletins.py
+++ b/blueprints/boletins.py
@@ -181,6 +181,7 @@ def buscar_boletins():
         boletins=pagination.items,
         termo=termo,
         can_manage=user.has_permissao('boletim_gerenciar'),
+        badge_for=_ocr_status_badge,
         pagination=pagination,
         per_page=per_page,
     )

--- a/templates/boletins/busca.html
+++ b/templates/boletins/busca.html
@@ -13,16 +13,30 @@
     </select>
   </div>
 </form>
-  <ul class="list-group">
-    {% for b in boletins %}
-      <li class="list-group-item d-flex justify-content-between align-items-center">
-        <a href="{{ url_for('boletins_visualizar', id=b.id) }}">{{ b.titulo }}</a>
-        <span class="text-muted">{{ b.data_boletim.strftime('%d/%m/%Y') }}</span>
-      </li>
-    {% else %}
-      <li class="list-group-item">Nenhum resultado.</li>
-    {% endfor %}
-  </ul>
+  {% if boletins %}
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Título</th>
+        <th>Data</th>
+        <th>Status OCR</th>
+        <th>Ações</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for b in boletins %}
+      <tr>
+        <td><a href="{{ url_for('boletins_visualizar', id=b.id) }}">{{ b.titulo }}</a></td>
+        <td>{{ b.data_boletim.strftime('%d/%m/%Y') }}</td>
+        <td><span class="badge bg-{{ badge_for(b.ocr_status) }}">{{ b.ocr_status }}</span></td>
+        <td><a class="btn btn-sm btn-outline-secondary" href="{{ url_for('boletins_visualizar', id=b.id) }}">Visualizar</a></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <div class="alert alert-light border">Nenhum resultado.</div>
+  {% endif %}
 {% if pagination and pagination.pages > 1 %}
 <nav class="mt-3" aria-label="Paginação">
   <ul class="pagination">


### PR DESCRIPTION
### Motivation
- Harmonizar a exibição de resultados da busca de boletins com o padrão já usado na listagem principal, fornecendo colunas claras para ações e status.
- Tornar o status OCR visualmente consistente reaproveitando a mesma lógica de badges usada em `templates/boletins/listagem.html`.
- Facilitar acesso rápido ao item com um botão dedicado de visualização além do link no título.

### Description
- Substitui a lista simples por uma tabela em `templates/boletins/busca.html` com colunas `Título`, `Data`, `Status OCR` e `Ações`.
- Em `Status OCR` passa a ser renderizado o badge com `badge_for(b.ocr_status)` para manter a mesma aparência da listagem principal.
- Em `Ações` adiciona o botão `Visualizar` apontando para `url_for('boletins_visualizar', id=b.id)` e mantém o título como link opcional para visualização.
- Mantém a mensagem de estado sem resultados como `Nenhum resultado.` exibida em um bloco de alerta e preserva a paginação existente.

### Testing
- Executei `git diff -- templates/boletins/busca.html` para revisar o patch e o diff exibiu as alterações esperadas, com sucesso.
- Verifiquei o estado do repositório com `git status --short` e confirmei a modificação do arquivo, com sucesso.
- Commit da alteração foi realizado com `git commit -m "Atualiza resultado de busca de boletins para tabela com ações"` com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f251e8a738832eba43c5830b0047f8)