### PR TITLE
Add article version snapshot history

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -379,6 +379,8 @@ class Article(db.Model):
     )
     created_at = db.Column(db.DateTime(timezone=True), nullable=False, server_default=func.now())
     updated_at = db.Column(db.DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+    current_version_number = db.Column(db.Integer, nullable=False, default=0, server_default='0')
+    current_revision_number = db.Column(db.Integer, nullable=False, default=1, server_default='1')
     arquivos = db.Column(db.Text, nullable=True)  # JSON list of filenames (se for o caso, ou remover se Attachment substitui)
     review_comment = db.Column(db.Text, nullable=True) # Comentário da última revisão
     tipo_id = db.Column(db.Integer, db.ForeignKey('artigo_tipo.id'), nullable=True)
@@ -400,12 +402,68 @@ class Article(db.Model):
     revision_requests = db.relationship('RevisionRequest', back_populates='article', lazy='dynamic', cascade='all, delete-orphan')
     attachments = db.relationship('Attachment', back_populates='article', lazy='dynamic', cascade='all, delete-orphan')
     comments = db.relationship('Comment', back_populates='artigo', lazy='dynamic', cascade='all, delete-orphan')
+    versions = db.relationship('ArticleVersion', back_populates='article', lazy='dynamic', cascade='all, delete-orphan')
     tipo = db.relationship('ArtigoTipo')
     area = db.relationship('ArtigoArea')
     sistema = db.relationship('ArtigoSistema')
 
     def __repr__(self):
         return f"<Article {self.titulo}>"
+
+
+class ArticleVersion(db.Model):
+    __tablename__ = "article_version"
+
+    id = db.Column(db.Integer, primary_key=True)
+    article_id = db.Column(db.Integer, db.ForeignKey('article.id', ondelete='CASCADE'), nullable=False)
+    version_number = db.Column(db.Integer, nullable=False)
+    revision_number = db.Column(db.Integer, nullable=False)
+
+    # Snapshot textual e metadados do artigo no momento da alteração.
+    titulo = db.Column(db.String(200), nullable=False)
+    texto = db.Column(db.Text, nullable=False)
+    status = db.Column(db.String(32), nullable=False)
+    visibility = db.Column(db.String(32), nullable=False)
+    tipo_id = db.Column(db.Integer, nullable=True)
+    area_id = db.Column(db.Integer, nullable=True)
+    sistema_id = db.Column(db.Integer, nullable=True)
+    instituicao_id = db.Column(db.Integer, nullable=True)
+    estabelecimento_id = db.Column(db.Integer, nullable=True)
+    setor_id = db.Column(db.Integer, nullable=True)
+    vis_celula_id = db.Column(db.Integer, nullable=True)
+    celula_id = db.Column(db.Integer, nullable=True)
+    user_id_original_author = db.Column(db.Integer, nullable=True)
+
+    # Snapshot do usuário que provocou a mudança para preservar auditoria histórica.
+    changed_by_user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
+    changed_by_username = db.Column(db.String(80), nullable=True)
+    changed_by_email = db.Column(db.String(120), nullable=True)
+    changed_by_nome_completo = db.Column(db.String(255), nullable=True)
+
+    change_action = db.Column(db.String(64), nullable=False)
+    change_reason = db.Column(db.Text, nullable=True)
+    source_status_before = db.Column(db.String(32), nullable=True)
+    source_status_after = db.Column(db.String(32), nullable=True)
+
+    title_char_count = db.Column(db.Integer, nullable=False, default=0, server_default='0')
+    text_char_count = db.Column(db.Integer, nullable=False, default=0, server_default='0')
+    text_word_count = db.Column(db.Integer, nullable=False, default=0, server_default='0')
+    content_hash = db.Column(db.String(64), nullable=True)
+    previous_text_char_count = db.Column(db.Integer, nullable=True)
+    text_reduction_percent = db.Column(db.Float, nullable=True)
+    drastic_reduction_detected = db.Column(db.Boolean, nullable=False, default=False, server_default='false')
+    correlation_id = db.Column(db.String(255), nullable=True)
+
+    created_at = db.Column(db.DateTime(timezone=True), nullable=False, server_default=func.now())
+
+    article = db.relationship('Article', back_populates='versions')
+    changed_by = db.relationship('User', foreign_keys=[changed_by_user_id])
+
+    def __repr__(self):
+        return (
+            f"<ArticleVersion article_id={self.article_id} "
+            f"v={self.version_number} r={self.revision_number}>"
+        )
 
 class RevisionRequest(db.Model):
     __tablename__ = 'revision_request'

--- a/migrations/versions/b4c7d9e1f2a3_add_article_version_table.py
+++ b/migrations/versions/b4c7d9e1f2a3_add_article_version_table.py
@@ -1,0 +1,247 @@
+"""add article version table
+
+Revision ID: b4c7d9e1f2a3
+Revises: aa91c3d7e5f1
+Create Date: 2026-05-06 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b4c7d9e1f2a3'
+down_revision = 'aa91c3d7e5f1'
+branch_labels = None
+depends_on = None
+
+
+def _insert_initial_snapshots_postgresql():
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO article_version (
+                article_id,
+                version_number,
+                revision_number,
+                titulo,
+                texto,
+                status,
+                visibility,
+                tipo_id,
+                area_id,
+                sistema_id,
+                instituicao_id,
+                estabelecimento_id,
+                setor_id,
+                vis_celula_id,
+                celula_id,
+                user_id_original_author,
+                changed_by_user_id,
+                changed_by_username,
+                changed_by_email,
+                changed_by_nome_completo,
+                change_action,
+                source_status_before,
+                source_status_after,
+                title_char_count,
+                text_char_count,
+                text_word_count,
+                content_hash,
+                drastic_reduction_detected,
+                created_at
+            )
+            SELECT
+                a.id,
+                a.current_version_number,
+                a.current_revision_number,
+                a.titulo,
+                a.texto,
+                a.status::text,
+                COALESCE(a.visibility::text, 'celula'),
+                a.tipo_id,
+                a.area_id,
+                a.sistema_id,
+                a.instituicao_id,
+                a.estabelecimento_id,
+                a.setor_id,
+                a.vis_celula_id,
+                a.celula_id,
+                a.user_id,
+                a.user_id,
+                u.username,
+                u.email,
+                u.nome_completo,
+                'migration_initial_snapshot',
+                NULL,
+                a.status::text,
+                char_length(COALESCE(a.titulo, '')),
+                char_length(COALESCE(a.texto, '')),
+                CASE
+                    WHEN btrim(COALESCE(a.texto, '')) = '' THEN 0
+                    ELSE cardinality(regexp_split_to_array(btrim(a.texto), '\\s+'))
+                END,
+                md5(concat_ws(chr(31), COALESCE(a.titulo, ''), COALESCE(a.texto, ''), a.status::text, COALESCE(a.visibility::text, 'celula'))),
+                false,
+                COALESCE(a.created_at, CURRENT_TIMESTAMP)
+            FROM article a
+            LEFT JOIN "user" u ON u.id = a.user_id
+            """
+        )
+    )
+
+
+def _insert_initial_snapshots_generic():
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO article_version (
+                article_id,
+                version_number,
+                revision_number,
+                titulo,
+                texto,
+                status,
+                visibility,
+                tipo_id,
+                area_id,
+                sistema_id,
+                instituicao_id,
+                estabelecimento_id,
+                setor_id,
+                vis_celula_id,
+                celula_id,
+                user_id_original_author,
+                changed_by_user_id,
+                changed_by_username,
+                changed_by_email,
+                changed_by_nome_completo,
+                change_action,
+                source_status_before,
+                source_status_after,
+                title_char_count,
+                text_char_count,
+                text_word_count,
+                drastic_reduction_detected,
+                created_at
+            )
+            SELECT
+                a.id,
+                a.current_version_number,
+                a.current_revision_number,
+                a.titulo,
+                a.texto,
+                a.status,
+                COALESCE(a.visibility, 'celula'),
+                a.tipo_id,
+                a.area_id,
+                a.sistema_id,
+                a.instituicao_id,
+                a.estabelecimento_id,
+                a.setor_id,
+                a.vis_celula_id,
+                a.celula_id,
+                a.user_id,
+                a.user_id,
+                u.username,
+                u.email,
+                u.nome_completo,
+                'migration_initial_snapshot',
+                NULL,
+                a.status,
+                length(COALESCE(a.titulo, '')),
+                length(COALESCE(a.texto, '')),
+                0,
+                false,
+                COALESCE(a.created_at, CURRENT_TIMESTAMP)
+            FROM article a
+            LEFT JOIN "user" u ON u.id = a.user_id
+            """
+        )
+    )
+
+
+def upgrade():
+    op.add_column(
+        'article',
+        sa.Column('current_version_number', sa.Integer(), nullable=False, server_default='0'),
+    )
+    op.add_column(
+        'article',
+        sa.Column('current_revision_number', sa.Integer(), nullable=False, server_default='1'),
+    )
+
+    op.create_table(
+        'article_version',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('article_id', sa.Integer(), nullable=False),
+        sa.Column('version_number', sa.Integer(), nullable=False),
+        sa.Column('revision_number', sa.Integer(), nullable=False),
+        sa.Column('titulo', sa.String(length=200), nullable=False),
+        sa.Column('texto', sa.Text(), nullable=False),
+        sa.Column('status', sa.String(length=32), nullable=False),
+        sa.Column('visibility', sa.String(length=32), nullable=False),
+        sa.Column('tipo_id', sa.Integer(), nullable=True),
+        sa.Column('area_id', sa.Integer(), nullable=True),
+        sa.Column('sistema_id', sa.Integer(), nullable=True),
+        sa.Column('instituicao_id', sa.Integer(), nullable=True),
+        sa.Column('estabelecimento_id', sa.Integer(), nullable=True),
+        sa.Column('setor_id', sa.Integer(), nullable=True),
+        sa.Column('vis_celula_id', sa.Integer(), nullable=True),
+        sa.Column('celula_id', sa.Integer(), nullable=True),
+        sa.Column('user_id_original_author', sa.Integer(), nullable=True),
+        sa.Column('changed_by_user_id', sa.Integer(), nullable=True),
+        sa.Column('changed_by_username', sa.String(length=80), nullable=True),
+        sa.Column('changed_by_email', sa.String(length=120), nullable=True),
+        sa.Column('changed_by_nome_completo', sa.String(length=255), nullable=True),
+        sa.Column('change_action', sa.String(length=64), nullable=False),
+        sa.Column('change_reason', sa.Text(), nullable=True),
+        sa.Column('source_status_before', sa.String(length=32), nullable=True),
+        sa.Column('source_status_after', sa.String(length=32), nullable=True),
+        sa.Column('title_char_count', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('text_char_count', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('text_word_count', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('content_hash', sa.String(length=64), nullable=True),
+        sa.Column('previous_text_char_count', sa.Integer(), nullable=True),
+        sa.Column('text_reduction_percent', sa.Float(), nullable=True),
+        sa.Column('drastic_reduction_detected', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('correlation_id', sa.String(length=255), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.ForeignKeyConstraint(['article_id'], ['article.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['changed_by_user_id'], ['user.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_article_version_article_id', 'article_version', ['article_id'], unique=False)
+    op.create_index(
+        'ix_article_version_article_version_revision',
+        'article_version',
+        ['article_id', 'version_number', 'revision_number'],
+        unique=False,
+    )
+    op.create_index('ix_article_version_created_at', 'article_version', ['created_at'], unique=False)
+    op.create_index('ix_article_version_changed_by_user_id', 'article_version', ['changed_by_user_id'], unique=False)
+
+    op.execute(
+        sa.text(
+            """
+            UPDATE article
+            SET current_version_number = CASE WHEN status = 'aprovado' THEN 1 ELSE 0 END,
+                current_revision_number = CASE WHEN status = 'aprovado' THEN 0 ELSE 1 END
+            """
+        )
+    )
+
+    bind = op.get_bind()
+    if bind.dialect.name == 'postgresql':
+        _insert_initial_snapshots_postgresql()
+    else:
+        _insert_initial_snapshots_generic()
+
+
+def downgrade():
+    op.drop_index('ix_article_version_changed_by_user_id', table_name='article_version')
+    op.drop_index('ix_article_version_created_at', table_name='article_version')
+    op.drop_index('ix_article_version_article_version_revision', table_name='article_version')
+    op.drop_index('ix_article_version_article_id', table_name='article_version')
+    op.drop_table('article_version')
+    op.drop_column('article', 'current_revision_number')
+    op.drop_column('article', 'current_version_number')


### PR DESCRIPTION
### Motivation
- Provide an append-only, audit-friendly history of article state by storing textual snapshots and metadata at each change. 
- Ensure existing articles are backfilled safely so the history starts populated and code can reason about current version/revision without changing existing flows.

### Description
- Add `ArticleVersion` model (`__tablename__ = "article_version"`) that stores textual snapshot fields (`titulo`, `texto`), metadata (`status`, `visibility`, `tipo_id`, `area_id`, `sistema_id`, `instituicao_id`, `estabelecimento_id`, `setor_id`, `vis_celula_id`, `celula_id`, `user_id_original_author`), changer snapshot (`changed_by_user_id`, `changed_by_username`, `changed_by_email`, `changed_by_nome_completo`), audit fields (`change_action`, `change_reason`, `source_status_before`, `source_status_after`), counters and hashes (`title_char_count`, `text_char_count`, `text_word_count`, `content_hash`, `previous_text_char_count`, `text_reduction_percent`, `drastic_reduction_detected`) and `correlation_id`, plus `created_at` and relationships. 
- Add `Article.versions = db.relationship("ArticleVersion", back_populates="article", lazy="dynamic", cascade="all, delete-orphan")` and add `Article.current_version_number` and `Article.current_revision_number` with compatible defaults. 
- Add Alembic migration `migrations/versions/b4c7d9e1f2a3_add_article_version_table.py` that creates the `article_version` table, foreign keys, and indexes for `article_id`, `(article_id, version_number, revision_number)`, `created_at` and `changed_by_user_id`, updates `article.current_version_number`/`current_revision_number` according to `status`, and inserts an initial snapshot for each existing `article` using a PostgreSQL-specific SQL path and a generic fallback. 
- Table is intended as append-only and no routes/forms to edit `ArticleVersion` were added. 

### Testing
- Compiled modified modules with `python -m py_compile core/models.py migrations/versions/b4c7d9e1f2a3_add_article_version_table.py` and the compile step succeeded. 
- Ran the unit tests `pytest tests/test_article_editing.py tests/test_article_approval_review.py` and the test suite passed (`14 passed`). 
- Performed an in-memory Alembic upgrade smoke test that exercised the new migration and validated initial snapshot insertion (asserted `change_action = 'migration_initial_snapshot'`) and the smoke test succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb3df8eb88832e84bd6dcca01258fe)