### PR TITLE
Ajusta layout da busca de boletins para alinhar com artigos

### DIFF
--- a/templates/boletins/busca.html
+++ b/templates/boletins/busca.html
@@ -13,65 +13,67 @@
             <div class="col-md-2">
               <label for="per_page" class="form-label mb-1">Por página:</label>
               <select id="per_page" name="per_page" class="form-select" onchange="this.form.submit()">
-        {% for option in [10, 20, 50, 100] %}
-          <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
-        {% endfor %}
-      </select>
+                {% for option in [10, 20, 50, 100] %}
+                  <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+              </select>
             </div>
           </form>
         </div>
       </div>
-    </div>
-  </div>
 
-  {% if boletins %}
-  <div class="row row-cols-1 g-3">
-    {% for b in boletins %}
-    <div class="col">
-      <div class="card clickable-card h-100" data-href="{{ url_for('boletins_visualizar', id=b.id) }}" role="link" tabindex="0" aria-label="Abrir boletim {{ b.titulo }}">
-        <div class="card-body d-flex flex-column gap-3">
-          <div class="d-flex flex-wrap justify-content-between gap-2">
-            <h2 class="h5 mb-0">{{ b.titulo }}</h2>
-            <span class="badge bg-{{ badge_for(b.ocr_status) }} align-self-start">{{ b.ocr_status }}</span>
-          </div>
+      {% if boletins %}
+      <div class="card shadow-sm mb-4 aprovacao-list">
+        <div class="card-body">
+          <div class="row row-cols-1 g-3">
+            {% for b in boletins %}
+            <div class="col">
+              <div class="card clickable-card h-100" data-href="{{ url_for('boletins_visualizar', id=b.id) }}" role="link" tabindex="0" aria-label="Abrir boletim {{ b.titulo }}">
+                <div class="card-body d-flex flex-column gap-3">
+                  <div class="d-flex flex-wrap justify-content-between gap-2">
+                    <h2 class="h5 mb-0">{{ b.titulo }}</h2>
+                    <span class="badge bg-{{ badge_for(b.ocr_status) }} align-self-start">{{ b.ocr_status }}</span>
+                  </div>
 
-          <div class="text-body-secondary small">
-            <strong>Data do boletim:</strong> {{ b.data_boletim.strftime('%d/%m/%Y') }}
-          </div>
+                  <div class="text-body-secondary small">
+                    <strong>Data do boletim:</strong> {{ b.data_boletim.strftime('%d/%m/%Y') }}
+                  </div>
 
-          {% if can_manage %}
-          <div class="d-flex flex-wrap gap-2 mt-auto">
-            <a class="btn btn-sm btn-outline-primary" href="{{ url_for('boletins_editar', id=b.id) }}">Editar</a>
-            <form class="d-inline" method="post" action="{{ url_for('boletins_reprocessar_ocr', id=b.id) }}">
-              <button class="btn btn-sm btn-outline-warning" type="submit">Reprocessar OCR</button>
-            </form>
-            <form class="d-inline" method="post" action="{{ url_for('boletins_excluir', id=b.id) }}" onsubmit="return confirm('Excluir boletim?');">
-              <button class="btn btn-sm btn-outline-danger" type="submit">Excluir</button>
-            </form>
+                  {% if can_manage %}
+                  <div class="d-flex flex-wrap gap-2 mt-auto">
+                    <a class="btn btn-sm btn-outline-primary" href="{{ url_for('boletins_editar', id=b.id) }}">Editar</a>
+                    <form class="d-inline" method="post" action="{{ url_for('boletins_reprocessar_ocr', id=b.id) }}">
+                      <button class="btn btn-sm btn-outline-warning" type="submit">Reprocessar OCR</button>
+                    </form>
+                    <form class="d-inline" method="post" action="{{ url_for('boletins_excluir', id=b.id) }}" onsubmit="return confirm('Excluir boletim?');">
+                      <button class="btn btn-sm btn-outline-danger" type="submit">Excluir</button>
+                    </form>
+                  </div>
+                  {% endif %}
+                </div>
+              </div>
+            </div>
+            {% endfor %}
           </div>
-          {% endif %}
         </div>
       </div>
-    </div>
-    {% endfor %}
-  </div>
-  {% else %}
-  <div class="alert alert-light border">Nenhum resultado.</div>
-  {% endif %}
+      {% else %}
+      <div class="alert alert-light border">Nenhum resultado.</div>
+      {% endif %}
 
-{% if pagination and pagination.pages > 1 %}
-<nav class="mt-3" aria-label="Paginação">
-  <ul class="pagination">
-    <li class="page-item {% if not pagination.has_prev %}disabled{% endif %}">
-      <a class="page-link" href="{{ url_for('boletins_buscar', q=termo, per_page=per_page, page=pagination.prev_num) }}">Anterior</a>
-    </li>
-    <li class="page-item disabled"><span class="page-link">Página {{ pagination.page }} de {{ pagination.pages }}</span></li>
-    <li class="page-item {% if not pagination.has_next %}disabled{% endif %}">
-      <a class="page-link" href="{{ url_for('boletins_buscar', q=termo, per_page=per_page, page=pagination.next_num) }}">Próxima</a>
-    </li>
-  </ul>
-</nav>
-{% endif %}
+      {% if pagination and pagination.pages > 1 %}
+      <nav class="mt-3" aria-label="Paginação">
+        <ul class="pagination">
+          <li class="page-item {% if not pagination.has_prev %}disabled{% endif %}">
+            <a class="page-link" href="{{ url_for('boletins_buscar', q=termo, per_page=per_page, page=pagination.prev_num) }}">Anterior</a>
+          </li>
+          <li class="page-item disabled"><span class="page-link">Página {{ pagination.page }} de {{ pagination.pages }}</span></li>
+          <li class="page-item {% if not pagination.has_next %}disabled{% endif %}">
+            <a class="page-link" href="{{ url_for('boletins_buscar', q=termo, per_page=per_page, page=pagination.next_num) }}">Próxima</a>
+          </li>
+        </ul>
+      </nav>
+      {% endif %}
     </div>
   </div>
 </div>


### PR DESCRIPTION
### Motivation
- Tornar a listagem de boletins visualmente consistente com a listagem de artigos usada em `templates/artigos/pesquisar.html` ao aplicar o mesmo contêiner e estilo.
- Centralizar e limitar a largura da área de resultados para alinhar com o bloco de filtros e o restante do layout da página.

### Description
- Atualiza `templates/boletins/busca.html` para envolver a listagem de resultados em `<div class="card shadow-sm mb-4 aprovacao-list">` com `card-body`, seguindo o mesmo padrão usado em pesquisas de artigos.
- Move a estrutura de resultados para dentro do `col-md-10 mx-auto` já usado pelo formulário de busca, preservando os `card` individuais dos boletins e os botões de ação (`Editar`, `Reprocessar OCR`, `Excluir`).
- Mantém a paginação e a mensagem de "Nenhum resultado" sem alterações funcionais, apenas reorganizando a marcação para consistência visual.

### Testing
- Executado `pytest -q tests/test_boletins_busca.py` e todos os testes passaram com sucesso (`5 passed`).
- Foram observados avisos de `LegacyAPIWarning` do SQLAlchemy, sem impacto nos testes de interface.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a93f8534832e9e4a0be0ffee131e)