### PR TITLE
Reestrutura visualização de boletim com cartão e miniatura PDF (PDF.js)

### DIFF
--- a/templates/boletins/visualizar.html
+++ b/templates/boletins/visualizar.html
@@ -1,14 +1,139 @@
 {% extends 'base.html' %}
+{% block title %}{{ boletim.titulo }}{% endblock %}
+
 {% block content %}
-<div class="container mt-4">
-  <h1>{{ boletim.titulo }}</h1>
-  <p><strong>Data:</strong> {{ boletim.data_boletim.strftime('%d/%m/%Y') }}</p>
-  <p><strong>Status OCR:</strong> {{ boletim.ocr_status }}</p>
-  <p><a class="btn btn-outline-secondary" href="{{ url_for('uploaded_file', filename=boletim.arquivo) }}" target="_blank">Abrir PDF</a></p>
-  {% if can_manage %}
-  <a class="btn btn-primary" href="{{ url_for('boletins_editar', id=boletim.id) }}">Editar</a>
-  <form method="post" class="d-inline" action="{{ url_for('boletins_reprocessar_ocr', id=boletim.id) }}"><button class="btn btn-warning">Reprocessar OCR</button></form>
-  <form method="post" class="d-inline" action="{{ url_for('boletins_excluir', id=boletim.id) }}" onsubmit="return confirm('Excluir boletim?');"><button class="btn btn-danger">Excluir</button></form>
-  {% endif %}
+{% set ocr_status_map = {
+  'nao_aplicavel': {'label': 'Não aplicável', 'class': 'bg-secondary'},
+  'pendente': {'label': 'Pendente', 'class': 'bg-warning text-dark'},
+  'processando': {'label': 'Processando', 'class': 'bg-info text-dark'},
+  'concluido': {'label': 'Concluído', 'class': 'bg-success'},
+  'erro': {'label': 'Erro', 'class': 'bg-danger'},
+  'baixo_aproveitamento': {'label': 'Baixo aproveitamento', 'class': 'bg-warning text-dark'}
+} %}
+{% set status_info = ocr_status_map.get((boletim.ocr_status or '')|lower, {'label': boletim.ocr_status or 'Não informado', 'class': 'bg-secondary'}) %}
+{% set pdf_url = url_for('uploaded_file', filename=boletim.arquivo) %}
+
+<div class="container-fluid page-root mt-4">
+  <div class="row">
+    <div class="col-md-10 mx-auto">
+      <div class="card shadow-sm">
+        <div class="card-body">
+          <div class="d-flex justify-content-between align-items-start flex-wrap gap-2">
+            <div>
+              <h3 class="mb-1">{{ boletim.titulo }}</h3>
+              <p class="text-muted mb-0">
+                <strong>Data do boletim:</strong> {{ boletim.data_boletim.strftime('%d/%m/%Y') }}
+                <strong class="ms-2">Criado em:</strong> {{ boletim.created_at.strftime('%d/%m/%Y %H:%M') if boletim.created_at else '—' }}
+              </p>
+            </div>
+            <span class="badge {{ status_info.class }} fs-6">OCR: {{ status_info.label }}</span>
+          </div>
+
+          <hr>
+
+          <div class="row g-4">
+            <div class="col-12 col-lg-4">
+              <div class="border rounded p-3 bg-light h-100">
+                <h5 class="mb-3">Capa do PDF</h5>
+                <div id="boletim-pdf-thumbnail" class="d-flex align-items-center justify-content-center border rounded bg-white" style="min-height: 260px;">
+                  <div id="boletim-pdf-placeholder" class="text-center text-muted px-3">
+                    <i class="bi bi-file-earmark-pdf fs-1 d-block mb-2" aria-hidden="true"></i>
+                    <span>Miniatura indisponível.</span>
+                  </div>
+                </div>
+                <div class="mt-3 d-flex flex-wrap gap-2">
+                  <a class="btn btn-outline-secondary btn-sm" href="{{ pdf_url }}" target="_blank" rel="noopener">
+                    Abrir PDF
+                  </a>
+                  <a class="btn btn-outline-primary btn-sm" href="{{ pdf_url }}" download>
+                    Download
+                  </a>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-12 col-lg-8">
+              <h5>Texto OCR</h5>
+              <div class="border rounded bg-light p-3" style="max-height: 380px; overflow-y: auto; white-space: pre-wrap;">
+                {% if boletim.ocr_text and boletim.ocr_text.strip() %}
+                {{ boletim.ocr_text }}
+                {% else %}
+                <span class="text-muted">Sem conteúdo OCR disponível para este boletim.</span>
+                {% endif %}
+              </div>
+
+              <h6 class="mt-4">Metadados de processamento</h6>
+              <div class="row row-cols-1 row-cols-md-2 g-2 small">
+                <div><strong>Caracteres OCR:</strong> {{ boletim.ocr_char_count if boletim.ocr_char_count is not none else '—' }}</div>
+                <div><strong>Páginas OCR:</strong> {{ boletim.ocr_page_count if boletim.ocr_page_count is not none else '—' }}</div>
+                <div><strong>Páginas com sucesso:</strong> {{ boletim.ocr_pages_success if boletim.ocr_pages_success is not none else '—' }}</div>
+                <div><strong>Páginas com falha:</strong> {{ boletim.ocr_pages_failed if boletim.ocr_pages_failed is not none else '—' }}</div>
+                <div><strong>Tentativas OCR:</strong> {{ boletim.ocr_attempts if boletim.ocr_attempts is not none else '—' }}</div>
+                <div><strong>Motor OCR:</strong> {{ boletim.ocr_engine or '—' }}</div>
+                <div><strong>Confiabilidade:</strong> {{ ('%.2f'|format(boletim.ocr_confidence_score)) if boletim.ocr_confidence_score is not none else '—' }}</div>
+                <div><strong>Tempo de processamento (s):</strong> {{ ('%.2f'|format(boletim.ocr_processing_time_seconds)) if boletim.ocr_processing_time_seconds is not none else '—' }}</div>
+                <div><strong>Último processamento:</strong> {{ boletim.ocr_processed_at.strftime('%d/%m/%Y %H:%M') if boletim.ocr_processed_at else '—' }}</div>
+                <div><strong>Último erro:</strong> {{ boletim.ocr_last_error or boletim.ocr_error_message or '—' }}</div>
+              </div>
+            </div>
+          </div>
+
+          {% if can_manage %}
+          <hr>
+          <div class="d-flex flex-wrap gap-2">
+            <a class="btn btn-primary" href="{{ url_for('boletins_editar', id=boletim.id) }}">Editar</a>
+            <form method="post" class="d-inline" action="{{ url_for('boletins_reprocessar_ocr', id=boletim.id) }}">
+              <button class="btn btn-warning" type="submit">Reprocessar OCR</button>
+            </form>
+            <form method="post" class="d-inline" action="{{ url_for('boletins_excluir', id=boletim.id) }}" onsubmit="return confirm('Excluir boletim?');">
+              <button class="btn btn-danger" type="submit">Excluir</button>
+            </form>
+          </div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.4.168/pdf.min.mjs" type="module"></script>
+<script type="module">
+  const thumbnailContainer = document.getElementById('boletim-pdf-thumbnail');
+  const placeholder = document.getElementById('boletim-pdf-placeholder');
+  const pdfUrl = {{ pdf_url | tojson }};
+
+  async function renderPdfThumbnail() {
+    try {
+      const pdfjsLib = await import('https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.4.168/pdf.min.mjs');
+      pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.4.168/pdf.worker.min.mjs';
+
+      const loadingTask = pdfjsLib.getDocument({ url: pdfUrl });
+      const pdf = await loadingTask.promise;
+      const page = await pdf.getPage(1);
+
+      const viewport = page.getViewport({ scale: 1 });
+      const targetWidth = 220;
+      const scale = targetWidth / viewport.width;
+      const scaledViewport = page.getViewport({ scale });
+
+      const canvas = document.createElement('canvas');
+      canvas.className = 'img-fluid rounded shadow-sm';
+      canvas.width = Math.ceil(scaledViewport.width);
+      canvas.height = Math.ceil(scaledViewport.height);
+
+      const context = canvas.getContext('2d', { alpha: false });
+      await page.render({ canvasContext: context, viewport: scaledViewport }).promise;
+
+      placeholder?.remove();
+      thumbnailContainer.appendChild(canvas);
+    } catch (error) {
+      console.error('Falha ao gerar miniatura do PDF:', error);
+      if (placeholder) {
+        placeholder.innerHTML = '<i class="bi bi-exclamation-triangle fs-1 d-block mb-2" aria-hidden="true"></i><span>Não foi possível renderizar a miniatura deste PDF.</span>';
+      }
+    }
+  }
+
+  renderPdfThumbnail();
+</script>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Tornar a tela de visualização de boletim consistente com a exibição de artigo e oferecer preview da capa do PDF para facilitar verificação rápida do documento.

### Description
- Reestruturei `templates/boletins/visualizar.html` para usar container + card principal, adicionando `block title` e cabeçalho com título, data e badge de status OCR.
- Substituí o layout simples por duas colunas: área de miniatura da capa do PDF (coluna lateral) e área principal com texto OCR em um bloco com borda, fundo leve e rolagem, além de metadados de processamento exibidos em grid.
- Implementei renderização client-side da primeira página do PDF usando PDF.js e canvas, com fallback visual (placeholder) e tratamento de erro quando o PDF não puder ser renderizado; adicionei links para abrir e baixar o PDF original.
- Mantive as ações de gestão (Editar / Reprocessar OCR / Excluir) somente quando `can_manage` for verdadeiro e preservei exibição de campos OCR existentes (contagens, engine, tempo, erro, etc.).

### Testing
- Nenhum teste automatizado foi executado durante esta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26ed66080832e9308b04f1004bf39)