### PR TITLE
Corrige contraste de blocos OCR no modo escuro

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -954,3 +954,19 @@
   background-color: #6c757d;
   color: #fff;
 }
+
+
+.ocr-details-panel,
+.boletim-surface,
+.boletim-ocr-text,
+.boletim-pdf-thumbnail {
+  background-color: var(--bg-muted) !important;
+  color: var(--text-default);
+}
+
+[data-bs-theme="dark"] .ocr-details-panel,
+[data-bs-theme="dark"] .boletim-surface,
+[data-bs-theme="dark"] .boletim-ocr-text,
+[data-bs-theme="dark"] .boletim-pdf-thumbnail {
+  border-color: var(--border-default) !important;
+}

--- a/templates/artigos/artigo.html
+++ b/templates/artigos/artigo.html
@@ -126,7 +126,7 @@
                     Detalhes do OCR
                   </button>
                   <div class="collapse mt-2" id="{{ ocr_panel_id }}">
-                    <div class="border rounded p-2 small bg-light">
+                    <div class="border rounded p-2 small ocr-details-panel">
                       <div><strong>Caracteres OCR:</strong> {{ att.ocr_char_count if att.ocr_char_count is not none else '—' }}</div>
                       <div><strong>Páginas OCR:</strong> {{ att.ocr_page_count if att.ocr_page_count is not none else '—' }}</div>
                       <div><strong>Páginas com sucesso:</strong> {{ att.ocr_pages_success if att.ocr_pages_success is not none else '—' }}</div>

--- a/templates/boletins/visualizar.html
+++ b/templates/boletins/visualizar.html
@@ -33,9 +33,9 @@
 
           <div class="row g-4">
             <div class="col-12 col-lg-4">
-              <div class="border rounded p-3 bg-light h-100">
+              <div class="border rounded p-3 boletim-surface h-100">
                 <h5 class="mb-3">Capa do PDF</h5>
-                <div id="boletim-pdf-thumbnail" class="d-flex align-items-center justify-content-center border rounded bg-white" style="min-height: 260px;">
+                <div id="boletim-pdf-thumbnail" class="d-flex align-items-center justify-content-center border rounded boletim-pdf-thumbnail" style="min-height: 260px;">
                   <div id="boletim-pdf-placeholder" class="text-center text-muted px-3">
                     <i class="bi bi-file-earmark-pdf fs-1 d-block mb-2" aria-hidden="true"></i>
                     <span>Miniatura indisponível.</span>
@@ -54,7 +54,7 @@
 
             <div class="col-12 col-lg-8">
               <h5>Texto OCR</h5>
-              <div class="border rounded bg-light p-3" style="max-height: 380px; overflow-y: auto; white-space: pre-wrap;">
+              <div class="border rounded boletim-ocr-text p-3" style="max-height: 380px; overflow-y: auto; white-space: pre-wrap;">
                 {% if boletim.ocr_text and boletim.ocr_text.strip() %}
                 {{ boletim.ocr_text }}
                 {% else %}


### PR DESCRIPTION
### Motivation
- Corrigir problema de contraste em que textos e painéis relacionados ao OCR (miniatura, capa do PDF e detalhes) ficavam com letra branca sobre fundo branco no tema escuro.
- Garantir que os blocos de OCR respeitem as variáveis de tema e mantenham fundo, texto e borda adequados em claro/escuro.

### Description
- Substitui o uso de `bg-light` por classes temáticas específicas nos templates `templates/artigos/artigo.html` e `templates/boletins/visualizar.html`, adicionando `ocr-details-panel`, `boletim-surface`, `boletim-pdf-thumbnail` e `boletim-ocr-text` onde aplicável.
- Adiciona regras em `static/css/custom.css` para essas classes que usam as variáveis de tema (`--bg-muted`, `--text-default`) e aplica ajuste de borda para `[data-bs-theme="dark"]` para preservar contraste.
- Ajustes afetam a miniatura da capa do PDF, a caixa de texto OCR do boletim e o painel de detalhes do OCR em anexos PDF.

### Testing
- Executado `python -m py_compile app.py` e compilação de bytecode Python completou sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ba0098a0832e87e2a53b0c1fa15e)