### PR TITLE
Navegação de paginação nas buscas de artigos e boletins

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash, session, jsonify, current_app as app, g
 from sqlalchemy import or_, func, text, and_
+import math
 import re
 
 try:
@@ -1141,6 +1142,8 @@ def pesquisar():
         return redirect(url_for('login'))
 
     q = request.args.get('q','').strip()
+    page = request.args.get('page', 1, type=int)
+    per_page = min(max(request.args.get('per_page', 20, type=int), 1), 100)
     tipo_id = request.args.get('tipo_id', type=int)
     area_id = request.args.get('area_id', type=int)
     sistema_id = request.args.get('sistema_id', type=int)
@@ -1231,6 +1234,12 @@ def pesquisar():
         return redirect(url_for('login'))
 
     artigos = [a for a in artigos if user_can_view_article(user, a)]
+    total_artigos = len(artigos)
+    total_paginas = max(1, math.ceil(total_artigos / per_page))
+    page = min(max(page, 1), total_paginas)
+    inicio = (page - 1) * per_page
+    fim = inicio + per_page
+    artigos = artigos[inicio:fim]
 
     # formata datas para o fuso local
     for art in artigos:
@@ -1258,5 +1267,9 @@ def pesquisar():
         tipos_artigo=ArtigoTipo.query.filter_by(ativo=True).order_by(ArtigoTipo.nome).all(),
         areas_artigo=ArtigoArea.query.filter_by(ativo=True).order_by(ArtigoArea.nome).all(),
         sistemas_artigo=ArtigoSistema.query.filter_by(ativo=True).order_by(ArtigoSistema.nome).all(),
-        now=datetime.now(ZoneInfo("America/Sao_Paulo"))
+        now=datetime.now(ZoneInfo("America/Sao_Paulo")),
+        page=page,
+        per_page=per_page,
+        total_paginas=total_paginas,
+        total_artigos=total_artigos,
     )

--- a/templates/artigos/pesquisar.html
+++ b/templates/artigos/pesquisar.html
@@ -37,6 +37,7 @@
             <div class="col-md-2 d-grid">
             <button class="btn btn-outline-primary">Pesquisar</button>
             </div>
+            <input type="hidden" name="page" value="1">
           </form>
         </div>
       </div>
@@ -86,6 +87,37 @@
       </div>
       {% else %}
       <p class="text-muted mt-3">Nenhum artigo encontrado.</p>
+      {% endif %}
+
+      {% if total_paginas > 1 %}
+      <nav class="mt-3" aria-label="Paginação">
+        <ul class="pagination flex-wrap gap-1">
+          <li class="page-item {% if page <= 1 %}disabled{% endif %}">
+            <a class="page-link" href="{{ url_for('pesquisar', q=q, tipo_id=tipo_id, area_id=area_id, sistema_id=sistema_id, per_page=per_page, page=1) }}">Primeira</a>
+          </li>
+          <li class="page-item {% if page <= 1 %}disabled{% endif %}">
+            <a class="page-link" href="{{ url_for('pesquisar', q=q, tipo_id=tipo_id, area_id=area_id, sistema_id=sistema_id, per_page=per_page, page=page-1) }}">Anterior</a>
+          </li>
+          <li class="page-item disabled"><span class="page-link">Página {{ page }} de {{ total_paginas }}</span></li>
+          <li class="page-item {% if page >= total_paginas %}disabled{% endif %}">
+            <a class="page-link" href="{{ url_for('pesquisar', q=q, tipo_id=tipo_id, area_id=area_id, sistema_id=sistema_id, per_page=per_page, page=page+1) }}">Próxima</a>
+          </li>
+          <li class="page-item {% if page >= total_paginas %}disabled{% endif %}">
+            <a class="page-link" href="{{ url_for('pesquisar', q=q, tipo_id=tipo_id, area_id=area_id, sistema_id=sistema_id, per_page=per_page, page=total_paginas) }}">Última</a>
+          </li>
+          <li class="page-item">
+            <form method="get" class="d-flex ms-2">
+              <input type="hidden" name="q" value="{{ q }}">
+              <input type="hidden" name="tipo_id" value="{{ tipo_id or '' }}">
+              <input type="hidden" name="area_id" value="{{ area_id or '' }}">
+              <input type="hidden" name="sistema_id" value="{{ sistema_id or '' }}">
+              <input type="hidden" name="per_page" value="{{ per_page }}">
+              <input class="form-control form-control-sm" type="number" name="page" min="1" max="{{ total_paginas }}" value="{{ page }}" style="width: 90px;" aria-label="Página específica">
+              <button class="btn btn-sm btn-outline-secondary ms-1" type="submit">Ir</button>
+            </form>
+          </li>
+        </ul>
+      </nav>
       {% endif %}
     </div>
   </div>

--- a/templates/boletins/busca.html
+++ b/templates/boletins/busca.html
@@ -63,13 +63,27 @@
 
       {% if pagination and pagination.pages > 1 %}
       <nav class="mt-3" aria-label="Paginação">
-        <ul class="pagination">
+        <ul class="pagination flex-wrap gap-1">
+          <li class="page-item {% if not pagination.has_prev %}disabled{% endif %}">
+            <a class="page-link" href="{{ url_for('boletins_buscar', q=termo, per_page=per_page, page=1) }}">Primeira</a>
+          </li>
           <li class="page-item {% if not pagination.has_prev %}disabled{% endif %}">
             <a class="page-link" href="{{ url_for('boletins_buscar', q=termo, per_page=per_page, page=pagination.prev_num) }}">Anterior</a>
           </li>
           <li class="page-item disabled"><span class="page-link">Página {{ pagination.page }} de {{ pagination.pages }}</span></li>
           <li class="page-item {% if not pagination.has_next %}disabled{% endif %}">
             <a class="page-link" href="{{ url_for('boletins_buscar', q=termo, per_page=per_page, page=pagination.next_num) }}">Próxima</a>
+          </li>
+          <li class="page-item {% if not pagination.has_next %}disabled{% endif %}">
+            <a class="page-link" href="{{ url_for('boletins_buscar', q=termo, per_page=per_page, page=pagination.pages) }}">Última</a>
+          </li>
+          <li class="page-item">
+            <form method="get" class="d-flex ms-2">
+              <input type="hidden" name="q" value="{{ termo }}">
+              <input type="hidden" name="per_page" value="{{ per_page }}">
+              <input class="form-control form-control-sm" type="number" name="page" min="1" max="{{ pagination.pages }}" value="{{ pagination.page }}" style="width: 90px;" aria-label="Página específica">
+              <button class="btn btn-sm btn-outline-secondary ms-1" type="submit">Ir</button>
+            </form>
           </li>
         </ul>
       </nav>


### PR DESCRIPTION
### Motivation
- Tornar a busca de artigos e boletins navegável quando há muitos resultados adicionando controles para ir à primeira, última e a uma página específica.
- Evitar perder os filtros de busca ao navegar entre páginas preservando os parâmetros `q`, `tipo_id`, `area_id`, `sistema_id` e `per_page` nas URLs.

### Description
- Adiciona suporte a `page` e `per_page` na rota de pesquisa de artigos (`blueprints/articles.py`) e calcula `total_artigos` e `total_paginas`, aplicando o recorte (`slice`) da lista de artigos antes de renderizar; também importa `math` para o cálculo.
- Expõe `page`, `per_page`, `total_paginas` e `total_artigos` ao template de artigos (`templates/artigos/pesquisar.html`).
- Atualiza o template de pesquisa de artigos para incluir botões `Primeira`, `Anterior`, `Próxima`, `Última` e um formulário para ir a uma página específica preservando os filtros ativos.
- Amplia o template de busca de boletins (`templates/boletins/busca.html`) para adicionar os botões `Primeira` e `Última` e um campo para navegar para página específica, mantendo `q` e `per_page`.

### Testing
- Executado `pytest -q tests/test_search.py tests/test_boletins_busca.py` e todos os testes relevantes passaram (`17 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9df234318832e98498e081f04ab2b)