### PR TITLE
Agrupa permissões por categoria no admin de usuários

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -91,6 +91,7 @@ except ImportError:  # pragma: no cover
     )
 
 import json
+from collections import OrderedDict
 from datetime import datetime, timezone, timedelta
 from zoneinfo import ZoneInfo
 from werkzeug.utils import secure_filename
@@ -101,6 +102,30 @@ import os
 admin_bp = Blueprint('admin_bp', __name__)
 
 
+
+
+def _categoria_permissao_por_codigo(codigo: str) -> str:
+    codigo_normalizado = (codigo or '').lower()
+    if codigo_normalizado.startswith('artigo_'):
+        return 'Permissões de Artigos'
+    if codigo_normalizado.startswith('boletim_'):
+        return 'Permissões de Boletins'
+    if codigo_normalizado.startswith('admin'):
+        return 'Permissões Administrativas'
+    return 'Outras Permissões'
+
+
+def _agrupar_funcoes_por_categoria(funcoes):
+    categorias_ordenadas = OrderedDict((categoria, []) for categoria in (
+        'Permissões de Artigos',
+        'Permissões de Boletins',
+        'Permissões Administrativas',
+        'Outras Permissões',
+    ))
+    for funcao in funcoes:
+        categoria = _categoria_permissao_por_codigo(funcao.codigo)
+        categorias_ordenadas[categoria].append(funcao)
+    return categorias_ordenadas
 def _can_manage_taxonomy(user, permission_code: str) -> bool:
     return bool(user and (user.has_permissao('admin') or user.has_permissao(permission_code)))
 
@@ -1007,6 +1032,7 @@ def admin_usuarios():
     cargos = Cargo.query.order_by(Cargo.nome).all()
     celulas = Celula.query.order_by(Celula.nome).all()
     funcoes = Funcao.query.order_by(Funcao.nome).all()
+    funcoes_por_categoria = _agrupar_funcoes_por_categoria(funcoes)
     cargo_defaults = {
         c.id: {
             'estabelecimentos': [e.id for e in c.default_estabelecimentos],
@@ -1026,6 +1052,7 @@ def admin_usuarios():
         cargos=cargos,
         celulas=celulas,
         funcoes=funcoes,
+        funcoes_por_categoria=funcoes_por_categoria,
         cargo_defaults=json.dumps(cargo_defaults),
         admin_funcao_id=admin_funcao.id if admin_funcao else None,
         manter_aba_cadastro=manter_aba_cadastro,

--- a/templates/admin/usuarios.html
+++ b/templates/admin/usuarios.html
@@ -214,11 +214,16 @@
                         <div class="card-header"><h6 class="mb-0">Permissões (Funções)</h6></div>
                         <div class="card-body">
                             <p class="text-muted mb-2">Permissões herdadas do cargo já vêm marcadas e não podem ser desmarcadas.</p>
-                            {% for f in funcoes %}
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="func{{ f.id }}" name="funcao_ids" value="{{ f.id }}" {% if f.id|string in request.form.getlist('funcao_ids') %}checked{% endif %}>
-                                    <label class="form-check-label" for="func{{ f.id }}">{{ f.nome }}</label>
-                                </div>
+                            {% for categoria, funcoes_categoria in funcoes_por_categoria.items() %}
+                                {% if funcoes_categoria %}
+                                    <h6 class="mt-3 mb-2">{{ categoria }}</h6>
+                                    {% for f in funcoes_categoria %}
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="checkbox" id="func{{ f.id }}" name="funcao_ids" value="{{ f.id }}" {% if f.id|string in request.form.getlist('funcao_ids') %}checked{% endif %}>
+                                            <label class="form-check-label" for="func{{ f.id }}">{{ f.nome }}</label>
+                                        </div>
+                                    {% endfor %}
+                                {% endif %}
                             {% endfor %}
                         </div>
                     </div>
@@ -404,11 +409,16 @@
                         <div class="card-header"><h6 class="mb-0">Permissões (Funções)</h6></div>
                         <div class="card-body">
                             <p class="text-muted mb-2">Permissões herdadas do cargo já vêm marcadas e não podem ser desmarcadas.</p>
-                            {% for f in funcoes %}
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="edit_func{{ f.id }}" name="funcao_ids" value="{{ f.id }}" {% if (request.form.getlist('funcao_ids') and f.id|string in request.form.getlist('funcao_ids')) or (not request.form.getlist('funcao_ids') and (f in user_editar.permissoes_personalizadas.all() or (user_editar.cargo and f in user_editar.cargo.permissoes.all()))) %}checked{% endif %} {% if user_editar.cargo and f in user_editar.cargo.permissoes.all() %}disabled{% endif %}>
-                                    <label class="form-check-label" for="edit_func{{ f.id }}">{{ f.nome }}</label>
-                                </div>
+                            {% for categoria, funcoes_categoria in funcoes_por_categoria.items() %}
+                                {% if funcoes_categoria %}
+                                    <h6 class="mt-3 mb-2">{{ categoria }}</h6>
+                                    {% for f in funcoes_categoria %}
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="checkbox" id="edit_func{{ f.id }}" name="funcao_ids" value="{{ f.id }}" {% if (request.form.getlist('funcao_ids') and f.id|string in request.form.getlist('funcao_ids')) or (not request.form.getlist('funcao_ids') and (f in user_editar.permissoes_personalizadas.all() or (user_editar.cargo and f in user_editar.cargo.permissoes.all()))) %}checked{% endif %} {% if user_editar.cargo and f in user_editar.cargo.permissoes.all() %}disabled{% endif %}>
+                                            <label class="form-check-label" for="edit_func{{ f.id }}">{{ f.nome }}</label>
+                                        </div>
+                                    {% endfor %}
+                                {% endif %}
                             {% endfor %}
                         </div>
                     </div>


### PR DESCRIPTION
### Motivation
- Melhorar a usabilidade do formulário de permissões agrupando as funções por categorias em vez de uma lista única.
- Garantir que novas permissões sem regra explícita sejam exibidas sem quebra em um grupo de fallback.

### Description
- Adiciona em `blueprints/admin.py` as funções `_categoria_permissao_por_codigo` e `_agrupar_funcoes_por_categoria` para categorizar `Funcao` por `codigo` e monta `funcoes_por_categoria` ordenado.
- `admin_usuarios` agora popula e envia `funcoes_por_categoria` ao template junto com os dados já existentes.
- Atualiza `templates/admin/usuarios.html` nos blocos de criação e edição para iterar por `funcoes_por_categoria` e renderizar os checkboxes por categoria, mantendo submissão por `funcao_ids` e a lógica de marcação/desabilitação para permissões herdadas.
- Define as categorias mínimas: `Permissões de Artigos`, `Permissões de Boletins`, `Permissões Administrativas` e `Outras Permissões` (fallback automático).

### Testing
- Executado `python -m py_compile blueprints/admin.py` que retornou sucesso.
- Nenhum teste automatizado adicional foi adicionado nesta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a5c7ea84832e91aa105060688188)