### PR TITLE
Refatora menu de Boletins para submenu colapsável

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -401,7 +401,7 @@
                         <div class="collapse {{ 'show' if boletins_active }}" id="collapseBoletins">
                             <ul class="nav flex-column ps-3">
                                 <li class="nav-item"><a class="nav-link {{ 'active' if current_endpoint == 'boletins_novo' else '' }}" href="{{ url_for('boletins_novo') }}"><i class="bi bi-plus-square me-2"></i> Cadastro de Boletins</a></li>
-                                <li class="nav-item"><a class="nav-link {{ 'active' if current_endpoint == 'boletins_buscar' else '' }}" href="{{ url_for('boletins_buscar') }}"><i class="bi bi-search me-2"></i> Pesquisa de Boletins</a></li>
+                                <li class="nav-item"><a class="nav-link {{ 'active' if current_endpoint == 'boletins_buscar' else '' }}" href="{{ url_for('boletins_buscar') }}"><i class="bi bi-search me-2"></i> Pesquisar boletins</a></li>
                             </ul>
                         </div>
                     </li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -388,19 +388,22 @@
                         'artigo',
                         'editar_artigo'
                     ] %}
-                    {% set boletins_active = current_endpoint in ['boletins_listar', 'boletins_buscar', 'boletins_visualizar', 'boletins_novo', 'boletins_editar'] %}
-                    {% if current_user.is_authenticated and (current_user.has_permissao('boletim_visualizar') or current_user.has_permissao('boletim_buscar')) %}
+                    {% set boletins_active = current_endpoint in ['boletins_listar', 'boletins_novo', 'boletins_buscar', 'boletins_visualizar', 'boletins_editar'] %}
+                    {% if current_user.is_authenticated and (current_user.has_permissao('boletim_visualizar') or current_user.has_permissao('boletim_buscar') or current_user.has_permissao('admin')) %}
                     <li class="nav-item">
-                        <a class="nav-link {{ 'active' if boletins_active else '' }}" href="{{ url_for('boletins_listar') }}">
-                            <i class="bi bi-journal-richtext me-2"></i> Boletins
+                        <a class="nav-link d-flex justify-content-between align-items-center {{ 'active' if boletins_active else '' }} {{ 'collapsed' if not boletins_active }}"
+                        data-bs-toggle="collapse" href="#collapseBoletins" role="button"
+                        aria-expanded="{{ 'true' if boletins_active else 'false' }}"
+                        aria-controls="collapseBoletins">
+                            <span><i class="bi bi-journal-richtext me-2"></i> Boletins</span>
+                            <i class="bi bi-chevron-down small"></i>
                         </a>
-                    </li>
-                    {% endif %}
-                    {% if current_user.is_authenticated and (current_user.has_permissao('boletim_buscar') or current_user.has_permissao('admin')) %}
-                    <li class="nav-item">
-                        <a class="nav-link {{ 'active' if current_endpoint == 'boletins_buscar' else '' }}" href="{{ url_for('boletins_buscar') }}">
-                            <i class="bi bi-search me-2"></i> Pesquisar boletins
-                        </a>
+                        <div class="collapse {{ 'show' if boletins_active }}" id="collapseBoletins">
+                            <ul class="nav flex-column ps-3">
+                                <li class="nav-item"><a class="nav-link {{ 'active' if current_endpoint == 'boletins_novo' else '' }}" href="{{ url_for('boletins_novo') }}"><i class="bi bi-plus-square me-2"></i> Cadastro de Boletins</a></li>
+                                <li class="nav-item"><a class="nav-link {{ 'active' if current_endpoint == 'boletins_buscar' else '' }}" href="{{ url_for('boletins_buscar') }}"><i class="bi bi-search me-2"></i> Pesquisa de Boletins</a></li>
+                            </ul>
+                        </div>
                     </li>
                     {% endif %}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -401,7 +401,9 @@
                         <div class="collapse {{ 'show' if boletins_active }}" id="collapseBoletins">
                             <ul class="nav flex-column ps-3">
                                 <li class="nav-item"><a class="nav-link {{ 'active' if current_endpoint == 'boletins_novo' else '' }}" href="{{ url_for('boletins_novo') }}"><i class="bi bi-plus-square me-2"></i> Cadastro de Boletins</a></li>
+                                {% if current_user.has_permissao('boletim_buscar') or current_user.has_permissao('admin') %}
                                 <li class="nav-item"><a class="nav-link {{ 'active' if current_endpoint == 'boletins_buscar' else '' }}" href="{{ url_for('boletins_buscar') }}"><i class="bi bi-search me-2"></i> Pesquisar boletins</a></li>
+                                {% endif %}
                             </ul>
                         </div>
                     </li>


### PR DESCRIPTION
### Motivation
- Unificar o comportamento do menu de Boletins com os blocos existentes de "Biblioteca"/"Administração" e evitar duplicidade de links.
- Garantir que o grupo Boletins apresente estado visual correto (`active`, `collapsed`, `show`) conforme o endpoint atual.

### Description
- Adiciona a variável de estado `boletins_active` para os endpoints `boletins_listar`, `boletins_novo`, `boletins_buscar`, `boletins_visualizar` e `boletins_editar`.
- Substitui os links avulsos por um item pai colapsável com `data-bs-toggle="collapse"` e `id="collapseBoletins"` seguindo o padrão já usado em outros blocos.
- Inclui dois subitens dentro do collapse: `Cadastro de Boletins` apontando para `url_for('boletins_novo')` e `Pesquisa de Boletins` apontando para `url_for('boletins_buscar')`.
- Ajusta condições de permissão e as classes `active`, `collapsed` e `show` para refletir corretamente o endpoint atual e remove o link avulso duplicado de pesquisa.

### Testing
- Nenhum teste automatizado foi executado para esta mudança de template Jinja2.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f269a5a6c8832e88035a009961ef49)