### PR TITLE
Corrige fallback OCR de PDF e contagem real de páginas

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -13,6 +13,7 @@ import xlrd
 from odf import opendocument
 from odf.text import P
 import logging
+import time
 import warnings
 from cryptography.utils import CryptographyDeprecationWarning
 
@@ -429,20 +430,38 @@ def extract_text_from_pdf(
     correspondentes são habilitados. Com todos os parâmetros em ``False`` o
     comportamento é idêntico ao anterior.
     """
+    started_at = time.monotonic()
+    total_pages = _get_pdf_total_pages(path)
+    logger.info("pdf_page_count_detected", extra={"ocr_page_count": total_pages})
+
     direct_text = _extract_pdf_text_without_ocr(path)
-    if direct_text:
-        total_pages = direct_text.count("\n") + 1 if direct_text else 1
-        final_char_count = len(direct_text.strip())
-        logger.info(
-            "pdf_direct_text",
-            extra={
-                "ocr_method": "pdf_direct_text",
-                "ocr_engine": "pdf_direct_text",
-                "ocr_page_count": total_pages,
-                "ocr_char_count": final_char_count,
-                "ocr_status": "concluido",
-            },
-        )
+    direct_char_count = len(re.sub(r"\s+", "", direct_text or ""))
+    direct_text_min_chars = 100
+    min_chars_per_page = 50
+    should_fallback = (
+        not direct_text
+        or direct_char_count < direct_text_min_chars
+        or (total_pages > 0 and (direct_char_count / total_pages) < min_chars_per_page)
+    )
+    fallback_reason = None
+    if not direct_text:
+        fallback_reason = "direct_text_empty"
+    elif direct_char_count < direct_text_min_chars:
+        fallback_reason = "direct_text_below_min_chars"
+    elif total_pages > 0 and (direct_char_count / total_pages) < min_chars_per_page:
+        fallback_reason = "direct_text_below_min_chars_per_page"
+
+    logger.info(
+        "pdf_direct_text_evaluation",
+        extra={
+            "ocr_page_count": total_pages,
+            "ocr_char_count": direct_char_count,
+            "ocr_fallback": should_fallback,
+            "ocr_fallback_reason": fallback_reason,
+        },
+    )
+
+    if not should_fallback:
         result = _build_extraction_result(
             direct_text,
             method="pdf_direct_text",
@@ -450,12 +469,42 @@ def extract_text_from_pdf(
             pages_success=total_pages if direct_text.strip() else 0,
             pages_failed=0 if direct_text.strip() else total_pages,
         )
+        final_char_count = len(re.sub(r"\s+", "", result["text"] or ""))
+        logger.info(
+            "ocr_result_selected",
+            extra={
+                "ocr_method": result["method"],
+                "ocr_engine": result["method"],
+                "ocr_page_count": result["total_pages"],
+                "ocr_pages_success": result["pages_success"],
+                "ocr_pages_failed": result["pages_failed"],
+                "ocr_char_count": final_char_count,
+                "ocr_status": "concluido",
+            },
+        )
+        logger.info(
+            "ocr_processing_finished",
+            extra={
+                "ocr_method": result["method"],
+                "ocr_engine": result["method"],
+                "ocr_processing_time_seconds": round(time.monotonic() - started_at, 4),
+                "ocr_status": "concluido",
+            },
+        )
         return result if return_metadata else result["text"]
 
     if not (convert_from_path and Image and pytesseract):
         logger.warning("pdf2image, PIL ou pytesseract indisponivel para %s", path)
         result = _build_extraction_result("", method="pdf_ocr_page_by_page")
         return result if return_metadata else result["text"]
+    logger.info(
+        "ocr_fallback_started",
+        extra={
+            "ocr_page_count": total_pages,
+            "ocr_fallback_reason": fallback_reason or "direct_text_low_yield",
+            "ocr_status": "baixo_aproveitamento",
+        },
+    )
     try:
         images = convert_from_path(path, dpi=300)
     except Exception as e:  # pragma: no cover - erro ao converter
@@ -463,7 +512,6 @@ def extract_text_from_pdf(
         result = _build_extraction_result("", method="pdf_ocr_page_by_page")
         return result if return_metadata else result["text"]
     text_parts: list[str] = []
-    total_pages = len(images) or 1
     logger.info(
         "pdf_ocr_page_by_page",
         extra={
@@ -497,27 +545,47 @@ def extract_text_from_pdf(
             text_parts.append("")
     pages_success = sum(1 for txt in text_parts if (txt or "").strip())
     final_text = "\n".join(text_parts)
-    final_char_count = len(final_text.strip())
+    final_char_count = len(re.sub(r"\s+", "", final_text or ""))
+    pages_failed = max(total_pages - pages_success, 0)
     logger.info(
-        "pdf_ocr_page_by_page",
+        "ocr_result_selected",
         extra={
             "ocr_method": "pdf_ocr_page_by_page",
             "ocr_engine": "pdf_ocr_page_by_page",
-            "ocr_page_count": total_pages or 1,
+            "ocr_page_count": total_pages,
             "ocr_pages_success": pages_success,
-            "ocr_pages_failed": max((total_pages or 1) - pages_success, 0),
+            "ocr_pages_failed": pages_failed,
             "ocr_char_count": final_char_count,
-            "ocr_status": "concluido",
+            "ocr_status": "concluido" if final_char_count else "baixo_aproveitamento",
+        },
+    )
+    logger.info(
+        "ocr_processing_finished",
+        extra={
+            "ocr_method": "pdf_ocr_page_by_page",
+            "ocr_engine": "pdf_ocr_page_by_page",
+            "ocr_processing_time_seconds": round(time.monotonic() - started_at, 4),
+            "ocr_status": "concluido" if final_char_count else "baixo_aproveitamento",
         },
     )
     result = _build_extraction_result(
         final_text,
         method="pdf_ocr_page_by_page",
-        total_pages=total_pages or 1,
+        total_pages=total_pages,
         pages_success=pages_success,
-        pages_failed=max((total_pages or 1) - pages_success, 0),
+        pages_failed=pages_failed,
     )
     return result if return_metadata else result["text"]
+
+
+def _get_pdf_total_pages(path: str) -> int:
+    if not PdfReader:  # pragma: no cover
+        return 1
+    try:
+        return max(len(PdfReader(path).pages), 1)
+    except Exception as e:  # pragma: no cover
+        logger.warning("Falha ao detectar total de paginas de %s: %s", path, e)
+        return 1
 
 
 def _extract_pdf_text_without_ocr(path: str, sample_pages: int = 3) -> str:

--- a/tests/test_ocr_postprocess.py
+++ b/tests/test_ocr_postprocess.py
@@ -1,5 +1,4 @@
 import types
-import os
 from PIL import Image
 from core.utils import extract_text_from_pdf
 
@@ -114,3 +113,55 @@ def test_detect_sparse(monkeypatch, tmp_path):
     calls["count"] = 0
     text2 = extract_text_from_pdf(str(pdf), reorder=True, clean=True, detect_sparse=False)
     assert calls["count"] == 0
+
+
+def test_pdf_direct_text_sufficient_skips_convert_from_path(monkeypatch, tmp_path):
+    pdf = tmp_path / "sample.pdf"
+    create_dummy_pdf(pdf)
+
+    monkeypatch.setattr("core.utils._get_pdf_total_pages", lambda p: 2)
+    monkeypatch.setattr("core.utils._extract_pdf_text_without_ocr", lambda p: "A" * 220)
+    monkeypatch.setattr("core.utils.convert_from_path", lambda p, dpi=300: (_ for _ in ()).throw(AssertionError("não deveria chamar OCR por página")))
+
+    result = extract_text_from_pdf(str(pdf), return_metadata=True)
+    assert result["method"] == "pdf_direct_text"
+    assert result["total_pages"] == 2
+
+
+def test_pdf_direct_text_low_yield_fallbacks_to_page_ocr(monkeypatch, tmp_path):
+    pdf = tmp_path / "scan.pdf"
+    create_dummy_pdf(pdf)
+    img = Image.new("RGB", (800, 800), "white")
+    calls = {"preprocess": 0, "extract": 0}
+
+    monkeypatch.setattr("core.utils._get_pdf_total_pages", lambda p: 4)
+    monkeypatch.setattr("core.utils._extract_pdf_text_without_ocr", lambda p: "abc")
+    monkeypatch.setattr("core.utils.convert_from_path", lambda p, dpi=300: [img, img, img, img])
+
+    def fake_preprocess(image, **kwargs):
+        calls["preprocess"] += 1
+        return image
+
+    def fake_extract(image, **kwargs):
+        calls["extract"] += 1
+        return "texto ocr"
+
+    monkeypatch.setattr("core.utils.preprocess_image", fake_preprocess)
+    monkeypatch.setattr("core.utils.extract_text_from_image", fake_extract)
+
+    result = extract_text_from_pdf(str(pdf), return_metadata=True)
+    assert result["method"] == "pdf_ocr_page_by_page"
+    assert result["total_pages"] == 4
+    assert calls["preprocess"] == 4
+    assert calls["extract"] == 4
+
+
+def test_total_pages_comes_from_pdf_counter_not_newlines(monkeypatch, tmp_path):
+    pdf = tmp_path / "lines.pdf"
+    create_dummy_pdf(pdf)
+    monkeypatch.setattr("core.utils._get_pdf_total_pages", lambda p: 4)
+    monkeypatch.setattr("core.utils._extract_pdf_text_without_ocr", lambda p: "linha1\nlinha2\nlinha3\nlinha4\nlinha5\n" + ("x" * 250))
+    monkeypatch.setattr("core.utils.convert_from_path", lambda p, dpi=300: (_ for _ in ()).throw(AssertionError("não deveria chamar OCR por página")))
+
+    result = extract_text_from_pdf(str(pdf), return_metadata=True)
+    assert result["total_pages"] == 4


### PR DESCRIPTION
## Resumo
Ajusta o pipeline de OCR de PDFs para preservar o caminho rápido de texto direto em PDFs pesquisáveis e garantir fallback real para OCR por página quando o aproveitamento do texto direto é baixo.

## Principais mudanças
- Implementa detecção confiável de total de páginas via `_get_pdf_total_pages(path)` (com `PdfReader`).
- Remove contagem de páginas baseada em quebras de linha (`direct_text.count("\n") + 1`).
- Reorganiza fluxo de retorno para evitar retorno antecipado que bloqueava o fallback.
- Mantém extração direta quando o aproveitamento é suficiente (`method=pdf_direct_text`).
- Dispara OCR página a página (`dpi=300`) quando texto direto está vazio/insuficiente.
- Mantém preprocessamento OpenCV + Tesseract (`--oem 3 --psm 6`) no fluxo OCR.
- Corrige métricas de páginas/caracteres com base no total real de páginas.
- Adiciona logs diagnósticos para:
  - `pdf_page_count_detected`
  - `pdf_direct_text_evaluation`
  - `ocr_fallback_started`
  - `pdf_ocr_page_by_page`
  - `ocr_result_selected`
  - `ocr_processing_finished`

## Testes
- Atualiza `tests/test_ocr_postprocess.py` para cobrir:
  - PDF com texto direto suficiente não chama `convert_from_path`.
  - PDF com texto direto baixo faz fallback para OCR por página.
  - `total_pages` vem da contagem real do PDF (não de quebras de linha).
  - Fallback de baixo aproveitamento passa por `preprocess_image` e `extract_text_from_image`.

Comando executado:
- `pytest tests/test_ocr_postprocess.py` ✅ (5 passed)


------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa1ebe80a4832eb24369dac2258b3e)