### PR TITLE
Add artigo_restaurar_versao permission and seed migration

### DIFF
--- a/core/enums.py
+++ b/core/enums.py
@@ -67,6 +67,7 @@ class Permissao(Enum):
     ARTIGO_AREA_GERENCIAR = "artigo_area_gerenciar"
     ARTIGO_OCR_REPROCESSAR = "artigo_ocr_reprocessar"
     ARTIGO_EXCLUIR_DEFINITIVO = "artigo_excluir_definitivo"
+    ARTIGO_RESTAURAR_VERSAO = "artigo_restaurar_versao"
 
     # --- boletim ---
     BOLETIM_VISUALIZAR = "boletim_visualizar"

--- a/core/permission_catalog.py
+++ b/core/permission_catalog.py
@@ -20,6 +20,7 @@ class PermissionCatalogItem:
 
 
 FRIENDLY_NAMES: dict[str, str] = {
+    Permissao.ARTIGO_RESTAURAR_VERSAO.value: "Restaurar versão de artigo",
     Permissao.BOLETIM_VISUALIZAR.value: "Boletim visualizar",
     Permissao.BOLETIM_BUSCAR.value: "Boletim buscar",
     Permissao.BOLETIM_GERENCIAR.value: "Boletim gerenciar",

--- a/core/utils.py
+++ b/core/utils.py
@@ -958,6 +958,17 @@ def user_can_view_article(user, article):
     return False
 
 
+def user_can_restore_article_version(user):
+    """Verifica se o usuário pode restaurar versões de artigos."""
+    return bool(
+        user
+        and (
+            user.has_permissao("admin")
+            or user.has_permissao(Permissao.ARTIGO_RESTAURAR_VERSAO.value)
+        )
+    )
+
+
 def eligible_review_notification_users(article):
     """Retorna os usuários que devem ser notificados sobre a revisão do artigo."""
     try:

--- a/migrations/versions/a7c5d3e9f012_seed_artigo_restaurar_versao_permission.py
+++ b/migrations/versions/a7c5d3e9f012_seed_artigo_restaurar_versao_permission.py
@@ -1,0 +1,45 @@
+"""seed artigo restaurar versao permission
+
+Revision ID: a7c5d3e9f012
+Revises: 6d8e9f0a1b2c
+Create Date: 2026-05-06 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'a7c5d3e9f012'
+down_revision = '6d8e9f0a1b2c'
+branch_labels = None
+depends_on = None
+
+
+CODIGO = "artigo_restaurar_versao"
+NOME = "Restaurar versão de artigo"
+
+
+def upgrade():
+    connection = op.get_bind()
+    res = connection.execute(
+        sa.text("SELECT id FROM funcao WHERE codigo = :codigo"),
+        {"codigo": CODIGO},
+    ).first()
+    if not res:
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO funcao (codigo, nome, managed_by_system)
+                VALUES (:codigo, :nome, true)
+                """
+            ),
+            {"codigo": CODIGO, "nome": NOME},
+        )
+
+
+def downgrade():
+    connection = op.get_bind()
+    connection.execute(
+        sa.text("DELETE FROM funcao WHERE codigo = :codigo"),
+        {"codigo": CODIGO},
+    )

--- a/migrations/versions/bb1d9e24176f_seed_specific_article_permissions.py
+++ b/migrations/versions/bb1d9e24176f_seed_specific_article_permissions.py
@@ -3,27 +3,43 @@
 from alembic import op
 import sqlalchemy as sa
 
-try:
-    from core.enums import Permissao
-except ImportError:  # pragma: no cover - fallback when PYTHONPATH isn't set
-    import sys
-    from pathlib import Path
-
-    ROOT = Path(__file__).resolve().parents[2]
-    if str(ROOT) not in sys.path:
-        sys.path.append(str(ROOT))
-    from core.enums import Permissao
-
 revision = 'bb1d9e24176f'
 down_revision = 'fa23b0c1c9d0'
 branch_labels = None
 depends_on = None
 
 
+PERMS = [
+    ("artigo_editar_celula", "Artigo editar celula"),
+    ("artigo_editar_setor", "Artigo editar setor"),
+    ("artigo_editar_estabelecimento", "Artigo editar estabelecimento"),
+    ("artigo_editar_instituicao", "Artigo editar instituicao"),
+    ("artigo_editar_todas", "Artigo editar todas"),
+    ("artigo_aprovar_celula", "Artigo aprovar celula"),
+    ("artigo_aprovar_setor", "Artigo aprovar setor"),
+    ("artigo_aprovar_estabelecimento", "Artigo aprovar estabelecimento"),
+    ("artigo_aprovar_instituicao", "Artigo aprovar instituicao"),
+    ("artigo_aprovar_todas", "Artigo aprovar todas"),
+    ("artigo_revisar_celula", "Artigo revisar celula"),
+    ("artigo_revisar_setor", "Artigo revisar setor"),
+    ("artigo_revisar_estabelecimento", "Artigo revisar estabelecimento"),
+    ("artigo_revisar_instituicao", "Artigo revisar instituicao"),
+    ("artigo_revisar_todas", "Artigo revisar todas"),
+    ("artigo_assumir_revisao_celula", "Artigo assumir revisao celula"),
+    ("artigo_assumir_revisao_setor", "Artigo assumir revisao setor"),
+    ("artigo_assumir_revisao_estabelecimento", "Artigo assumir revisao estabelecimento"),
+    ("artigo_assumir_revisao_instituicao", "Artigo assumir revisao instituicao"),
+    ("artigo_assumir_revisao_todas", "Artigo assumir revisao todas"),
+    ("artigo_tipo_gerenciar", "Artigo tipo gerenciar"),
+    ("artigo_area_gerenciar", "Artigo area gerenciar"),
+    ("artigo_ocr_reprocessar", "Artigo ocr reprocessar"),
+    ("artigo_excluir_definitivo", "Artigo excluir definitivo"),
+]
+
+
 def upgrade():
     connection = op.get_bind()
-    perms = [(p.value, p.value.replace('_', ' ').capitalize()) for p in Permissao]
-    for codigo, nome in perms:
+    for codigo, nome in PERMS:
         res = connection.execute(
             sa.text("SELECT id FROM funcao WHERE codigo=:c"), {"c": codigo}
         ).first()
@@ -36,7 +52,7 @@ def upgrade():
 
 def downgrade():
     connection = op.get_bind()
-    codes = [p.value for p in Permissao]
+    codes = [codigo for codigo, _nome in PERMS]
     connection.execute(
         sa.text("DELETE FROM funcao WHERE codigo = ANY(:codes)"),
         {"codes": codes},

--- a/tests/test_article_permissions.py
+++ b/tests/test_article_permissions.py
@@ -8,6 +8,7 @@ from core.utils import (
     user_can_edit_article,
     user_can_approve_article,
     user_can_review_article,
+    user_can_restore_article_version,
     user_can_view_article,
 )
 
@@ -135,6 +136,16 @@ def test_valid_user_permissions_keep_current_behavior():
     assert user_can_review_article(admin, article) is True
     assert user_can_view_article(admin, article) is True
     assert user_can_approve_article(admin, article) is True
+    assert user_can_restore_article_version(admin) is True
+
+
+def test_user_can_restore_article_version_requires_admin_or_specific_permission():
+    assert user_can_restore_article_version(None) is False
+    assert user_can_restore_article_version(_FakeUser(perms=set())) is False
+    assert user_can_restore_article_version(_FakeUser(perms={'admin'})) is True
+    assert user_can_restore_article_version(
+        _FakeUser(perms={Permissao.ARTIGO_RESTAURAR_VERSAO.value})
+    ) is True
 
 
 def test_pesquisar_filter_with_none_user_does_not_raise_exception():

--- a/tests/test_artigo_restaurar_versao_permission.py
+++ b/tests/test_artigo_restaurar_versao_permission.py
@@ -1,0 +1,10 @@
+from core.enums import Permissao
+from core.permission_catalog import CATALOG_BY_CODE, PERMISSION_CATEGORY_BY_CODE
+
+
+def test_permission_catalog_includes_artigo_restaurar_versao_in_article_category():
+    codigo = Permissao.ARTIGO_RESTAURAR_VERSAO.value
+
+    assert codigo == "artigo_restaurar_versao"
+    assert CATALOG_BY_CODE[codigo].nome == "Restaurar versão de artigo"
+    assert PERMISSION_CATEGORY_BY_CODE[codigo] == "Permissões de Artigos"


### PR DESCRIPTION
### Motivation
- Permitir restauração de versões de artigo por permissão dedicada além de `admin` e expor essa permissão no catálogo de permissões. 
- Garantir que a UI de gerenciamento de cargos mostre a permissão automaticamente pela categorização por prefixo `artigo_` sem alterações manuais no template. 
- Inserir a permissão no banco de forma idempotente via migration seed para ambientes existentes e futuros.

### Description
- Adiciona `ARTIGO_RESTAURAR_VERSAO = "artigo_restaurar_versao"` à enum de permissões em `core/enums.py`. 
- Inclui nome amigável `"Restaurar versão de artigo"` no `FRIENDLY_NAMES` do `core/permission_catalog.py` para aparecer no `CATALOG` e ser categorizada automaticamente por prefixo `artigo_`. 
- Adiciona o helper `user_can_restore_article_version(user)` em `core/utils.py` que permite `admin` ou a permissão `artigo_restaurar_versao` (uso previsto nas rotas de restauração). 
- Cria a migration seed idempotente `migrations/versions/a7c5d3e9f012_seed_artigo_restaurar_versao_permission.py` para inserir a função `artigo_restaurar_versao` em `funcao` com `managed_by_system=true`. 
- Ajusta a seed de permissões específicas `migrations/versions/bb1d9e24176f_seed_specific_article_permissions.py` para manter uma lista congelada de permissões históricas (evita semear automaticamente novas permissões antes da migration própria). 
- Adiciona testes: estende `tests/test_article_permissions.py` com verificações do helper e cria `tests/test_artigo_restaurar_versao_permission.py` que valida `CATALOG_BY_CODE` e `PERMISSION_CATEGORY_BY_CODE` para a nova permissão.

### Testing
- Executado `python -m pytest tests/test_article_permissions.py tests/test_artigo_restaurar_versao_permission.py tests/test_migrations.py` e todos os testes passaram (`11 passed`).
- Verificada a árvore de migrations com um script Python que listou as revisões e assegurou que a nova migration `a7c5d3e9f012_seed_artigo_restaurar_versao_permission.py` é a cabeça esperada, e a verificação teve sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4256c9a0832eaa0d616e2ea8c044)