### PR TITLE
Adiciona atalho para pesquisa de boletins na página inicial

### DIFF
--- a/templates/pagina_inicial.html
+++ b/templates/pagina_inicial.html
@@ -33,6 +33,16 @@
                 </div>
             </div>
         </div>
+        <div class="col-md-4 col-lg-3 mb-3">
+            <div class="card text-center h-100">
+                <div class="card-body">
+                    <a href="{{ url_for('boletins_buscar') }}" class="text-decoration-none stretched-link">
+                        <i class="bi bi-journal-text display-4 text-secondary mb-2"></i>
+                        <h6 class="card-title">Pesquisar Boletins</h6>
+                    </a>
+                </div>
+            </div>
+        </div>
         {% if current_user.is_authenticated %}
             {% set codes = [
                 Permissao.ARTIGO_APROVAR_CELULA.value,


### PR DESCRIPTION
### Motivation
- Disponibilizar na página inicial um atalho rápido para a busca de boletins, alinhando a home com as ações já presentes no menu lateral.

### Description
- Adiciona um novo card em `templates/pagina_inicial.html` que aponta para a rota `boletins_buscar` com ícone `bi bi-journal-text` e título "Pesquisar Boletins".

### Testing
- Executado `pytest -q tests/test_boletins_busca.py` que retornou sucesso (6 passed, 26 warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e90ff838832e8259a67b20551b1b)