### PR TITLE
Trata notificações de artigos excluídos com tela amigável

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -142,6 +142,19 @@ def _render_editar_artigo_form(artigo, arquivos, can_submit_actions, form_data=N
         form_data=form_data,
     )
 
+def _render_artigo_indisponivel(artigo_id):
+    auditoria_exclusao = (
+        ArticleDeletionAudit.query
+        .filter_by(article_id=artigo_id)
+        .order_by(ArticleDeletionAudit.deleted_at.desc())
+        .first()
+    )
+    return render_template(
+        "artigos/artigo_indisponivel.html",
+        artigo_id=artigo_id,
+        auditoria_exclusao=auditoria_exclusao,
+    ), 200
+
 
 @articles_bp.route('/upload-progress/<progress_id>', methods=['GET'])
 def upload_progress(progress_id):
@@ -427,7 +440,9 @@ def meus_artigos():
 def artigo(artigo_id):
     if 'username' not in session:
         return redirect(url_for('login'))
-    artigo = Article.query.get_or_404(artigo_id)
+    artigo = Article.query.get(artigo_id)
+    if not artigo:
+        return _render_artigo_indisponivel(artigo_id)
     user = User.query.filter_by(username=session['username']).first()
     if not user_can_view_article(user, artigo):
         flash('Você não tem permissão para ver este artigo.', 'danger')
@@ -994,7 +1009,9 @@ def aprovacao_detail(artigo_id):
         flash('Permissão negada.', 'danger')
         return redirect(url_for('login'))
 
-    artigo = Article.query.get_or_404(artigo_id)
+    artigo = Article.query.get(artigo_id)
+    if not artigo:
+        return _render_artigo_indisponivel(artigo_id)
     if not (
         user_can_approve_article(user, artigo) or
         user_can_review_article(user, artigo)

--- a/templates/artigos/artigo_indisponivel.html
+++ b/templates/artigos/artigo_indisponivel.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block title %}Recurso indisponível{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+  <div class="alert alert-warning" role="alert">
+    <h4 class="alert-heading">Recurso indisponível</h4>
+    <p class="mb-0">Este artigo não está mais disponível. Ele pode ter sido excluído definitivamente por um administrador.</p>
+  </div>
+
+  {% if auditoria_exclusao %}
+  <div class="card shadow-sm">
+    <div class="card-header">Detalhes da exclusão (auditoria)</div>
+    <div class="card-body">
+      <dl class="row mb-0">
+        <dt class="col-sm-4">Título do artigo</dt>
+        <dd class="col-sm-8">{{ auditoria_exclusao.article_title }}</dd>
+
+        <dt class="col-sm-4">Excluído por</dt>
+        <dd class="col-sm-8">{{ auditoria_exclusao.deleted_by.username if auditoria_exclusao.deleted_by else 'Usuário não identificado' }}</dd>
+
+        <dt class="col-sm-4">Data/hora da exclusão</dt>
+        <dd class="col-sm-8">{{ auditoria_exclusao.deleted_at }}</dd>
+
+        <dt class="col-sm-4">Motivo</dt>
+        <dd class="col-sm-8">{{ auditoria_exclusao.reason }}</dd>
+
+        <dt class="col-sm-4">ID original do artigo</dt>
+        <dd class="col-sm-8">{{ auditoria_exclusao.article_id }}</dd>
+      </dl>
+    </div>
+  </div>
+  {% else %}
+  <p class="text-muted">Não foi encontrado log de exclusão para este artigo. Se precisar de mais detalhes, contate o administrador.</p>
+  <p><strong>ID original do artigo:</strong> {{ artigo_id }}</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/tests/test_notification_deleted_article_fallback.py
+++ b/tests/test_notification_deleted_article_fallback.py
@@ -1,0 +1,85 @@
+from datetime import datetime, timezone
+
+from app import app, db
+from core.enums import ArticleStatus
+from core.models import (
+    Article,
+    ArticleDeletionAudit,
+    Celula,
+    Estabelecimento,
+    Funcao,
+    Instituicao,
+    Setor,
+    User,
+)
+
+
+def _setup_user(client, username='notif_user', perms=None):
+    perms = perms or []
+    with app.app_context():
+        inst = Instituicao(codigo=f'INST_{username}', nome='Inst')
+        db.session.add(inst)
+        db.session.flush()
+        est = Estabelecimento(codigo=f'EST_{username}', nome_fantasia='Est', instituicao_id=inst.id)
+        db.session.add(est)
+        db.session.flush()
+        setor = Setor(nome=f'Setor {username}', estabelecimento_id=est.id)
+        db.session.add(setor)
+        db.session.flush()
+        cel = Celula(nome=f'Cel {username}', estabelecimento_id=est.id, setor_id=setor.id)
+        db.session.add(cel)
+        db.session.flush()
+
+        user = User(username=username, email=f'{username}@test', estabelecimento_id=est.id, setor_id=setor.id, celula_id=cel.id)
+        user.set_password('x')
+        for code in perms:
+            perm = Funcao.query.filter_by(codigo=code).first()
+            if not perm:
+                perm = Funcao(codigo=code, nome=code)
+                db.session.add(perm)
+                db.session.flush()
+            user.permissoes_personalizadas.append(perm)
+        db.session.add(user)
+        db.session.commit()
+        uid = user.id
+        uname = user.username
+
+    with client.session_transaction() as sess:
+        sess['user_id'] = uid
+        sess['username'] = uname
+
+
+def test_artigo_url_exibe_tela_amigavel_quando_recurso_foi_excluido(client):
+    _setup_user(client)
+    resp = client.get('/artigo/999999')
+    assert resp.status_code == 200
+    assert b'Este artigo n\xc3\xa3o est\xc3\xa1 mais dispon\xc3\xadvel' in resp.data
+    assert b'contate o administrador' in resp.data
+
+
+def test_aprovacao_detail_exibe_auditoria_quando_artigo_excluido(client):
+    _setup_user(client, username='aprovador', perms=['artigo_aprovar_todas'])
+    with app.app_context():
+        autor = User.query.filter_by(username='aprovador').first()
+        art = Article(titulo='Artigo auditado', texto='x', status=ArticleStatus.PENDENTE, user_id=autor.id)
+        db.session.add(art)
+        db.session.flush()
+        aid = art.id
+        db.session.add(
+            ArticleDeletionAudit(
+                article_id=aid,
+                article_title='Artigo auditado',
+                deleted_by_user_id=autor.id,
+                deleted_at=datetime.now(timezone.utc),
+                reason='limpeza',
+                attachment_count=0,
+            )
+        )
+        db.session.delete(art)
+        db.session.commit()
+
+    resp = client.get(f'/aprovacao/{aid}')
+    assert resp.status_code == 200
+    assert b'Detalhes da exclus\xc3\xa3o (auditoria)' in resp.data
+    assert b'Artigo auditado' in resp.data
+    assert b'limpeza' in resp.data


### PR DESCRIPTION
### Motivation
- Evitar erro técnico (404) ao usuário clicar em notificações que apontam para artigos excluídos definitivamente. 
- Exibir mensagem amigável explicando que o artigo não está mais disponível e, quando existir, mostrar dados de auditoria da exclusão. 
- Manter o histórico da notificação intacto enquanto evita links quebrados no fluxo de navegação. 

### Description
- Adiciona o fallback `_render_artigo_indisponivel` em `blueprints/articles.py` que consulta `ArticleDeletionAudit` e renderiza a página de recurso indisponível. 
- Substitui `Article.query.get_or_404` por `Article.query.get` nos endpoints de visualização e aprovação (`/artigo/<id>` e `/aprovacao/<id>`) para invocar o fallback em vez de disparar 404 técnico. 
- Cria o template `templates/artigos/artigo_indisponivel.html` com a mensagem amigável sugerida e painel de auditoria com título, usuário, data/hora, motivo e ID original quando disponível. 
- Adiciona testes em `tests/test_notification_deleted_article_fallback.py` que validam o comportamento ao acessar `/artigo/<id>` inexistente e `/aprovacao/<id>` quando há auditoria de exclusão. 

### Testing
- Executado `pytest -q tests/test_notification_deleted_article_fallback.py` e os testes completaram com sucesso (`2 passed`).
- As alterações foram validadas localmente garantindo que o clique em notificações de artigos removidos retorna a página de “recurso indisponível” em vez de um erro bruto.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3acff9414832ebfc4642e742a9332)