### PR TITLE
Adicionar histórico de versões de artigo e restauração

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -68,6 +68,12 @@ except ImportError:  # pragma: no cover
         create_article_version_snapshot,
     )
 
+
+# Importados separadamente após a definição/carregamento dos modelos para evitar
+# acoplamento com a lista principal de modelos do blueprint.
+from core.models import ArticleVersion
+from core.utils import user_can_restore_article_version
+
 try:
     from ..core.progress import (
         clear_progress,
@@ -563,6 +569,145 @@ def artigo(artigo_id):
         can_reprocess_ocr=can_reprocess_ocr,
         can_delete_definitive=can_delete_definitive,
     )
+
+
+def _article_status_from_snapshot(status_value):
+    if status_value in ArticleStatus._value2member_map_:
+        return ArticleStatus(status_value)
+    return ArticleStatus.RASCUNHO
+
+
+def _article_visibility_from_snapshot(visibility_value):
+    if visibility_value in ArticleVisibility._value2member_map_:
+        return ArticleVisibility(visibility_value)
+    return ArticleVisibility.CELULA
+
+
+def _local_datetime(dt):
+    if not dt:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(ZoneInfo("America/Sao_Paulo"))
+
+
+@articles_bp.route('/artigo/<int:artigo_id>/versoes', methods=['GET'], endpoint='historico_versoes_artigo')
+def historico_versoes_artigo(artigo_id):
+    if 'username' not in session:
+        return redirect(url_for('login'))
+
+    artigo = Article.query.get(artigo_id)
+    if not artigo:
+        return _render_artigo_indisponivel(artigo_id)
+
+    user = User.query.filter_by(username=session['username']).first()
+    if not user_can_view_article(user, artigo):
+        flash('Você não tem permissão para ver este artigo.', 'danger')
+        return redirect(url_for('pagina_inicial'))
+
+    versoes = (
+        ArticleVersion.query
+        .filter_by(article_id=artigo.id)
+        .order_by(
+            ArticleVersion.version_number.desc(),
+            ArticleVersion.revision_number.desc(),
+            ArticleVersion.created_at.desc(),
+        )
+        .all()
+    )
+    for versao in versoes:
+        versao.local_created_at = _local_datetime(versao.created_at)
+
+    return render_template(
+        'artigos/historico_versoes.html',
+        artigo=artigo,
+        versoes=versoes,
+        can_restore_versions=user_can_restore_article_version(user),
+        ArticleStatus=ArticleStatus,
+    )
+
+
+@articles_bp.route('/artigo/<int:artigo_id>/versoes/<int:version_id>', methods=['GET'], endpoint='visualizar_versao_artigo')
+def visualizar_versao_artigo(artigo_id, version_id):
+    if 'username' not in session:
+        return redirect(url_for('login'))
+
+    artigo = Article.query.get(artigo_id)
+    if not artigo:
+        return _render_artigo_indisponivel(artigo_id)
+
+    user = User.query.filter_by(username=session['username']).first()
+    if not user_can_view_article(user, artigo):
+        flash('Você não tem permissão para ver este artigo.', 'danger')
+        return redirect(url_for('pagina_inicial'))
+
+    versao = ArticleVersion.query.filter_by(id=version_id, article_id=artigo.id).first_or_404()
+    versao.local_created_at = _local_datetime(versao.created_at)
+
+    return render_template(
+        'artigos/visualizar_versao.html',
+        artigo=artigo,
+        versao=versao,
+        can_restore_versions=user_can_restore_article_version(user),
+        ArticleStatus=ArticleStatus,
+    )
+
+
+@articles_bp.route('/artigo/<int:artigo_id>/versoes/<int:version_id>/restaurar', methods=['POST'], endpoint='restaurar_versao_artigo')
+def restaurar_versao_artigo(artigo_id, version_id):
+    if 'username' not in session:
+        return redirect(url_for('login'))
+
+    artigo = Article.query.get(artigo_id)
+    if not artigo:
+        return _render_artigo_indisponivel(artigo_id)
+
+    user = User.query.filter_by(username=session['username']).first()
+    if not user_can_view_article(user, artigo):
+        flash('Você não tem permissão para ver este artigo.', 'danger')
+        return redirect(url_for('pagina_inicial'))
+    if not user_can_restore_article_version(user):
+        flash('Permissão negada para restaurar versões de artigos.', 'danger')
+        return redirect(url_for('historico_versoes_artigo', artigo_id=artigo.id))
+
+    versao = ArticleVersion.query.filter_by(id=version_id, article_id=artigo.id).first_or_404()
+    motivo = (request.form.get('motivo') or '').strip() or None
+    status_before = artigo.status
+    status_after = _article_status_from_snapshot(versao.status)
+    previous_text_char_count = calculate_text_char_count(artigo.texto)
+
+    artigo.titulo = versao.titulo
+    artigo.texto = versao.texto
+    artigo.status = status_after
+    artigo.visibility = _article_visibility_from_snapshot(versao.visibility)
+    artigo.tipo_id = versao.tipo_id
+    artigo.area_id = versao.area_id
+    artigo.sistema_id = versao.sistema_id
+    artigo.instituicao_id = versao.instituicao_id
+    artigo.estabelecimento_id = versao.estabelecimento_id
+    artigo.setor_id = versao.setor_id
+    artigo.vis_celula_id = versao.vis_celula_id
+    artigo.celula_id = versao.celula_id or artigo.celula_id
+    if versao.user_id_original_author:
+        artigo.user_id = versao.user_id_original_author
+    artigo.updated_at = datetime.now(timezone.utc)
+
+    create_article_version_snapshot(
+        artigo,
+        user,
+        "restore_version",
+        change_reason=motivo,
+        source_status_before=status_before,
+        source_status_after=status_after,
+        correlation_id=getattr(g, "request_correlation_id", None),
+        drastic_reduction_data={
+            "previous_text_char_count": previous_text_char_count,
+        },
+    )
+    db.session.commit()
+
+    flash('Versão restaurada com sucesso. Um novo snapshot de restauração foi criado.', 'success')
+    return redirect(url_for('artigo', artigo_id=artigo.id))
 
 
 @articles_bp.route('/artigo/<int:artigo_id>/excluir-definitivo', methods=['POST'])

--- a/templates/artigos/artigo.html
+++ b/templates/artigos/artigo.html
@@ -216,6 +216,9 @@
           <i class="bi bi-chat-left-text" aria-hidden="true"></i> Solicitar Revisão
         </a>
         {% endif %}
+        <a href="{{ url_for('historico_versoes_artigo', artigo_id=artigo.id) }}" class="btn btn-app btn-app-secondary">
+          <i class="bi bi-clock-history" aria-hidden="true"></i> Histórico de versões
+        </a>
         {% if artigo.status == ArticleStatus.APROVADO %}
         <i
           class="bi bi-copy text-secondary copy-link-icon"

--- a/templates/artigos/historico_versoes.html
+++ b/templates/artigos/historico_versoes.html
@@ -1,0 +1,132 @@
+{% extends 'base.html' %}
+{% block title %}Histórico de versões - {{ artigo.titulo }}{% endblock %}
+
+{% block content %}
+{% set status_labels = {
+  'rascunho': 'Rascunho',
+  'pendente': 'Pendente',
+  'aprovado': 'Aprovado',
+  'rejeitado': 'Rejeitado'
+} %}
+{% set action_labels = {
+  'create_initial': 'Criação inicial',
+  'initial_create': 'Criação inicial',
+  'submit_for_approval': 'Enviado para aprovação',
+  'edit_after_approved': 'Edição pós-aprovação',
+  'approve': 'Aprovação',
+  'reject': 'Rejeição',
+  'request_revision': 'Solicitação de revisão',
+  'restore_version': 'Restauração de versão'
+} %}
+<div class="container-fluid page-root">
+  <div class="row">
+    <div class="col-12 mx-auto">
+      <div class="card shadow-sm">
+        <div class="card-body">
+          <div class="d-flex flex-wrap justify-content-between align-items-start gap-2">
+            <div>
+              <h3 class="mb-1">Histórico de versões</h3>
+              <p class="text-muted mb-0">
+                <strong>Artigo:</strong> {{ artigo.titulo }}
+                <span class="ms-2"><strong>Versão atual:</strong> v{{ artigo.current_version_number }}.r{{ artigo.current_revision_number }}</span>
+              </p>
+            </div>
+            <a href="{{ url_for('artigo', artigo_id=artigo.id) }}" class="btn btn-app btn-app-secondary">
+              <i class="bi bi-arrow-left" aria-hidden="true"></i> Voltar ao artigo
+            </a>
+          </div>
+
+          <hr>
+
+          {% if versoes %}
+          <div class="table-responsive">
+            <table class="table table-hover align-middle">
+              <thead>
+                <tr>
+                  <th>Versão/Revisão</th>
+                  <th>Data/hora</th>
+                  <th>Usuário</th>
+                  <th>Cargo</th>
+                  <th>Ação</th>
+                  <th>Status antes</th>
+                  <th>Status depois</th>
+                  <th>Tamanho do texto</th>
+                  <th class="text-end">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for versao in versoes %}
+                <tr>
+                  <td><span class="badge bg-secondary">v{{ versao.version_number }}.r{{ versao.revision_number }}</span></td>
+                  <td>
+                    {% if versao.local_created_at %}
+                    {{ versao.local_created_at.strftime('%d/%m/%Y %H:%M') }}
+                    {% else %}
+                    —
+                    {% endif %}
+                  </td>
+                  <td>{{ versao.changed_by_nome_completo or versao.changed_by_username or 'Não informado' }}</td>
+                  <td>{{ versao.changed_by_cargo_nome or 'Cargo não informado' }}</td>
+                  <td>{{ action_labels.get(versao.change_action, versao.change_action) }}</td>
+                  <td>{{ status_labels.get(versao.source_status_before, versao.source_status_before or '—') }}</td>
+                  <td>{{ status_labels.get(versao.source_status_after, versao.source_status_after or status_labels.get(versao.status, versao.status)) }}</td>
+                  <td>{{ versao.text_char_count }} caracteres</td>
+                  <td class="text-end">
+                    <div class="d-flex justify-content-end flex-wrap gap-2">
+                      <a href="{{ url_for('visualizar_versao_artigo', artigo_id=artigo.id, version_id=versao.id) }}" class="btn btn-sm btn-app btn-app-secondary">
+                        <i class="bi bi-eye" aria-hidden="true"></i> Visualizar
+                      </a>
+                      {% if can_restore_versions %}
+                      <button type="button" class="btn btn-sm btn-app btn-app-primary" data-bs-toggle="modal" data-bs-target="#restoreVersionModal{{ versao.id }}">
+                        <i class="bi bi-arrow-counterclockwise" aria-hidden="true"></i> Restaurar
+                      </button>
+                      {% endif %}
+                    </div>
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% else %}
+          <div class="alert alert-info mb-0" role="alert">Nenhum snapshot de versão foi encontrado para este artigo.</div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% if can_restore_versions %}
+  {% for versao in versoes %}
+  <div class="modal fade" id="restoreVersionModal{{ versao.id }}" tabindex="-1" aria-labelledby="restoreVersionModalLabel{{ versao.id }}" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form method="post" action="{{ url_for('restaurar_versao_artigo', artigo_id=artigo.id, version_id=versao.id) }}">
+          <div class="modal-header">
+            <h5 class="modal-title" id="restoreVersionModalLabel{{ versao.id }}">Restaurar v{{ versao.version_number }}.r{{ versao.revision_number }}</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+          </div>
+          <div class="modal-body">
+            {% if csrf_token is defined %}
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            {% endif %}
+            <div class="alert alert-warning" role="alert">
+              A restauração atualizará apenas o artigo atual com este snapshot e criará um novo registro de auditoria de restauração.
+            </div>
+            <div class="mb-3">
+              <label for="motivoRestore{{ versao.id }}" class="form-label">Motivo da restauração (opcional)</label>
+              <textarea class="form-control" id="motivoRestore{{ versao.id }}" name="motivo" rows="3" placeholder="Descreva o motivo, se necessário"></textarea>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-app btn-app-secondary" data-bs-dismiss="modal">Cancelar</button>
+            <button type="submit" class="btn btn-app btn-app-primary">Confirmar restauração</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+{% endif %}
+{% endblock %}

--- a/templates/artigos/visualizar_versao.html
+++ b/templates/artigos/visualizar_versao.html
@@ -1,0 +1,119 @@
+{% extends 'base.html' %}
+{% block title %}Versão v{{ versao.version_number }}.r{{ versao.revision_number }} - {{ versao.titulo }}{% endblock %}
+
+{% block content %}
+{% set status_labels = {
+  'rascunho': 'Rascunho',
+  'pendente': 'Pendente',
+  'aprovado': 'Aprovado',
+  'rejeitado': 'Rejeitado'
+} %}
+{% set action_labels = {
+  'create_initial': 'Criação inicial',
+  'initial_create': 'Criação inicial',
+  'submit_for_approval': 'Enviado para aprovação',
+  'edit_after_approved': 'Edição pós-aprovação',
+  'approve': 'Aprovação',
+  'reject': 'Rejeição',
+  'request_revision': 'Solicitação de revisão',
+  'restore_version': 'Restauração de versão'
+} %}
+<div class="container-fluid page-root">
+  <div class="row">
+    <div class="col-md-10 mx-auto">
+      <div class="alert alert-secondary d-flex align-items-center gap-2" role="alert">
+        <i class="bi bi-lock" aria-hidden="true"></i>
+        <div>Você está visualizando uma versão antiga em modo somente leitura.</div>
+      </div>
+
+      <div class="card shadow-sm">
+        <div class="card-body position-relative">
+          <div class="d-flex justify-content-between align-items-start gap-2">
+            <div>
+              <h3>{{ versao.titulo }}</h3>
+              <p class="text-muted mb-0">
+                <strong>Snapshot:</strong> v{{ versao.version_number }}.r{{ versao.revision_number }}
+                <strong class="ms-2">Criado em:</strong>
+                {% if versao.local_created_at %}{{ versao.local_created_at.strftime('%d/%m/%Y %H:%M') }}{% else %}—{% endif %}
+                <strong class="ms-2">Usuário:</strong> {{ versao.changed_by_nome_completo or versao.changed_by_username or 'Não informado' }}
+                <strong class="ms-2">Cargo:</strong> {{ versao.changed_by_cargo_nome or 'Cargo não informado' }}
+              </p>
+            </div>
+            <span class="badge bg-secondary fs-6 mt-1">{{ status_labels.get(versao.status, versao.status) }}</span>
+          </div>
+
+          <hr>
+
+          <dl class="row small text-muted">
+            <dt class="col-sm-2">Ação</dt>
+            <dd class="col-sm-10">{{ action_labels.get(versao.change_action, versao.change_action) }}</dd>
+            <dt class="col-sm-2">Status antes</dt>
+            <dd class="col-sm-10">{{ status_labels.get(versao.source_status_before, versao.source_status_before or '—') }}</dd>
+            <dt class="col-sm-2">Status depois</dt>
+            <dd class="col-sm-10">{{ status_labels.get(versao.source_status_after, versao.source_status_after or status_labels.get(versao.status, versao.status)) }}</dd>
+            <dt class="col-sm-2">Tamanho</dt>
+            <dd class="col-sm-10">{{ versao.text_char_count }} caracteres • {{ versao.text_word_count }} palavras</dd>
+            {% if versao.change_reason %}
+            <dt class="col-sm-2">Motivo</dt>
+            <dd class="col-sm-10">{{ versao.change_reason }}</dd>
+            {% endif %}
+          </dl>
+
+          <hr>
+
+          <div class="article-version-readonly border rounded p-3 bg-light">
+            {{ versao.texto.replace('\n', '<br>')|safe }}
+          </div>
+
+          <hr>
+
+          <div class="d-flex flex-wrap gap-2">
+            <a href="{{ url_for('historico_versoes_artigo', artigo_id=artigo.id) }}" class="btn btn-app btn-app-secondary">
+              <i class="bi bi-arrow-left" aria-hidden="true"></i> Voltar ao histórico
+            </a>
+            <a href="{{ url_for('artigo', artigo_id=artigo.id) }}" class="btn btn-app btn-app-secondary">
+              <i class="bi bi-file-text" aria-hidden="true"></i> Ver artigo atual
+            </a>
+            {% if can_restore_versions %}
+            <button type="button" class="btn btn-app btn-app-primary" data-bs-toggle="modal" data-bs-target="#restoreVersionModal">
+              <i class="bi bi-arrow-counterclockwise" aria-hidden="true"></i> Restaurar esta versão
+            </button>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% if can_restore_versions %}
+<div class="modal fade" id="restoreVersionModal" tabindex="-1" aria-labelledby="restoreVersionModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" action="{{ url_for('restaurar_versao_artigo', artigo_id=artigo.id, version_id=versao.id) }}">
+        <div class="modal-header">
+          <h5 class="modal-title" id="restoreVersionModalLabel">Restaurar v{{ versao.version_number }}.r{{ versao.revision_number }}</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+        </div>
+        <div class="modal-body">
+          {% if csrf_token is defined %}
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          {% endif %}
+          <div class="alert alert-warning" role="alert">
+            A versão selecionada não será alterada; a aplicação atualizará o artigo atual e criará um novo snapshot de restauração.
+          </div>
+          <div class="mb-3">
+            <label for="motivoRestore" class="form-label">Motivo da restauração (opcional)</label>
+            <textarea class="form-control" id="motivoRestore" name="motivo" rows="3" placeholder="Descreva o motivo, se necessário"></textarea>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-app btn-app-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="submit" class="btn btn-app btn-app-primary">Confirmar restauração</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
### Motivation
- Fornecer histórico de snapshots de artigos e permitir visualizar/restaurar versões antigas sem alterar os registros históricos de `ArticleVersion`.
- Garantir que a restauração atualize apenas o `Article` atual e registre a ação como um novo snapshot com `change_action = "restore_version"` e motivo opcional.

### Description
- Importa `ArticleVersion` e `user_can_restore_article_version` no `blueprints/articles.py` e adiciona helpers para conversão de status/visibilidade e timezone local (`_article_status_from_snapshot`, `_article_visibility_from_snapshot`, `_local_datetime`).
- Adiciona rota GET `'/artigo/<int:artigo_id>/versoes'` (`historico_versoes_artigo`) para listar snapshots, validando `user_can_view_article(user, artigo)` e passando `can_restore_versions` para o template.
- Adiciona rota GET `'/artigo/<int:artigo_id>/versoes/<int:version_id>'` (`visualizar_versao_artigo`) para exibir um snapshot em modo somente leitura com metadados e botão de restauração condicional.
- Adiciona rota POST `'/artigo/<int:artigo_id>/versoes/<int:version_id>/restaurar'` (`restaurar_versao_artigo`) que exige permissão de restauração, aplica os campos do snapshot selecionado ao `Article` atual (sem modificar o `ArticleVersion` existente) e cria um novo snapshot via `create_article_version_snapshot(..., change_action="restore_version", change_reason=motivo)`.
- Cria templates `templates/artigos/historico_versoes.html` e `templates/artigos/visualizar_versao.html` exibindo versão/revisão, data/hora, usuário, cargo, ação, status antes/depois, tamanho do texto, botão visualizar e botão restaurar quando permitido.
- Atualiza `templates/artigos/artigo.html` para incluir o botão “Histórico de versões” próximo às ações do artigo.

### Testing
- Executado `python -m compileall blueprints/articles.py` com sucesso.
- Executado `pytest -q` com sucesso: `155 passed, 1 skipped` (test suite completa localmente).
- Verificado que as rotas foram registradas com `app.url_map` e as novas endpoints existem: `'/artigo/<int:artigo_id>/versoes'`, `'/artigo/<int:artigo_id>/versoes/<int:version_id>'` e `'/artigo/<int:artigo_id>/versoes/<int:version_id>/restaurar'`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4413ef50832ea62cdaf82f5c7550)