### PR TITLE
Remove dark-mode logo inversion styling

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -807,15 +807,6 @@
   }
 }
 
-/* Dark theme helpers */
-.invert-on-dark {
-  filter: none;
-}
-
-[data-bs-theme="dark"] .invert-on-dark {
-  filter: invert(1);
-}
-
 /* Quill editor dark adjustments */
 [data-bs-theme="dark"] .ql-container,
 [data-bs-theme="dark"] .ql-editor {

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -12,7 +12,7 @@ data-remembered-username="{{ remembered_user.username if remembered_user else ''
     <div class="login-card card">
       <div class="card-body p-3 p-md-4">
         <div class="login-brand text-center mb-4">
-          <img src="{{ url_for('static', filename='icons/sua_logo.png') }}" class="login-logo mb-2 invert-on-dark" alt="Logo Orquetask">
+          <img src="{{ url_for('static', filename='icons/sua_logo.png') }}" class="login-logo mb-2" alt="Logo Orquetask">
           <div>
             <h1 class="h4 fw-bold mb-1">Orquetask</h1>
             <p class="text-muted mb-0 small">Sistema Integrado de Gestão e Conhecimento</p>

--- a/templates/auth/reset_password_request.html
+++ b/templates/auth/reset_password_request.html
@@ -4,7 +4,7 @@
 <div class="row justify-content-center">
   <div class="col-md-4">
     <div class="text-center mb-4">
-      <img src="{{ url_for('static', filename='icons/sua_logo.png') }}" class="login-logo mb-2 invert-on-dark" alt="Logo Orquetask">
+      <img src="{{ url_for('static', filename='icons/sua_logo.png') }}" class="login-logo mb-2" alt="Logo Orquetask">
       <h1 class="h4 fw-bold mb-0">Orquetask</h1>
     </div>
     {% with messages = get_flashed_messages(with_categories=true) %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -224,7 +224,7 @@
                 </button>
                 
                 <a class="navbar-brand d-flex align-items-center ms-3" href="{{ url_for('pagina_inicial') }}"> {# Link do brand pode ser o dashboard ou meus_artigos #}
-                    <img src="{{ url_for('static', filename='icons/favicon.png') }}" alt="Logo Orquetask" height="30" class="me-2 invert-on-dark">
+                    <img src="{{ url_for('static', filename='icons/favicon.png') }}" alt="Logo Orquetask" height="30" class="me-2">
                     <span>Orquetask</span>
                 </a>
                 


### PR DESCRIPTION
### Motivation
- The logo was being color-inverted in dark mode via an `.invert-on-dark` helper which made the logo look off in dark theme, so the goal is to keep the logo's original colors consistent across themes.

### Description
- Removed the `invert-on-dark` class from the navbar favicon image in `templates/base.html` so the brand image is no longer inverted in dark mode.
- Removed the `invert-on-dark` class from the login and password-reset page logos in `templates/auth/login.html` and `templates/auth/reset_password_request.html` so auth screens keep the original logo colors.
- Deleted the unused `.invert-on-dark` CSS rules from `static/css/custom.css` to remove the dark-mode inversion helper.

### Testing
- Ran `rg -n "invert-on-dark" templates static/css/custom.css` and confirmed there are no remaining matches. (success)
- Inspected the updated template and stylesheet snippets to verify the class and CSS block were removed. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8de030870832eb9f4e4a011735f3a)