### PR TITLE
Refina organização das permissões de artigos por nível hierárquico

### DIFF
--- a/templates/admin/cargos.html
+++ b/templates/admin/cargos.html
@@ -258,15 +258,17 @@
                     <div class="card mb-3">
                         <div class="card-header"><h6 class="mb-0">Permissões de Artigos</h6></div>
                         <div class="card-body">
-                            {% set ns = namespace(celula=[], setor=[], area=[]) %}
+                            {% set ns = namespace(instituicao=[], estabelecimento=[], setor=[], celula=[], cadastros=[]) %}
                             {% for f in funcoes_por_categoria.get('Permissões de Artigos', []) %}
-                                {% if 'celula' in f.codigo %}{% set _ = ns.celula.append(f) %}
+                                {% if 'instituicao' in f.codigo %}{% set _ = ns.instituicao.append(f) %}
+                                {% elif 'estabelecimento' in f.codigo %}{% set _ = ns.estabelecimento.append(f) %}
                                 {% elif 'setor' in f.codigo %}{% set _ = ns.setor.append(f) %}
-                                {% else %}{% set _ = ns.area.append(f) %}
+                                {% elif 'celula' in f.codigo %}{% set _ = ns.celula.append(f) %}
+                                {% else %}{% set _ = ns.cadastros.append(f) %}
                                 {% endif %}
                             {% endfor %}
 
-                            {% for titulo, permissoes in [('Permissões por Célula', ns.celula), ('Permissões por Setor', ns.setor), ('Permissões por Área', ns.area)] %}
+                            {% for titulo, permissoes in [('Permissões por Instituição', ns.instituicao), ('Permissões por Estabelecimento', ns.estabelecimento), ('Permissões por Setor', ns.setor), ('Permissões por Célula', ns.celula), ('Cadastros de Artigo', ns.cadastros)] %}
                                 {% if permissoes %}
                                     <h6 class="mt-2 mb-1 text-muted">{{ titulo }}</h6>
                                     {% for f in permissoes %}
@@ -391,14 +393,16 @@
                     <div class="card mb-3">
                         <div class="card-header"><h6 class="mb-0">Permissões de Artigos</h6></div>
                     <div class="card-body">
-                            {% set ns_edit = namespace(celula=[], setor=[], area=[]) %}
+                            {% set ns_edit = namespace(instituicao=[], estabelecimento=[], setor=[], celula=[], cadastros=[]) %}
                             {% for f in funcoes_por_categoria.get('Permissões de Artigos', []) %}
-                                {% if 'celula' in f.codigo %}{% set _ = ns_edit.celula.append(f) %}
+                                {% if 'instituicao' in f.codigo %}{% set _ = ns_edit.instituicao.append(f) %}
+                                {% elif 'estabelecimento' in f.codigo %}{% set _ = ns_edit.estabelecimento.append(f) %}
                                 {% elif 'setor' in f.codigo %}{% set _ = ns_edit.setor.append(f) %}
-                                {% else %}{% set _ = ns_edit.area.append(f) %}
+                                {% elif 'celula' in f.codigo %}{% set _ = ns_edit.celula.append(f) %}
+                                {% else %}{% set _ = ns_edit.cadastros.append(f) %}
                                 {% endif %}
                             {% endfor %}
-                            {% for titulo, permissoes in [('Permissões por Célula', ns_edit.celula), ('Permissões por Setor', ns_edit.setor), ('Permissões por Área', ns_edit.area)] %}
+                            {% for titulo, permissoes in [('Permissões por Instituição', ns_edit.instituicao), ('Permissões por Estabelecimento', ns_edit.estabelecimento), ('Permissões por Setor', ns_edit.setor), ('Permissões por Célula', ns_edit.celula), ('Cadastros de Artigo', ns_edit.cadastros)] %}
                                 {% if permissoes %}
                                     <h6 class="mt-2 mb-1 text-muted">{{ titulo }}</h6>
                                     {% for f in permissoes %}


### PR DESCRIPTION
### Motivation
- Corrigir agrupamento excessivamente genérico que colocava várias permissões de artigo na categoria de "Área", dificultando identificação do escopo correto. 
- Apresentar as permissões alinhadas à modelagem organizacional (Instituição → Estabelecimento → Setor → Célula) e separar permissões de cadastros sem escopo hierárquico.

### Description
- Atualiza `templates/admin/cargos.html` para criar namespaces `instituicao`, `estabelecimento`, `setor`, `celula` e `cadastros` e agrupar `funcoes_por_categoria['Permissões de Artigos']` por esses escopos com checagem em `f.codigo`.
- Substitui o agrupamento anterior (`area`) por cinco seções visuais: `Permissões por Instituição`, `Permissões por Estabelecimento`, `Permissões por Setor`, `Permissões por Célula` e `Cadastros de Artigo`.
- Aplica a mesma reorganização tanto no formulário de cadastro quanto no modal de edição de cargos para manter consistência na UI.

### Testing
- Executado `pytest -q tests/test_admin_usuarios.py -k permissoes` e o teste relacionado passou com sucesso (`1 passed, 17 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e9b16374832ea0de4c62dffad957)