### PR TITLE
Adicionar seção de permissões de boletim em cargos

### DIFF
--- a/templates/admin/cargos.html
+++ b/templates/admin/cargos.html
@@ -284,6 +284,17 @@
                         </div>
                     </div>
                     <div class="card mb-3">
+                        <div class="card-header"><h6 class="mb-0">Permissões de Boletim</h6></div>
+                        <div class="card-body">
+                            {% for f in funcoes if f.codigo in ['boletim_visualizar', 'boletim_buscar', 'boletim_gerenciar'] %}
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" id="c_funcao{{ f.id }}" name="funcao_ids" value="{{ f.id }}" {% if f.id|string in request.form.getlist('funcao_ids') %}checked{% endif %}>
+                                    <label class="form-check-label" for="c_funcao{{ f.id }}">{{ f.nome }}</label>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="card mb-3">
                         <div class="card-header"><h6 class="mb-0">Permissões Globais</h6></div>
                         <div class="card-body">
                             {% for f in funcoes if f.codigo == 'admin' %}
@@ -436,6 +447,17 @@
                                         <label class="form-check-label" for="e_funcao{{ f.id }}">{{ f.nome }}</label>
                                     </div>
                                 {% endfor %}
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="card mb-3">
+                        <div class="card-header"><h6 class="mb-0">Permissões de Boletim</h6></div>
+                        <div class="card-body">
+                            {% for f in funcoes if f.codigo in ['boletim_visualizar', 'boletim_buscar', 'boletim_gerenciar'] %}
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" id="e_funcao{{ f.id }}" name="funcao_ids" value="{{ f.id }}" {% if (request.form.getlist('funcao_ids') and f.id|string in request.form.getlist('funcao_ids')) or (not request.form.getlist('funcao_ids') and (f in cargo_editar.permissoes.all())) %}checked{% endif %}>
+                                    <label class="form-check-label" for="e_funcao{{ f.id }}">{{ f.nome }}</label>
+                                </div>
                             {% endfor %}
                         </div>
                     </div>


### PR DESCRIPTION
### Motivation
- Incluir controles de permissão de boletim no formulário de criação e no modal de edição de cargos porque atualmente apenas permissões de artigos e globais estavam expostas.
- Manter consistência com o padrão existente de marcação e comportamento de `checked` para que essas funções possam ser atribuídas da mesma forma que outras permissões.

### Description
- Adicionado um novo card `Permissões de Boletim` imediatamente abaixo de `Permissões de Artigos` no formulário de cadastro com checkboxes para funções com os códigos `boletim_visualizar`, `boletim_buscar` e `boletim_gerenciar` e `name="funcao_ids"` (arquivo `templates/admin/cargos.html`).
- Inserida a mesma seção no modal de edição de cargo, com `id` prefixado por `e_` e lógica de `checked` que respeita `request.form.getlist('funcao_ids')` ou, em ausência de `request.form`, as permissões atuais vindas de `cargo_editar.permissoes.all()`.
- As novas entradas seguem exatamente o mesmo padrão de marcação já usado para outras permissões (mesma estrutura `for f in funcoes if f.codigo in [...]`, wrappers `.card`, `.card-body` e classes `form-check`).

### Testing
- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a48fa280832e8b7b425d6fb8fb23)