### PR TITLE
Permitir busca de boletins sem acentuação

### DIFF
--- a/blueprints/boletins.py
+++ b/blueprints/boletins.py
@@ -147,33 +147,41 @@ def buscar_boletins():
         normalized = unicodedata.normalize('NFD', value or '')
         return ''.join(ch for ch in normalized if unicodedata.category(ch) != 'Mn')
 
+    def _sql_strip_accents(expression):
+        normalized = func.lower(func.coalesce(expression, ''))
+        for accented, plain in (
+            ('á', 'a'), ('à', 'a'), ('â', 'a'), ('ã', 'a'), ('ä', 'a'),
+            ('é', 'e'), ('è', 'e'), ('ê', 'e'), ('ë', 'e'),
+            ('í', 'i'), ('ì', 'i'), ('î', 'i'), ('ï', 'i'),
+            ('ó', 'o'), ('ò', 'o'), ('ô', 'o'), ('õ', 'o'), ('ö', 'o'),
+            ('ú', 'u'), ('ù', 'u'), ('û', 'u'), ('ü', 'u'),
+            ('ç', 'c'),
+        ):
+            normalized = func.replace(normalized, accented, plain)
+        return normalized
+
     query = Boletim.query
     if termo:
         tokens = [t for t in termo.split() if t]
-        if is_postgresql:
-            for token in tokens:
-                like = f"%{token}%"
-                conditions = [
-                    Boletim.titulo.ilike(like),
-                    Boletim.ocr_text.ilike(like),
-                    func.to_tsvector('portuguese', func.coalesce(Boletim.titulo, '') + text("' '") + func.coalesce(Boletim.ocr_text, '')).op('@@')(func.plainto_tsquery('portuguese', token)),
-                ]
-                if supports_unaccent:
-                    like_unaccent = f"%{_strip_accents(token)}%"
-                    conditions.extend([
-                        func.unaccent(Boletim.titulo).ilike(like_unaccent),
-                        func.unaccent(func.coalesce(Boletim.ocr_text, '')).ilike(like_unaccent),
-                    ])
-                query = query.filter(or_(*conditions))
-        else:
-            for token in tokens:
-                normalized_token = _strip_accents(token).lower()
-                query = query.filter(
-                    or_(
-                        func.lower(Boletim.titulo).ilike(f"%{normalized_token}%"),
-                        func.lower(func.coalesce(Boletim.ocr_text, '')).ilike(f"%{normalized_token}%"),
-                    )
+        for token in tokens:
+            like = f"%{token}%"
+            like_normalized = f"%{_strip_accents(token).lower()}%"
+            conditions = [
+                Boletim.titulo.ilike(like),
+                Boletim.ocr_text.ilike(like),
+                _sql_strip_accents(Boletim.titulo).ilike(like_normalized),
+                _sql_strip_accents(Boletim.ocr_text).ilike(like_normalized),
+            ]
+            if is_postgresql:
+                conditions.append(
+                    func.to_tsvector('portuguese', func.coalesce(Boletim.titulo, '') + text("' '") + func.coalesce(Boletim.ocr_text, '')).op('@@')(func.plainto_tsquery('portuguese', token))
                 )
+                if supports_unaccent:
+                    conditions.extend([
+                        func.unaccent(Boletim.titulo).ilike(f"%{_strip_accents(token)}%"),
+                        func.unaccent(func.coalesce(Boletim.ocr_text, '')).ilike(f"%{_strip_accents(token)}%"),
+                    ])
+            query = query.filter(or_(*conditions))
 
     pagination = query.order_by(Boletim.data_boletim.desc(), Boletim.created_at.desc()).paginate(page=page, per_page=per_page, error_out=False)
     return render_template(

--- a/tests/test_boletins_busca.py
+++ b/tests/test_boletins_busca.py
@@ -66,6 +66,17 @@ def test_busca_boletim_match_ocr(client):
     assert b'Atualiza' in resp.data
 
 
+
+def test_busca_boletim_ignora_acentos(client):
+    with app.app_context():
+        user = _setup_user(client, ['boletim_buscar', 'boletim_visualizar'])
+        _create_boletim(user, 'Boletim de Ação Integrada', 'Texto com informação técnica', date(2026, 1, 3))
+
+    resp = client.get('/boletins/buscar', query_string={'q': 'acao informacao'})
+
+    assert resp.status_code == 200
+    assert b'Boletim de A' in resp.data
+
 def test_busca_boletim_sem_permissao(client):
     with app.app_context():
         _setup_user(client, ['boletim_visualizar'])


### PR DESCRIPTION
### Motivation
- Tornar a busca de boletins tolerante a acentuação para que consultas sem acento encontrem títulos e texto OCR que contenham acentos.
- Manter o comportamento atual de busca full-text no PostgreSQL e aproveitar a extensão `unaccent` quando disponível.

### Description
- Adiciona a função `_sql_strip_accents` em `blueprints/boletins.py` que normaliza `titulo` e `ocr_text` no SQL usando `lower` + várias chamadas `replace` para remover acentos antes de comparar.
- Altera a construção dos filtros para combinar busca direta (`ilike`), busca normalizada sem acentos e, no PostgreSQL, `to_tsvector/plainto_tsquery` e comparações com `unaccent` quando presente.
- Atualiza a lógica para aplicar os mesmos filtros independentemente do banco, garantindo comportamento consistente em SQLite (testes) e PostgreSQL (produção).
- Adiciona o teste `test_busca_boletim_ignora_acentos` em `tests/test_boletins_busca.py` que verifica que a query sem acentos encontra um boletim com texto acentuado.

### Testing
- Executei `pytest -q tests/test_boletins_busca.py` e todos os testes do arquivo passaram (`6 passed`) com avisos de compatibilidade do SQLAlchemy, sem falhas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3aadf560c832eb7f1570067c334a7)