### PR TITLE
Reutiliza `direct_char_count` para `final_char_count` no fluxo PDF sem OCR

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -469,7 +469,7 @@ def extract_text_from_pdf(
             pages_success=total_pages if direct_text.strip() else 0,
             pages_failed=0 if direct_text.strip() else total_pages,
         )
-        final_char_count = len(re.sub(r"\s+", "", result["text"] or ""))
+        final_char_count = direct_char_count
         logger.info(
             "ocr_result_selected",
             extra={


### PR DESCRIPTION
### Motivation
- Corrigir redundância e manter consistência de métricas/logs no fluxo de OCR de PDF, garantindo que `total_pages` siga vindo de `_get_pdf_total_pages(path)` e eliminando cálculos duplicados de contagem de caracteres.

### Description
- Em `core/utils.py` substituí `final_char_count = len(re.sub(r"\s+", "", result["text"] or ""))` por `final_char_count = direct_char_count` no caminho de texto direto do PDF para evitar recomputação desnecessária.

### Testing
- Executei `pytest -q tests/test_ocr_postprocess.py` e obteve `5 passed`; e executei `pytest -q tests/test_ocr_queue.py tests/test_article_logging.py` obtendo `7 passed` com avisos decompatibilidade do SQLAlchemy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa219cfe50832eb43273b03a1a0c9d)