### PR TITLE
Detect drastic article content reductions

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -59,14 +59,20 @@ except ImportError:  # pragma: no cover
 try:
     from ..core.services.article_versions import (
         article_relevant_state_changed,
+        calculate_plain_text_char_count,
+        calculate_reduction_percent,
         calculate_text_char_count,
         create_article_version_snapshot,
+        is_drastic_content_reduction,
     )
 except ImportError:  # pragma: no cover
     from core.services.article_versions import (
         article_relevant_state_changed,
+        calculate_plain_text_char_count,
+        calculate_reduction_percent,
         calculate_text_char_count,
         create_article_version_snapshot,
+        is_drastic_content_reduction,
     )
 
 
@@ -164,8 +170,30 @@ def _render_editar_artigo_form(artigo, arquivos, can_submit_actions, form_data=N
         areas_artigo=areas_artigo,
         sistemas_artigo=sistemas_artigo,
         can_submit_actions=can_submit_actions,
+        previous_char_count=calculate_plain_text_char_count(artigo.texto),
         form_data=form_data,
     )
+
+def _build_drastic_reduction_data(previous_text, new_text):
+    previous_char_count = calculate_plain_text_char_count(previous_text)
+    new_char_count = calculate_plain_text_char_count(new_text)
+    reduction_percent = calculate_reduction_percent(previous_char_count, new_char_count)
+    drastic_reduction = is_drastic_content_reduction(
+        previous_char_count,
+        new_char_count,
+        reduction_percent,
+    )
+    return {
+        "drastic_reduction": drastic_reduction,
+        "previous_char_count": previous_char_count,
+        "new_char_count": new_char_count,
+        "reduction_percent": reduction_percent,
+        # Compatibilidade com campos legados do ArticleVersion.
+        "previous_text_char_count": previous_char_count,
+        "text_reduction_percent": reduction_percent,
+        "drastic_reduction_detected": drastic_reduction,
+    }
+
 
 def _has_required_text_content(sanitized_text):
     text_without_tags = re.sub(r"<[^>]*>", " ", sanitized_text or "")
@@ -947,6 +975,13 @@ def editar_artigo(artigo_id):
             flash('Se você selecionou anexos, será necessário reenviá-los após corrigir o formulário (limitação de multipart).', 'info')
             return _render_editar_artigo_form(artigo, json.loads(artigo.arquivos or "[]"), can_submit_actions, form_data)
 
+        drastic_reduction_data = _build_drastic_reduction_data(artigo.texto, texto)
+        drastic_reduction_confirmed = request.form.get('drastic_reduction_confirmed') == 'true'
+        if drastic_reduction_data["drastic_reduction"] and not drastic_reduction_confirmed:
+            flash('Esta alteração reduz significativamente o conteúdo do artigo. Confirme se deseja continuar.', 'warning')
+            flash('Se você selecionou anexos, será necessário reenviá-los após confirmar a alteração (limitação de multipart).', 'info')
+            return _render_editar_artigo_form(artigo, json.loads(artigo.arquivos or "[]"), can_submit_actions, form_data)
+
         tipo_id = request.form.get('tipo_id', type=int)
         area_id = request.form.get('area_id', type=int)
         sistema_id = request.form.get('sistema_id', type=int)
@@ -993,17 +1028,6 @@ def editar_artigo(artigo_id):
                     snapshot_action = "edit_after_approved"
                 else:
                     snapshot_action = "edit"
-                create_article_version_snapshot(
-                    artigo,
-                    user,
-                    snapshot_action,
-                    source_status_before=status_before,
-                    source_status_after=status_after,
-                    correlation_id=correlation_id,
-                    drastic_reduction_data={
-                        "previous_text_char_count": calculate_text_char_count(artigo.texto),
-                    },
-                )
 
             artigo.titulo = titulo
             artigo.texto  = texto
@@ -1094,6 +1118,17 @@ def editar_artigo(artigo_id):
                 flash("Artigo enviado para revisão!", "success")
             else:
                 flash("Artigo salvo!", "success")
+
+            if relevant_change:
+                create_article_version_snapshot(
+                    artigo,
+                    user,
+                    snapshot_action,
+                    source_status_before=status_before,
+                    source_status_after=status_after,
+                    correlation_id=correlation_id,
+                    drastic_reduction_data=drastic_reduction_data,
+                )
 
             db.session.commit()
             mark_progress_done(progress_id)

--- a/core/models.py
+++ b/core/models.py
@@ -456,6 +456,10 @@ class ArticleVersion(db.Model):
     previous_text_char_count = db.Column(db.Integer, nullable=True)
     text_reduction_percent = db.Column(db.Float, nullable=True)
     drastic_reduction_detected = db.Column(db.Boolean, nullable=False, default=False, server_default='false')
+    previous_char_count = db.Column(db.Integer, nullable=True)
+    new_char_count = db.Column(db.Integer, nullable=True)
+    reduction_percent = db.Column(db.Float, nullable=True)
+    drastic_reduction = db.Column(db.Boolean, nullable=False, default=False, server_default='false')
     correlation_id = db.Column(db.String(255), nullable=True)
 
     created_at = db.Column(db.DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/core/services/article_versions.py
+++ b/core/services/article_versions.py
@@ -8,6 +8,7 @@ limite transacional.
 from __future__ import annotations
 
 import hashlib
+import html
 import re
 from datetime import datetime, timezone
 from typing import Any
@@ -33,9 +34,34 @@ def _enum_value(value: Any) -> str | None:
     return str(value)
 
 
+def extract_plain_text_for_count(text: str | None) -> str:
+    """Extrai texto legível de HTML/texto e normaliza espaços para contagem segura."""
+    without_tags = re.sub(r"<[^>]*>", " ", text or "")
+    unescaped = html.unescape(without_tags).replace("\xa0", " ")
+    return re.sub(r"\s+", " ", unescaped).strip()
+
+
+def calculate_plain_text_char_count(text: str | None) -> int:
+    """Conta caracteres do conteúdo textual legível, ignorando marcação HTML."""
+    return len(extract_plain_text_for_count(text))
+
+
 def calculate_text_char_count(text: str | None) -> int:
     """Conta caracteres do texto persistido no snapshot."""
     return len(text or "")
+
+
+def calculate_reduction_percent(previous_count: int | None, new_count: int | None) -> float:
+    """Calcula percentual de redução entre duas contagens textuais."""
+    if previous_count is None or new_count is None or previous_count <= 0 or new_count >= previous_count:
+        return 0.0
+    return ((previous_count - new_count) / previous_count) * 100
+
+
+def is_drastic_content_reduction(previous_count: int, new_count: int, reduction_percent: float | None) -> bool:
+    """Aplica regras de redução significativa usadas no cliente e no backend."""
+    percent_reduction = reduction_percent or 0
+    return percent_reduction > 70 or (previous_count > 2000 and new_count < 300)
 
 
 def calculate_text_word_count(text: str | None) -> int:
@@ -114,28 +140,56 @@ def _next_version_revision(article: Any, change_action: str) -> tuple[int, int]:
     return current_version, current_revision + 1
 
 
+def _safe_int(value: Any | None) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_float(value: Any | None) -> float | None:
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
 def _drastic_reduction_metrics(text_char_count: int, drastic_reduction_data: dict[str, Any] | None) -> dict[str, Any]:
     previous_count = None
-    threshold_percent = 50.0
-    if drastic_reduction_data:
-        previous_count = drastic_reduction_data.get("previous_text_char_count")
-        threshold_percent = float(drastic_reduction_data.get("threshold_percent", threshold_percent))
-
-    try:
-        previous_count = int(previous_count) if previous_count is not None else None
-    except (TypeError, ValueError):
-        previous_count = None
-
+    new_count = None
     reduction_percent = None
     detected = False
-    if previous_count and previous_count > 0 and text_char_count < previous_count:
-        reduction_percent = ((previous_count - text_char_count) / previous_count) * 100
+    threshold_percent = 50.0
+
+    if drastic_reduction_data:
+        previous_count = _safe_int(
+            drastic_reduction_data.get("previous_char_count")
+            if "previous_char_count" in drastic_reduction_data
+            else drastic_reduction_data.get("previous_text_char_count")
+        )
+        new_count = _safe_int(drastic_reduction_data.get("new_char_count"))
+        reduction_percent = _safe_float(drastic_reduction_data.get("reduction_percent"))
+        detected = bool(drastic_reduction_data.get("drastic_reduction", False))
+        threshold_percent = float(drastic_reduction_data.get("threshold_percent", threshold_percent))
+
+    if new_count is None:
+        new_count = text_char_count
+    if reduction_percent is None:
+        reduction_percent = calculate_reduction_percent(previous_count, new_count)
+
+    if drastic_reduction_data and "drastic_reduction" in drastic_reduction_data:
+        detected = bool(drastic_reduction_data.get("drastic_reduction"))
+    elif reduction_percent is not None:
         detected = reduction_percent >= threshold_percent
 
     return {
         "previous_text_char_count": previous_count,
         "text_reduction_percent": reduction_percent,
         "drastic_reduction_detected": detected,
+        "previous_char_count": previous_count,
+        "new_char_count": new_count,
+        "reduction_percent": reduction_percent,
+        "drastic_reduction": detected,
     }
 
 

--- a/migrations/versions/4e6f8a1b2c3d_add_article_version_reduction_fields.py
+++ b/migrations/versions/4e6f8a1b2c3d_add_article_version_reduction_fields.py
@@ -1,0 +1,40 @@
+"""add explicit article version reduction fields
+
+Revision ID: 4e6f8a1b2c3d
+Revises: a7c5d3e9f012
+Create Date: 2026-05-06 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '4e6f8a1b2c3d'
+down_revision = 'a7c5d3e9f012'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('article_version', sa.Column('previous_char_count', sa.Integer(), nullable=True))
+    op.add_column('article_version', sa.Column('new_char_count', sa.Integer(), nullable=True))
+    op.add_column('article_version', sa.Column('reduction_percent', sa.Float(), nullable=True))
+    op.add_column(
+        'article_version',
+        sa.Column('drastic_reduction', sa.Boolean(), nullable=False, server_default='false'),
+    )
+    op.execute(
+        """
+        UPDATE article_version
+        SET previous_char_count = previous_text_char_count,
+            new_char_count = text_char_count,
+            reduction_percent = text_reduction_percent,
+            drastic_reduction = drastic_reduction_detected
+        """
+    )
+
+
+def downgrade():
+    op.drop_column('article_version', 'drastic_reduction')
+    op.drop_column('article_version', 'reduction_percent')
+    op.drop_column('article_version', 'new_char_count')
+    op.drop_column('article_version', 'previous_char_count')

--- a/templates/artigos/editar_artigo.html
+++ b/templates/artigos/editar_artigo.html
@@ -42,6 +42,10 @@
           {% set form_texto = f.get('texto', artigo.texto) %}
           {% set vis = f.get('visibility', artigo.visibility.value) %}
           <input type="hidden" name="progress_id" id="progress-id">
+          <input type="hidden" name="drastic_reduction_confirmed" id="drastic-reduction-confirmed" value="false">
+          <input type="hidden" name="previous_char_count" id="previous-char-count">
+          <input type="hidden" name="new_char_count" id="new-char-count">
+          <input type="hidden" name="reduction_percent" id="reduction-percent">
           <div class="mb-3">
             <label class="form-label">Título</label>
             <input name="titulo" class="form-control" value="{{ form_titulo }}" required>
@@ -204,6 +208,34 @@
   const visInput = document.getElementById('visibilityInput');
   const visDisplay = document.getElementById('visibilityDisplay');
   const STORAGE_KEY = 'draft_editar_artigo_{{ artigo.id }}';
+  const DRASTIC_REDUCTION_MESSAGE = 'Esta alteração reduz significativamente o conteúdo do artigo. Confirme se deseja continuar.';
+  const previousArticleCharCount = Number({{ previous_char_count | default(0) | tojson }}) || 0;
+
+  function normalizePlainTextForCount(text) {
+    return (text || '').replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
+  }
+
+  function plainTextFromHtmlForCount(html) {
+    const holder = document.createElement('div');
+    holder.innerHTML = html || '';
+    return normalizePlainTextForCount(holder.textContent || holder.innerText || '');
+  }
+
+  function calculateReductionPercent(previousCount, newCount) {
+    if (!previousCount || previousCount <= 0 || newCount >= previousCount) return 0;
+    return ((previousCount - newCount) / previousCount) * 100;
+  }
+
+  function updateReductionFields({ confirmed = false } = {}) {
+    const newText = normalizePlainTextForCount(quill.getText ? quill.getText() : plainTextFromHtmlForCount(quill.root.innerHTML));
+    const newCharCount = newText.length;
+    const reductionPercent = calculateReductionPercent(previousArticleCharCount, newCharCount);
+    document.getElementById('drastic-reduction-confirmed').value = confirmed ? 'true' : 'false';
+    document.getElementById('previous-char-count').value = String(previousArticleCharCount);
+    document.getElementById('new-char-count').value = String(newCharCount);
+    document.getElementById('reduction-percent').value = reductionPercent.toFixed(2);
+    return { newCharCount, reductionPercent };
+  }
   function saveDraft() {
     localStorage.setItem(
       STORAGE_KEY,
@@ -366,6 +398,13 @@
       const hiddenTexto = document.getElementById('hidden-texto');
       if (hiddenTexto) {
         hiddenTexto.value = quill.root.innerHTML;
+      }
+      const reductionMetrics = updateReductionFields();
+      const hasDrasticReduction = reductionMetrics.reductionPercent > 70 || (previousArticleCharCount > 2000 && reductionMetrics.newCharCount < 300);
+      if (hasDrasticReduction) {
+        const confirmed = window.confirm(DRASTIC_REDUCTION_MESSAGE);
+        if (!confirmed) return;
+        updateReductionFields({ confirmed: true });
       }
       const progressId = progressIdInput?.value || (crypto.randomUUID ? crypto.randomUUID() : String(Date.now()));
       if (progressIdInput) progressIdInput.value = progressId;

--- a/tests/test_article_version_reduction.py
+++ b/tests/test_article_version_reduction.py
@@ -1,0 +1,17 @@
+from core.services.article_versions import (
+    calculate_plain_text_char_count,
+    calculate_reduction_percent,
+    is_drastic_content_reduction,
+)
+
+
+def test_plain_text_char_count_strips_html_and_normalizes_space():
+    assert calculate_plain_text_char_count('<p>Olá&nbsp; <strong>mundo</strong></p>') == len('Olá mundo')
+
+
+def test_reduction_percent_and_drastic_thresholds():
+    reduction_percent = calculate_reduction_percent(1000, 250)
+
+    assert reduction_percent == 75
+    assert is_drastic_content_reduction(1000, 250, reduction_percent) is True
+    assert is_drastic_content_reduction(2500, 299, None) is True


### PR DESCRIPTION
### Motivation
- Prevent accidental major deletions by surfacing a confirmation when an edit reduces article content significantly and ensure the server also recalculates and records the same metrics for audit.
- Record explicit reduction metrics on article snapshots so reductions are auditable in `ArticleVersion`.

### Description
- Client: added safe exposure of the previous plain-text character count and client-side reduction detection to `templates/artigos/editar_artigo.html`, including hidden fields `drastic_reduction_confirmed`, `previous_char_count`, `new_char_count` and `reduction_percent`, normalization of Quill/HTML text for counting, and a confirmation prompt with the message `Esta alteração reduz significativamente o conteúdo do artigo. Confirme se deseja continuar.` when reduction is >70% or when new text <300 chars and previous >2000; when confirmed the hidden fields are populated and `drastic_reduction_confirmed=true` is submitted.
- Backend: in `blueprints/articles.py` the server recalculates plain-text counts and reduction metrics via `_build_drastic_reduction_data(...)`, requires client confirmation if a drastic reduction is detected, and still permits the change when confirmed; the server passes the same `drastic_reduction_data` to `create_article_version_snapshot` so the snapshot is recorded consistently.
- Helpers & snapshot logic: extended `core/services/article_versions.py` with `extract_plain_text_for_count`, `calculate_plain_text_char_count`, `calculate_reduction_percent`, and `is_drastic_content_reduction`, and updated `_drastic_reduction_metrics` to accept and normalize the new fields while returning both legacy and new metric keys for compatibility.
- Model & migration: added explicit `ArticleVersion` columns `previous_char_count`, `new_char_count`, `reduction_percent` and `drastic_reduction` and included an Alembic migration at `migrations/versions/4e6f8a1b2c3d_add_article_version_reduction_fields.py` to persist and backfill values.
- Tests: added `tests/test_article_version_reduction.py` to cover plain-text extraction/counting and reduction threshold behavior.

### Testing
- Ran `pytest -q tests/test_article_version_reduction.py tests/test_article_permissions.py` and all tests passed (`11 passed, 12 warnings`).
- Compiled modified modules with `python -m py_compile blueprints/articles.py core/services/article_versions.py core/models.py migrations/versions/4e6f8a1b2c3d_add_article_version_reduction_fields.py tests/test_article_version_reduction.py` with no syntax errors.
- Ran `git diff --check` (no whitespace/check issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb47cd5d94832e91f54f4c66880ca8)