### PR TITLE
Ajusta visual do cadastro de boletins para padrão de artigos

### DIFF
--- a/templates/boletins/novo.html
+++ b/templates/boletins/novo.html
@@ -1,12 +1,60 @@
 {% extends 'base.html' %}
+
+{% block title %}{{ 'Editar Boletim' if modo_edicao else 'Novo Boletim' }}{% endblock %}
+
 {% block content %}
-<div class="container mt-4">
-  <h1>{{ 'Editar boletim' if modo_edicao else 'Novo boletim' }}</h1>
-  <form method="post" enctype="multipart/form-data">
-    <div class="mb-3"><label>Título</label><input class="form-control" name="titulo" value="{{ boletim.titulo if boletim else '' }}" required></div>
-    <div class="mb-3"><label>Data</label><input type="date" class="form-control" name="data_boletim" value="{{ boletim.data_boletim.strftime('%Y-%m-%d') if boletim else '' }}" required></div>
-    {% if not modo_edicao %}<div class="mb-3"><label>PDF</label><input type="file" name="arquivo" accept="application/pdf" class="form-control" required></div>{% endif %}
-    <button class="btn btn-primary" type="submit">Salvar</button>
-  </form>
+<div class="container-fluid page-root">
+  <div class="row">
+    <div class="col-md-10 mx-auto">
+      <div class="card shadow-sm">
+        <div class="card-body">
+          <h3 class="mb-4">{{ 'Editar Boletim' if modo_edicao else 'Criar Novo Boletim' }}</h3>
+          <form method="post" enctype="multipart/form-data">
+            <div class="mb-3">
+              <label for="titulo" class="form-label">Título</label>
+              <input
+                type="text"
+                class="form-control"
+                id="titulo"
+                name="titulo"
+                value="{{ boletim.titulo if boletim else '' }}"
+                required
+              >
+            </div>
+
+            <div class="mb-3">
+              <label for="data_boletim" class="form-label">Data</label>
+              <input
+                type="date"
+                class="form-control"
+                id="data_boletim"
+                name="data_boletim"
+                value="{{ boletim.data_boletim.strftime('%Y-%m-%d') if boletim else '' }}"
+                required
+              >
+            </div>
+
+            {% if not modo_edicao %}
+            <div class="mb-3">
+              <label for="arquivo" class="form-label">PDF</label>
+              <input
+                type="file"
+                class="form-control"
+                id="arquivo"
+                name="arquivo"
+                accept="application/pdf"
+                required
+              >
+            </div>
+            {% endif %}
+
+            <div class="d-flex justify-content-end mt-4">
+              <button class="btn btn-primary" type="submit">{{ 'Salvar Alterações' if modo_edicao else 'Salvar Boletim' }}</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Tornar o formulário de criação/edição de boletins visualmente consistente com o padrão usado em `templates/artigos/novo_artigo.html` para melhorar a experiência do usuário.
- Uniformizar hierarquia de títulos, espaçamentos e controles de formulário entre telas similares.
- Garantir que o template de cadastro seja exclusivo para criação/edição e não contenha listagens embutidas.

### Description
- Atualiza `templates/boletins/novo.html` para usar `container-fluid page-root`, grid centralizada (`row` + `col-md-10 mx-auto`) e `card shadow-sm` com `card-body` como container principal do formulário.
- Padroniza campos do formulário com `form-label`, atributos `id`/`name` e blocos `mb-3`, e adiciona `h3` com espaçamento (`mb-4`) para título da página.
- Mantém o upload de PDF apenas no modo de criação (`{% if not modo_edicao %}`) e altera o botão para alinhamento à direita com texto condicional para novo/edição.
- Adiciona `block title` para o template e remove qualquer estrutura compacta anterior, garantindo ausência de listagem embutida no template de cadastro.

### Testing
- Executado `git diff -- templates/boletins/novo.html` para validar as alterações no arquivo e a saída foi obtida com sucesso.
- Executado `nl -ba templates/boletins/novo.html` para inspeção numerada do arquivo modificado e a saída foi obtida com sucesso.
- Executado `git commit -m "Ajusta layout do formulário de boletim ao padrão de artigo"` para registrar a alteração e o commit foi criado com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26cc773b0832e99ad3251d657327c)