### PR TITLE
Ajusta busca de boletins para frase exata e curinga explícito

### DIFF
--- a/blueprints/boletins.py
+++ b/blueprints/boletins.py
@@ -3,7 +3,7 @@ import os
 import uuid
 
 from flask import Blueprint, current_app as app, flash, redirect, render_template, request, session, url_for
-from sqlalchemy import and_, func, or_, text
+from sqlalchemy import and_, func, or_
 from werkzeug.utils import secure_filename
 import unicodedata
 
@@ -162,26 +162,23 @@ def buscar_boletins():
 
     query = Boletim.query
     if termo:
-        tokens = [t for t in termo.split() if t]
-        for token in tokens:
-            like = f"%{token}%"
-            like_normalized = f"%{_strip_accents(token).lower()}%"
-            conditions = [
-                Boletim.titulo.ilike(like),
-                Boletim.ocr_text.ilike(like),
-                _sql_strip_accents(Boletim.titulo).ilike(like_normalized),
-                _sql_strip_accents(Boletim.ocr_text).ilike(like_normalized),
-            ]
-            if is_postgresql:
-                conditions.append(
-                    func.to_tsvector('portuguese', func.coalesce(Boletim.titulo, '') + text("' '") + func.coalesce(Boletim.ocr_text, '')).op('@@')(func.plainto_tsquery('portuguese', token))
-                )
-                if supports_unaccent:
-                    conditions.extend([
-                        func.unaccent(Boletim.titulo).ilike(f"%{_strip_accents(token)}%"),
-                        func.unaccent(func.coalesce(Boletim.ocr_text, '')).ilike(f"%{_strip_accents(token)}%"),
-                    ])
-            query = query.filter(or_(*conditions))
+        has_wildcard = '%' in termo
+        like = termo if has_wildcard else f"%{termo}%"
+        like_normalized = _strip_accents(termo).lower()
+        like_normalized = like_normalized if has_wildcard else f"%{like_normalized}%"
+
+        conditions = [
+            Boletim.titulo.ilike(like),
+            Boletim.ocr_text.ilike(like),
+            _sql_strip_accents(Boletim.titulo).ilike(like_normalized),
+            _sql_strip_accents(Boletim.ocr_text).ilike(like_normalized),
+        ]
+        if is_postgresql and supports_unaccent:
+            conditions.extend([
+                func.unaccent(Boletim.titulo).ilike(like_normalized),
+                func.unaccent(func.coalesce(Boletim.ocr_text, '')).ilike(like_normalized),
+            ])
+        query = query.filter(or_(*conditions))
 
     pagination = query.order_by(Boletim.data_boletim.desc(), Boletim.created_at.desc()).paginate(page=page, per_page=per_page, error_out=False)
     return render_template(

--- a/tests/test_boletins_busca.py
+++ b/tests/test_boletins_busca.py
@@ -72,7 +72,7 @@ def test_busca_boletim_ignora_acentos(client):
         user = _setup_user(client, ['boletim_buscar', 'boletim_visualizar'])
         _create_boletim(user, 'Boletim de Ação Integrada', 'Texto com informação técnica', date(2026, 1, 3))
 
-    resp = client.get('/boletins/buscar', query_string={'q': 'acao informacao'})
+    resp = client.get('/boletins/buscar', query_string={'q': '%acao%'})
 
     assert resp.status_code == 200
     assert b'Boletim de A' in resp.data
@@ -107,3 +107,27 @@ def test_listagem_oculta_atalho_buscar_sem_permissao(client):
     assert resp.status_code == 200
     assert b'Pesquisar boletins' not in resp.data
     assert b'>Buscar<' not in resp.data
+
+
+def test_busca_boletim_frase_exata_sem_percentual(client):
+    with app.app_context():
+        user = _setup_user(client, ['boletim_buscar', 'boletim_visualizar'])
+        _create_boletim(user, 'Comunicado Dia dos pais 2026', 'Texto irrelevante', date(2026, 1, 4))
+        _create_boletim(user, 'Comunicado Dia livre dos pais 2026', 'Texto irrelevante', date(2026, 1, 5))
+
+    resp = client.get('/boletins/buscar', query_string={'q': 'Dia dos pais'})
+
+    assert resp.status_code == 200
+    assert b'Comunicado Dia dos pais 2026' in resp.data
+    assert b'Comunicado Dia livre dos pais 2026' not in resp.data
+
+
+def test_busca_boletim_aproximada_com_percentual(client):
+    with app.app_context():
+        user = _setup_user(client, ['boletim_buscar', 'boletim_visualizar'])
+        _create_boletim(user, 'Comunicado Dia livre dos pais 2026', 'Texto irrelevante', date(2026, 1, 6))
+
+    resp = client.get('/boletins/buscar', query_string={'q': '%Dia%pais%'})
+
+    assert resp.status_code == 200
+    assert b'Comunicado Dia livre dos pais 2026' in resp.data


### PR DESCRIPTION
### Motivation
- Corrigir comportamento de busca que atualmente tokenizava a consulta e realizava OR por palavra, retornando resultados indesejados para consultas com múltiplas palavras.
- Fazer com que buscas sem `%` procurem a frase/expressão completa e apenas buscas com `%` usem comportamento aproximado/curinga.
- Preservar a comparação sem acentos em `titulo` e `ocr_text` mantendo a mesma semântica de correspondência.

### Description
- Atualiza a lógica em `blueprints/boletins.py` para tratar o parâmetro `termo` como uma única expressão ao invés de dividir em tokens por espaço, detectando presença de `%` para decidir entre pesquisa aproximada ou exata; a detecção monta `like` e `like_normalized` apropriadamente.
- Removeu o uso de `to_tsvector/plainto_tsquery` como fallback nessa rota para evitar expansão por termos; manteve comparações `ILIKE` e comparações sem acentos usando `_sql_strip_accents` e `func.unaccent` quando disponível.
- Ajustou imports para remover `text` não mais necessário.
- Atualizou `tests/test_boletins_busca.py` para adaptar um caso de acentuação e adicionar dois testes novos cobrindo busca por frase sem `%` (`Dia dos pais`) e busca aproximada com `%` (`%Dia%pais%`).

### Testing
- Executei `pytest -q tests/test_boletins_busca.py` e todos os testes do arquivo passaram: `8 passed`.
- Os testes verificam correspondência por `titulo` e `ocr_text`, comportamento sem acentos, permissão e os novos cenários de busca exata e com curinga.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90f1b53e0832ea15b23c5e1ea6cc5)