### PR TITLE
Padroniza busca de boletins e adiciona feedback de hover clicável

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -704,6 +704,15 @@
   padding: 0 2px;
   border-radius: 3px;
 }
+
+.clickable-card {
+  cursor: pointer;
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.clickable-card:hover {
+  box-shadow: 0 0.2rem 0.6rem rgba(0, 0, 0, 0.12);
+}
 /* Form builder styles */
 #fieldsContainer .field.card {
   border: 1px solid var(--border-light);

--- a/templates/boletins/busca.html
+++ b/templates/boletins/busca.html
@@ -1,18 +1,28 @@
 {% extends 'base.html' %}
 {% block content %}
-<div class="container mt-4">
-  <h1>Buscar boletins</h1>
-  <form method="get" class="mb-3">
-    <input class="form-control" type="text" name="q" placeholder="Título ou texto OCR" value="{{ termo or '' }}">
-    <div class="mt-2 d-flex gap-2 align-items-center">
-      <label for="per_page" class="form-label mb-0">Por página:</label>
-      <select id="per_page" name="per_page" class="form-select w-auto" onchange="this.form.submit()">
+<div class="container-fluid page-root">
+  <div class="row">
+    <div class="col-md-10 mx-auto">
+      <div class="card shadow-sm mb-4">
+        <div class="card-body">
+          <h1 class="h2 mb-3">Buscar boletins</h1>
+          <form method="get" class="row g-2 align-items-end">
+            <div class="col-md-10">
+              <input class="form-control" type="text" name="q" placeholder="Título ou texto OCR" value="{{ termo or '' }}">
+            </div>
+            <div class="col-md-2">
+              <label for="per_page" class="form-label mb-1">Por página:</label>
+              <select id="per_page" name="per_page" class="form-select" onchange="this.form.submit()">
         {% for option in [10, 20, 50, 100] %}
           <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
         {% endfor %}
       </select>
+            </div>
+          </form>
+        </div>
+      </div>
     </div>
-  </form>
+  </div>
 
   {% if boletins %}
   <div class="row row-cols-1 g-3">
@@ -62,5 +72,7 @@
   </ul>
 </nav>
 {% endif %}
+    </div>
+  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- A página de busca de boletins estava visualmente diferente da pesquisa de artigos e não mostrava feedback de interatividade (cursor não mudava ao passar sobre os cards). 
- Objetivo é tornar a busca de boletins consistente com a pesquisa de artigos e sinalizar que cada card é clicável.

### Description
- Atualiza `templates/boletins/busca.html` para usar a mesma estrutura centralizada em card (`container-fluid page-root`, card com `shadow-sm`) e organiza o formulário em grid responsivo. 
- Mantém a listagem de boletins com o `data-href` existente e os controles de gestão (Editar, Reprocessar OCR, Excluir) intactos. 
- Adiciona estilos em `static/css/custom.css` para `.clickable-card` com `cursor: pointer` e efeito de hover (`box-shadow` e transição) para fornecer feedback visual de clique. 
- Não foram necessárias alterações no JavaScript porque o script global já vincula `.clickable-card` para navegação via `data-href`.

### Testing
- Executado `pytest -q tests/test_boletins_busca.py`, com resultado: `5 passed, 22 warnings`.
- Os testes específicos de busca de boletins passaram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a57826f8832eab0e52cb0d2ce137)