### PR TITLE
Ajusta tela 'Recurso indisponível' — mensagem condicional e sanitização do motivo

### DIFF
--- a/templates/artigos/artigo_indisponivel.html
+++ b/templates/artigos/artigo_indisponivel.html
@@ -6,7 +6,7 @@
 <div class="container py-4">
   <div class="alert alert-warning" role="alert">
     <h4 class="alert-heading">Recurso indisponível</h4>
-    <p class="mb-0">Este artigo não está mais disponível. Ele pode ter sido excluído definitivamente por um administrador.</p>
+    <p class="mb-0">{% if auditoria_exclusao %}Este artigo foi excluído definitivamente por um administrador.{% else %}Este artigo não está mais disponível. Ele pode ter sido excluído definitivamente por um administrador.{% endif %}</p>
   </div>
 
   {% if auditoria_exclusao %}
@@ -24,7 +24,7 @@
         <dd class="col-sm-8">{{ auditoria_exclusao.deleted_at }}</dd>
 
         <dt class="col-sm-4">Motivo</dt>
-        <dd class="col-sm-8">{{ auditoria_exclusao.reason }}</dd>
+        <dd class="col-sm-8">{{ auditoria_exclusao.reason | striptags | trim }}</dd>
 
         <dt class="col-sm-4">ID original do artigo</dt>
         <dd class="col-sm-8">{{ auditoria_exclusao.article_id }}</dd>


### PR DESCRIPTION
### Motivation
- Exibir mensagem afirmativa quando existir auditoria de exclusão e evitar que o campo “Motivo” mostre HTML cru (por exemplo `<p>ok</p>`), exibindo apenas texto limpo.

### Description
- Atualiza `templates/artigos/artigo_indisponivel.html` para tornar a mensagem principal condicional usando `{% if auditoria_exclusao %}...{% else %}...{% endif %}` e aplica `| striptags | trim` em `auditoria_exclusao.reason` para remover tags HTML.

### Testing
- Nenhum teste automatizado foi executado para esta alteração; a mudança foi verificada localmente inspecionando o diff e o conteúdo do arquivo (`git diff` e visualização do arquivo).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e5dac990832e986a3d0f8bc2cfe8)