### PR TITLE
Exige conteúdo textual em artigos

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash, session, jsonify, current_app as app, g
 from sqlalchemy import or_, func, text, and_
+import html
 import math
 import re
 
@@ -166,6 +167,12 @@ def _render_editar_artigo_form(artigo, arquivos, can_submit_actions, form_data=N
         form_data=form_data,
     )
 
+def _has_required_text_content(sanitized_text):
+    text_without_tags = re.sub(r"<[^>]*>", " ", sanitized_text or "")
+    text_without_nbsp = html.unescape(text_without_tags).replace("\xa0", " ")
+    return bool(text_without_nbsp.strip())
+
+
 def _render_artigo_indisponivel(artigo_id):
     auditoria_exclusao = (
         ArticleDeletionAudit.query
@@ -222,10 +229,9 @@ def novo_artigo():
             'visibility': request.form.get('visibility') or 'celula',
         }
 
-        # Campos obrigatórios: título e ao menos texto ou anexo
-        has_uploads = any(f and f.filename for f in files)
-        if not titulo or (not texto_limpo and not has_uploads):
-            flash('Erro de validação: título e conteúdo são obrigatórios (texto ou anexo).', 'warning')
+        # Campos obrigatórios: título e conteúdo textual sanitizado
+        if not titulo or not _has_required_text_content(texto_limpo):
+            flash('Erro de validação: título e conteúdo textual são obrigatórios.', 'warning')
             flash('Se você selecionou anexos, será necessário reenviá-los após corrigir o formulário (limitação de multipart).', 'info')
             return _render_novo_artigo_form(form_data)
 
@@ -485,8 +491,13 @@ def artigo(artigo_id):
             flash('Permissão negada.', 'danger')
             return redirect(url_for('artigo', artigo_id=artigo_id))
         # 1) campos básicos
-        novo_titulo = request.form['titulo']
-        novo_texto = request.form['texto']
+        novo_titulo = request.form['titulo'].strip()
+        novo_texto_raw = request.form['texto']
+        novo_texto = sanitize_html(novo_texto_raw).strip()
+        if not novo_titulo or not _has_required_text_content(novo_texto):
+            flash('Erro de validação: título e conteúdo textual são obrigatórios.', 'warning')
+            return redirect(url_for('artigo', artigo_id=artigo_id))
+
         status_before = artigo.status
         if article_relevant_state_changed(
             artigo,
@@ -921,17 +932,18 @@ def editar_artigo(artigo_id):
 
         # campos básicos
         titulo = request.form["titulo"].strip()
-        texto  = request.form["texto"].strip()
+        texto_raw = request.form["texto"]
+        texto = sanitize_html(texto_raw).strip()
         form_data = {
             'titulo': titulo,
-            'texto': texto,
+            'texto': texto_raw,
             'tipo_id': request.form.get('tipo_id') or '',
             'area_id': request.form.get('area_id') or '',
             'sistema_id': request.form.get('sistema_id') or '',
             'visibility': request.form.get('visibility') or artigo.visibility.value,
         }
-        if not titulo or not texto:
-            flash('Erro de validação: título e texto são obrigatórios.', 'warning')
+        if not titulo or not _has_required_text_content(texto):
+            flash('Erro de validação: título e conteúdo textual são obrigatórios.', 'warning')
             flash('Se você selecionou anexos, será necessário reenviá-los após corrigir o formulário (limitação de multipart).', 'info')
             return _render_editar_artigo_form(artigo, json.loads(artigo.arquivos or "[]"), can_submit_actions, form_data)
 

--- a/tests/test_required_fields.py
+++ b/tests/test_required_fields.py
@@ -114,20 +114,22 @@ def test_novo_artigo_persiste_campos_no_html_em_erro_validacao(client):
 
 
 
-def test_novo_artigo_accepts_attachment_without_text(client):
+def test_novo_artigo_rejects_attachment_without_text(client):
     _login_user(client, ['artigo_criar'])
-    client.post('/novo-artigo', data={
+    response = client.post('/novo-artigo', data={
         'titulo': 'OCR sem texto',
         'texto': '',
         'visibility': 'celula',
         'acao': 'enviar',
         'files': (BytesIO(b'conteudo teste ocr'), 'ocr.txt'),
-    }, content_type='multipart/form-data', follow_redirects=True)
+    }, content_type='multipart/form-data', follow_redirects=False)
 
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert 'título e conteúdo textual são obrigatórios' in html
     with app.app_context():
         artigo = Article.query.filter_by(titulo='OCR sem texto').first()
-        assert artigo is not None
-        assert artigo.status == ArticleStatus.PENDENTE
+        assert artigo is None
 
 def test_editar_artigo_requires_fields(client):
     uid = _login_user(client, ['artigo_criar', Permissao.ARTIGO_EDITAR_CELULA])
@@ -175,6 +177,61 @@ def test_editar_artigo_persiste_campos_no_html_em_erro_validacao(client):
     assert response.status_code == 200
     assert 'value="Novo Título Não Persistido"' in html
     assert 'name="visibility" id="visibilityInput" value="setor"' in html
+
+
+def test_editar_artigo_rejects_sanitized_empty_text(client):
+    uid = _login_user(client, ['artigo_criar', Permissao.ARTIGO_EDITAR_CELULA])
+    with app.app_context():
+        user = User.query.get(uid)
+        inst = Instituicao.query.first()
+        art = Article(
+            titulo='Titulo Original', texto='Texto original', status=ArticleStatus.RASCUNHO,
+            user_id=uid, celula_id=user.celula_id, setor_id=user.setor_id,
+            estabelecimento_id=user.estabelecimento_id, instituicao_id=inst.id
+        )
+        db.session.add(art)
+        db.session.commit()
+        aid = art.id
+
+    response = client.post(f'/artigo/{aid}/editar', data={
+        'titulo': 'Novo Título Não Persistido',
+        'texto': '<img src=x>',
+        'visibility': 'celula',
+        'acao': 'salvar',
+    }, follow_redirects=False)
+
+    assert response.status_code == 200
+    with app.app_context():
+        art = Article.query.get(aid)
+        assert art.titulo == 'Titulo Original'
+        assert art.texto == 'Texto original'
+
+
+def test_artigo_post_rejects_sanitized_empty_text(client):
+    uid = _login_user(client, ['artigo_criar', Permissao.ARTIGO_EDITAR_CELULA])
+    with app.app_context():
+        user = User.query.get(uid)
+        inst = Instituicao.query.first()
+        art = Article(
+            titulo='Titulo Original', texto='Texto original', status=ArticleStatus.RASCUNHO,
+            user_id=uid, celula_id=user.celula_id, setor_id=user.setor_id,
+            estabelecimento_id=user.estabelecimento_id, instituicao_id=inst.id
+        )
+        db.session.add(art)
+        db.session.commit()
+        aid = art.id
+
+    response = client.post(f'/artigo/{aid}', data={
+        'titulo': 'Novo Título Não Persistido',
+        'texto': '<img src=x>',
+    }, follow_redirects=False)
+
+    assert response.status_code == 302
+    with app.app_context():
+        art = Article.query.get(aid)
+        assert art.titulo == 'Titulo Original'
+        assert art.texto == 'Texto original'
+        assert art.status == ArticleStatus.RASCUNHO
 
 def test_editar_artigo_buttons_visible_for_editor_with_permission(client):
     author_id = _login_user(client, ['artigo_criar'])


### PR DESCRIPTION
### Motivation
- Garantir que artigos sempre tenham `titulo` e conteúdo textual significativo mesmo quando houver anexos, evitando salvar textos vazios ou apenas HTML/JS que são removidos pelo sanitizador.

### Description
- Adiciona `_has_required_text_content` para validar que o HTML sanitizado contém texto visível e normaliza entidades/`nbsp` antes de checar o conteúdo.  
- Atualiza `novo_artigo` para exigir sempre `titulo` e conteúdo sanitizado (`texto_limpo`), removendo a exceção que aceitava apenas anexos.  
- Sanitiza e valida o texto nas rotas de edição e no POST de ` /artigo/<int:artigo_id>` (`artigo` e `editar_artigo`), impedindo salvar quando o texto sanitizado fica vazio e retornando mensagens de validação com `título e conteúdo textual são obrigatórios`.  
- Mantém anexos como opcionais e não os relaciona ao requisito de versionamento textual; anexos continuam sendo processados normalmente quando presentes.

### Testing
- Executei `pytest tests/test_required_fields.py` e todos os testes desse arquivo passaram (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4683f0b4832ea4458eed1b5a2761)