### PR TITLE
Add transactional article version snapshots

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -54,6 +54,20 @@ except ImportError:  # pragma: no cover
         enqueue_attachment_for_ocr,
         is_pdf_ocr_eligible,
     )
+
+try:
+    from ..core.services.article_versions import (
+        article_relevant_state_changed,
+        calculate_text_char_count,
+        create_article_version_snapshot,
+    )
+except ImportError:  # pragma: no cover
+    from core.services.article_versions import (
+        article_relevant_state_changed,
+        calculate_text_char_count,
+        create_article_version_snapshot,
+    )
+
 try:
     from ..core.progress import (
         clear_progress,
@@ -278,6 +292,15 @@ def novo_artigo():
             )
             db.session.add(artigo)
             db.session.flush()
+            create_article_version_snapshot(
+                artigo,
+                user,
+                "create_initial",
+                source_status_after=status,
+                force_version=0,
+                force_revision=1,
+                correlation_id=correlation_id,
+            )
 
             # 3) Salva arquivos com nome único, extrai texto e cria Attachments
             filenames = []
@@ -328,7 +351,18 @@ def novo_artigo():
             # 4) Atualiza o campo JSON de nomes no artigo
             artigo.arquivos = json.dumps(filenames) if filenames else None
 
-            # 5) Persiste tudo num único commit
+            # 5) Notifica responsáveis/admins, se necessário
+            if status is ArticleStatus.PENDENTE:
+                destinatarios = eligible_review_notification_users(artigo)
+                for dest in destinatarios:
+                    notif = Notification(
+                        user_id = dest.id,
+                        message = f'Novo artigo pendente para revisão: “{artigo.titulo}”',
+                        url     = url_for('aprovacao_detail', artigo_id=artigo.id)
+                    )
+                    db.session.add(notif)
+
+            # 6) Persiste artigo, anexos, snapshot e notificações num único commit
             db.session.commit()
             mark_progress_done(progress_id)
             log_article_event(
@@ -341,18 +375,6 @@ def novo_artigo():
                 progress_id=progress_id,
                 correlation_id=correlation_id,
             )
-
-            # 6) Notifica responsáveis/admins, se necessário
-            if status is ArticleStatus.PENDENTE:
-                destinatarios = eligible_review_notification_users(artigo)
-                for dest in destinatarios:
-                    notif = Notification(
-                        user_id = dest.id,
-                        message = f'Novo artigo pendente para revisão: “{artigo.titulo}”',
-                        url     = url_for('aprovacao_detail', artigo_id=artigo.id)
-                    )
-                    db.session.add(notif)
-                db.session.commit()
         except RequestEntityTooLarge:
             db.session.rollback()
             flash('Erro de upload: o tamanho dos anexos excede o limite permitido.', 'danger')
@@ -457,8 +479,33 @@ def artigo(artigo_id):
             flash('Permissão negada.', 'danger')
             return redirect(url_for('artigo', artigo_id=artigo_id))
         # 1) campos básicos
-        artigo.titulo = request.form['titulo']
-        artigo.texto  = request.form['texto']
+        novo_titulo = request.form['titulo']
+        novo_texto = request.form['texto']
+        status_before = artigo.status
+        if article_relevant_state_changed(
+            artigo,
+            titulo=novo_titulo,
+            texto=novo_texto,
+            status=ArticleStatus.PENDENTE,
+        ):
+            snapshot_action = (
+                "edit_after_approved"
+                if status_before is ArticleStatus.APROVADO
+                else "submit_for_approval"
+            )
+            create_article_version_snapshot(
+                artigo,
+                user,
+                snapshot_action,
+                source_status_before=status_before,
+                source_status_after=ArticleStatus.PENDENTE,
+                correlation_id=getattr(g, "request_correlation_id", None),
+                drastic_reduction_data={
+                    "previous_text_char_count": calculate_text_char_count(artigo.texto),
+                },
+            )
+        artigo.titulo = novo_titulo
+        artigo.texto  = novo_texto
         artigo.status = ArticleStatus.PENDENTE
         artigo.updated_at = datetime.now(timezone.utc)
 
@@ -697,6 +744,7 @@ def editar_artigo(artigo_id):
         ArticleStatus.EM_REVISAO.value,
         ArticleStatus.EM_AJUSTE.value,
         ArticleStatus.REJEITADO.value,
+        ArticleStatus.APROVADO.value,
     }
     can_submit_actions = True
 
@@ -742,12 +790,9 @@ def editar_artigo(artigo_id):
             flash('Se você selecionou anexos, será necessário reenviá-los após corrigir o formulário (limitação de multipart).', 'info')
             return _render_editar_artigo_form(artigo, json.loads(artigo.arquivos or "[]"), can_submit_actions, form_data)
 
-        artigo.titulo = titulo
-        artigo.texto  = texto
-        artigo.tipo_id = request.form.get('tipo_id', type=int)
-        artigo.area_id = request.form.get('area_id', type=int)
-        artigo.sistema_id = request.form.get('sistema_id', type=int)
-        artigo.updated_at = datetime.now(timezone.utc)
+        tipo_id = request.form.get('tipo_id', type=int)
+        area_id = request.form.get('area_id', type=int)
+        sistema_id = request.form.get('sistema_id', type=int)
 
         # visibilidade
         user = User.query.filter_by(username=session["username"]).first()
@@ -766,13 +811,55 @@ def editar_artigo(artigo_id):
         elif vis is ArticleVisibility.CELULA:
             vis_cel_id = user.celula_id
 
-        artigo.visibility = vis
-        artigo.instituicao_id = inst_id
-        artigo.estabelecimento_id = est_id
-        artigo.setor_id = setor_vis_id
-        artigo.vis_celula_id = vis_cel_id
+        status_before = artigo.status
+        status_after = ArticleStatus.PENDENTE if acao == "enviar" else artigo.status
+        relevant_change = article_relevant_state_changed(
+            artigo,
+            titulo=titulo,
+            texto=texto,
+            tipo_id=tipo_id,
+            area_id=area_id,
+            sistema_id=sistema_id,
+            visibility=vis,
+            instituicao_id=inst_id,
+            estabelecimento_id=est_id,
+            setor_id=setor_vis_id,
+            vis_celula_id=vis_cel_id,
+            status=status_after,
+        )
 
         try:
+            if relevant_change:
+                if acao == "enviar":
+                    snapshot_action = "submit_for_approval"
+                elif status_value == ArticleStatus.APROVADO.value:
+                    snapshot_action = "edit_after_approved"
+                else:
+                    snapshot_action = "edit"
+                create_article_version_snapshot(
+                    artigo,
+                    user,
+                    snapshot_action,
+                    source_status_before=status_before,
+                    source_status_after=status_after,
+                    correlation_id=correlation_id,
+                    drastic_reduction_data={
+                        "previous_text_char_count": calculate_text_char_count(artigo.texto),
+                    },
+                )
+
+            artigo.titulo = titulo
+            artigo.texto  = texto
+            artigo.tipo_id = tipo_id
+            artigo.area_id = area_id
+            artigo.sistema_id = sistema_id
+            artigo.updated_at = datetime.now(timezone.utc)
+            artigo.visibility = vis
+            artigo.instituicao_id = inst_id
+            artigo.estabelecimento_id = est_id
+            artigo.setor_id = setor_vis_id
+            artigo.vis_celula_id = vis_cel_id
+
             # anexos ─ exclusões + novos
             existing = json.loads(artigo.arquivos or "[]")
 
@@ -1033,37 +1120,65 @@ def aprovacao_detail(artigo_id):
             flash('Comentário é obrigatório.', 'warning')
             return redirect(url_for('aprovacao_detail', artigo_id=artigo_id))
 
-        # 1) Atualiza o status -------------------------------------------------
+        # 1) Define a decisão de status ---------------------------------------
+        status_before = artigo.status
         if acao == 'aprovar':
             if not user_can_approve_article(user, artigo):
                 flash('Permissão negada.', 'danger')
                 return redirect(url_for('aprovacao_detail', artigo_id=artigo_id))
-            artigo.status = ArticleStatus.APROVADO
+            target_status = ArticleStatus.APROVADO
             msg = f"Artigo '{artigo.titulo}' aprovado!"
         elif acao == 'ajustar':
             if not user_can_review_article(user, artigo):
                 flash('Permissão negada.', 'danger')
                 return redirect(url_for('aprovacao_detail', artigo_id=artigo_id))
-            artigo.status = ArticleStatus.EM_AJUSTE
+            target_status = ArticleStatus.EM_AJUSTE
             msg = f"Artigo '{artigo.titulo}' marcado como Em Ajuste."
         elif acao == 'rejeitar':
             if not user_can_review_article(user, artigo):
                 flash('Permissão negada.', 'danger')
                 return redirect(url_for('aprovacao_detail', artigo_id=artigo_id))
-            artigo.status = ArticleStatus.REJEITADO
+            target_status = ArticleStatus.REJEITADO
             msg = f"Artigo '{artigo.titulo}' rejeitado!"
         else:
             flash('Ação desconhecida.', 'warning')
             return redirect(url_for('aprovacao_detail', artigo_id=artigo_id))
 
-        # 2) Registra comentário de ajuste/aprovação/rejeição ------------------
+        # 2) Versiona a decisão e registra comentário/notificação no mesmo commit
+        snapshot_action = {
+            'aprovar': 'approve',
+            'ajustar': 'request_adjustment',
+            'rejeitar': 'reject',
+        }[acao]
+        if acao == 'aprovar':
+            artigo.status = target_status
+            create_article_version_snapshot(
+                artigo,
+                user,
+                snapshot_action,
+                change_reason=comentario,
+                source_status_before=status_before,
+                source_status_after=target_status,
+                correlation_id=getattr(g, "request_correlation_id", None),
+            )
+        else:
+            create_article_version_snapshot(
+                artigo,
+                user,
+                snapshot_action,
+                change_reason=comentario,
+                source_status_before=status_before,
+                source_status_after=target_status,
+                correlation_id=getattr(g, "request_correlation_id", None),
+            )
+            artigo.status = target_status
+
         novo_comment = Comment(
             artigo_id = artigo.id,
             user_id   = user.id,
             texto     = comentario
         )
         db.session.add(novo_comment)
-        db.session.commit()
 
         # 3) Notifica autor com o status correto ------------------------------
         notif = Notification(
@@ -1118,8 +1233,17 @@ def solicitar_revisao(artigo_id):
         )
         db.session.add(rr)
 
+        status_before = artigo.status
+        create_article_version_snapshot(
+            artigo,
+            user,
+            "request_revision",
+            change_reason=comentario,
+            source_status_before=status_before,
+            source_status_after=ArticleStatus.EM_REVISAO,
+            correlation_id=getattr(g, "request_correlation_id", None),
+        )
         artigo.status = ArticleStatus.EM_REVISAO
-        db.session.commit()
 
         destinatarios = [artigo.author] + [u for u in User.query.all() if u.has_permissao('admin')]
         for u in destinatarios:

--- a/core/models.py
+++ b/core/models.py
@@ -439,6 +439,10 @@ class ArticleVersion(db.Model):
     changed_by_username = db.Column(db.String(80), nullable=True)
     changed_by_email = db.Column(db.String(120), nullable=True)
     changed_by_nome_completo = db.Column(db.String(255), nullable=True)
+    changed_by_cargo_nome = db.Column(db.String(200), nullable=True)
+    changed_by_setor_nome = db.Column(db.String(200), nullable=True)
+    changed_by_celula_nome = db.Column(db.String(200), nullable=True)
+    changed_by_estabelecimento_nome_fantasia = db.Column(db.String(200), nullable=True)
 
     change_action = db.Column(db.String(64), nullable=False)
     change_reason = db.Column(db.Text, nullable=True)

--- a/core/services/article_versions.py
+++ b/core/services/article_versions.py
@@ -1,0 +1,235 @@
+"""Helpers para snapshots e versionamento de artigos.
+
+As funções deste módulo apenas adicionam objetos à sessão ativa do SQLAlchemy e
+atualizam os contadores do artigo em memória. Elas não executam commit para que
+os fluxos chamadores mantenham artigo, anexos, notificações e snapshots no mesmo
+limite transacional.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+try:
+    from ..database import db
+    from ..enums import ArticleStatus, ArticleVisibility
+    from ..models import ArticleVersion
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from core.database import db
+    from core.enums import ArticleStatus, ArticleVisibility
+    from core.models import ArticleVersion
+
+_WORD_RE = re.compile(r"\S+", re.UNICODE)
+_TEXT_HASH_SEPARATOR = "\x1f"
+
+
+def _enum_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, (ArticleStatus, ArticleVisibility)):
+        return value.value
+    return str(value)
+
+
+def calculate_text_char_count(text: str | None) -> int:
+    """Conta caracteres do texto persistido no snapshot."""
+    return len(text or "")
+
+
+def calculate_text_word_count(text: str | None) -> int:
+    """Conta palavras por sequências não brancas, compatível com HTML sanitizado."""
+    normalized = (text or "").strip()
+    if not normalized:
+        return 0
+    return len(_WORD_RE.findall(normalized))
+
+
+def calculate_text_hash(article_or_text: Any, title: str | None = None, status: Any = None, visibility: Any = None) -> str:
+    """Gera hash SHA-256 estável do conteúdo textual e metadados principais.
+
+    O primeiro argumento pode ser um Article (preferencial) ou diretamente o
+    texto. Quando for Article, título/status/visibilidade são lidos dele.
+    """
+    if hasattr(article_or_text, "texto"):
+        article = article_or_text
+        text = article.texto
+        title = article.titulo
+        status = article.status
+        visibility = article.visibility
+    else:
+        text = article_or_text
+
+    payload = _TEXT_HASH_SEPARATOR.join(
+        [
+            title or "",
+            text or "",
+            _enum_value(status) or "",
+            _enum_value(visibility) or "",
+        ]
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def snapshot_changed_user(changed_by_user: Any | None) -> dict[str, Any]:
+    """Retorna um snapshot textual do usuário alterador e de sua hierarquia."""
+    if not changed_by_user:
+        return {
+            "changed_by_user_id": None,
+            "changed_by_username": None,
+            "changed_by_email": None,
+            "changed_by_nome_completo": None,
+            "changed_by_cargo_nome": None,
+            "changed_by_setor_nome": None,
+            "changed_by_celula_nome": None,
+            "changed_by_estabelecimento_nome_fantasia": None,
+        }
+
+    cargo = getattr(changed_by_user, "cargo", None)
+    setor = getattr(changed_by_user, "setor", None)
+    celula = getattr(changed_by_user, "celula", None)
+    estabelecimento = getattr(changed_by_user, "estabelecimento", None)
+    return {
+        "changed_by_user_id": getattr(changed_by_user, "id", None),
+        "changed_by_username": getattr(changed_by_user, "username", None),
+        "changed_by_email": getattr(changed_by_user, "email", None),
+        "changed_by_nome_completo": getattr(changed_by_user, "nome_completo", None),
+        "changed_by_cargo_nome": getattr(cargo, "nome", None),
+        "changed_by_setor_nome": getattr(setor, "nome", None),
+        "changed_by_celula_nome": getattr(celula, "nome", None),
+        "changed_by_estabelecimento_nome_fantasia": getattr(estabelecimento, "nome_fantasia", None),
+    }
+
+
+def _next_version_revision(article: Any, change_action: str) -> tuple[int, int]:
+    current_version = int(getattr(article, "current_version_number", 0) or 0)
+    current_revision = int(getattr(article, "current_revision_number", 0) or 0)
+
+    if change_action in {"create_initial", "initial_create"}:
+        return 0, 1
+    if change_action == "approve":
+        return current_version + 1, 0
+    # envio para aprovação, edição pós-aprovação, ajuste, rejeição, revisão e restauração.
+    return current_version, current_revision + 1
+
+
+def _drastic_reduction_metrics(text_char_count: int, drastic_reduction_data: dict[str, Any] | None) -> dict[str, Any]:
+    previous_count = None
+    threshold_percent = 50.0
+    if drastic_reduction_data:
+        previous_count = drastic_reduction_data.get("previous_text_char_count")
+        threshold_percent = float(drastic_reduction_data.get("threshold_percent", threshold_percent))
+
+    try:
+        previous_count = int(previous_count) if previous_count is not None else None
+    except (TypeError, ValueError):
+        previous_count = None
+
+    reduction_percent = None
+    detected = False
+    if previous_count and previous_count > 0 and text_char_count < previous_count:
+        reduction_percent = ((previous_count - text_char_count) / previous_count) * 100
+        detected = reduction_percent >= threshold_percent
+
+    return {
+        "previous_text_char_count": previous_count,
+        "text_reduction_percent": reduction_percent,
+        "drastic_reduction_detected": detected,
+    }
+
+
+def create_article_version_snapshot(
+    article,
+    changed_by_user,
+    change_action,
+    change_reason=None,
+    source_status_before=None,
+    source_status_after=None,
+    force_version=None,
+    force_revision=None,
+    correlation_id=None,
+    drastic_reduction_data=None,
+):
+    """Cria snapshot versionado do estado atual do artigo na sessão ativa.
+
+    A função atualiza `article.current_version_number` e
+    `article.current_revision_number`, adiciona `ArticleVersion` à sessão e
+    retorna a instância criada. Não há commit aqui por desenho transacional.
+    """
+    version_number, revision_number = _next_version_revision(article, change_action)
+    if force_version is not None:
+        version_number = int(force_version)
+    if force_revision is not None:
+        revision_number = int(force_revision)
+
+    titulo = article.titulo or ""
+    texto = article.texto or ""
+    text_char_count = calculate_text_char_count(texto)
+    metrics = _drastic_reduction_metrics(text_char_count, drastic_reduction_data)
+
+    snapshot = ArticleVersion(
+        article=article,
+        article_id=getattr(article, "id", None),
+        version_number=version_number,
+        revision_number=revision_number,
+        titulo=titulo,
+        texto=texto,
+        status=_enum_value(article.status) or ArticleStatus.RASCUNHO.value,
+        visibility=_enum_value(article.visibility) or ArticleVisibility.CELULA.value,
+        tipo_id=article.tipo_id,
+        area_id=article.area_id,
+        sistema_id=article.sistema_id,
+        instituicao_id=article.instituicao_id,
+        estabelecimento_id=article.estabelecimento_id,
+        setor_id=article.setor_id,
+        vis_celula_id=article.vis_celula_id,
+        celula_id=article.celula_id,
+        user_id_original_author=article.user_id,
+        change_action=change_action,
+        change_reason=change_reason,
+        source_status_before=_enum_value(source_status_before),
+        source_status_after=_enum_value(source_status_after),
+        title_char_count=len(titulo),
+        text_char_count=text_char_count,
+        text_word_count=calculate_text_word_count(texto),
+        content_hash=calculate_text_hash(article),
+        correlation_id=correlation_id,
+        created_at=datetime.now(timezone.utc),
+        **snapshot_changed_user(changed_by_user),
+        **metrics,
+    )
+    article.current_version_number = version_number
+    article.current_revision_number = revision_number
+    db.session.add(snapshot)
+    return snapshot
+
+
+RELEVANT_ARTICLE_FIELDS = (
+    "titulo",
+    "texto",
+    "status",
+    "visibility",
+    "tipo_id",
+    "area_id",
+    "sistema_id",
+    "instituicao_id",
+    "estabelecimento_id",
+    "setor_id",
+    "vis_celula_id",
+    "celula_id",
+)
+
+
+def article_relevant_state_changed(article, **new_values) -> bool:
+    """Indica se uma alteração toca campos auditados/versionados."""
+    for field, new_value in new_values.items():
+        if field not in RELEVANT_ARTICLE_FIELDS:
+            continue
+        old_value = getattr(article, field)
+        if field in {"status", "visibility"}:
+            old_value = _enum_value(old_value)
+            new_value = _enum_value(new_value)
+        if old_value != new_value:
+            return True
+    return False

--- a/migrations/versions/6d8e9f0a1b2c_add_article_version_user_org_snapshot.py
+++ b/migrations/versions/6d8e9f0a1b2c_add_article_version_user_org_snapshot.py
@@ -1,0 +1,29 @@
+"""add article version user org snapshot fields
+
+Revision ID: 6d8e9f0a1b2c
+Revises: b4c7d9e1f2a3
+Create Date: 2026-05-06 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6d8e9f0a1b2c'
+down_revision = 'b4c7d9e1f2a3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('article_version', sa.Column('changed_by_cargo_nome', sa.String(length=200), nullable=True))
+    op.add_column('article_version', sa.Column('changed_by_setor_nome', sa.String(length=200), nullable=True))
+    op.add_column('article_version', sa.Column('changed_by_celula_nome', sa.String(length=200), nullable=True))
+    op.add_column('article_version', sa.Column('changed_by_estabelecimento_nome_fantasia', sa.String(length=200), nullable=True))
+
+
+def downgrade():
+    op.drop_column('article_version', 'changed_by_estabelecimento_nome_fantasia')
+    op.drop_column('article_version', 'changed_by_celula_nome')
+    op.drop_column('article_version', 'changed_by_setor_nome')
+    op.drop_column('article_version', 'changed_by_cargo_nome')


### PR DESCRIPTION
### Motivation
- Implementar versionamento e snapshots auditáveis de artigos para preservar histórico textual e metadados do autor/organizacional ao longo do fluxo de criação/edição/aprovação/revisão.
- Garantir que snapshots não fiquem órfãos movendo a criação de snapshots para dentro da mesma transação do artigo, anexos e notificações.
- Calcular métricas textuais úteis (contagem de caracteres/palavras e hash) e detectar reduções drásticas no conteúdo para auditoria/alertas.

### Description
- Adicionado o service `core/services/article_versions.py` que expõe `create_article_version_snapshot`, `calculate_text_char_count`, `calculate_text_word_count`, `calculate_text_hash`, `article_relevant_state_changed` e utilitários relacionados; o service não faz `commit` e atualiza `article.current_version_number`/`current_revision_number` na sessão ativa.
- Estendido o modelo `ArticleVersion` em `core/models.py` com campos de snapshot organizacional do usuário alterador (`changed_by_cargo_nome`, `changed_by_setor_nome`, `changed_by_celula_nome`, `changed_by_estabelecimento_nome_fantasia`) e preservação de `changed_by_*` básicos.
- Criada migration `migrations/versions/6d8e9f0a1b2c_add_article_version_user_org_snapshot.py` para adicionar as novas colunas de snapshot organizacional.
- Integrado o service em `blueprints/articles.py` nos pontos relevantes: criação (`novo_artigo`), envio via view (`artigo` POST), edição (`editar_artigo`), decisão de aprovação (`aprovacao_detail`) e solicitação de revisão (`solicitar_revisao`), aplicando as regras de versionamento (ex.: `create_initial` -> `v0.1`, `approve` incrementa `version_number` e zera `revision_number`, outras ações incrementam revisão) e registrando snapshot antes de sobrescrever campos relevantes e também após criação/aprovação/restauração quando aplicável.
- Implementado cálculo e persistência de `text_char_count`, `text_word_count`, `content_hash`, snapshot textual do usuário alterador (username, nome_completo, email, cargo.nome, setor.nome, celula.nome, estabelecimento.nome_fantasia) e detecção de redução drástica, além de correlacionamento via `correlation_id` para rastreabilidade.

### Testing
- Executado `python -m compileall core blueprints` com sucesso para validar import/compilação dos módulos criados.
- Executados testes direcionados `pytest tests/test_article_editing.py tests/test_article_approval_review.py tests/test_migrations.py` e todos passaram.
- Executada suíte completa `pytest` e confirmados resultados finais: `153 passed, 1 skipped` (todas as asserções automatizadas relacionadas ao fluxo mantidas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb3fc9fa24832eacd246c419e494ed)