### PR TITLE
Restringe opções de boletins na navbar por permissão

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -389,7 +389,7 @@
                         'editar_artigo'
                     ] %}
                     {% set boletins_active = current_endpoint in ['boletins_listar', 'boletins_novo', 'boletins_buscar', 'boletins_visualizar', 'boletins_editar'] %}
-                    {% if current_user.is_authenticated and (current_user.has_permissao('boletim_visualizar') or current_user.has_permissao('boletim_buscar') or current_user.has_permissao('admin')) %}
+                    {% if current_user.is_authenticated and (current_user.has_permissao('boletim_visualizar') or current_user.has_permissao('boletim_buscar') or current_user.has_permissao('boletim_gerenciar') or current_user.has_permissao('admin')) %}
                     <li class="nav-item">
                         <a class="nav-link d-flex justify-content-between align-items-center {{ 'active' if boletins_active else '' }} {{ 'collapsed' if not boletins_active }}"
                         data-bs-toggle="collapse" href="#collapseBoletins" role="button"
@@ -400,7 +400,9 @@
                         </a>
                         <div class="collapse {{ 'show' if boletins_active }}" id="collapseBoletins">
                             <ul class="nav flex-column ps-3">
+                                {% if current_user.has_permissao('boletim_gerenciar') or current_user.has_permissao('admin') %}
                                 <li class="nav-item"><a class="nav-link {{ 'active' if current_endpoint == 'boletins_novo' else '' }}" href="{{ url_for('boletins_novo') }}"><i class="bi bi-plus-square me-2"></i> Cadastro de Boletins</a></li>
+                                {% endif %}
                                 {% if current_user.has_permissao('boletim_buscar') or current_user.has_permissao('admin') %}
                                 <li class="nav-item"><a class="nav-link {{ 'active' if current_endpoint == 'boletins_buscar' else '' }}" href="{{ url_for('boletins_buscar') }}"><i class="bi bi-search me-2"></i> Pesquisar boletins</a></li>
                                 {% endif %}


### PR DESCRIPTION
### Motivation
- Ajustar a interface para não exibir ações de cadastro de boletins a usuários que não possuem permissão de gerenciamento, alinhando a navbar às permissões aplicadas nas rotas.

### Description
- Atualiza `templates/base.html` alterando a condição do bloco de Boletins para considerar `boletim_gerenciar` além de `boletim_visualizar`, `boletim_buscar` e `admin`, e envolve o link `boletins_novo` com uma checagem para `boletim_gerenciar` (ou `admin`) para ocultá-lo de usuários sem permissão.

### Testing
- Nenhum teste automatizado foi executado para esta alteração; a mudança é apenas de exibição no template e não altera lógica backend ou rotas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3aa4c2120832eae6cbc6f81a85ecc)