### PR TITLE
Adicionar comparação de versões de artigos

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -62,6 +62,7 @@ try:
         calculate_plain_text_char_count,
         calculate_reduction_percent,
         calculate_text_char_count,
+        compare_article_versions,
         create_article_version_snapshot,
         is_drastic_content_reduction,
     )
@@ -71,6 +72,7 @@ except ImportError:  # pragma: no cover
         calculate_plain_text_char_count,
         calculate_reduction_percent,
         calculate_text_char_count,
+        compare_article_versions,
         create_article_version_snapshot,
         is_drastic_content_reduction,
     )
@@ -662,6 +664,56 @@ def historico_versoes_artigo(artigo_id):
         artigo=artigo,
         versoes=versoes,
         can_restore_versions=user_can_restore_article_version(user),
+        ArticleStatus=ArticleStatus,
+    )
+
+
+@articles_bp.route('/artigo/<int:artigo_id>/versoes/comparar', methods=['GET'], endpoint='comparar_versoes_artigo')
+def comparar_versoes_artigo(artigo_id):
+    if 'username' not in session:
+        return redirect(url_for('login'))
+
+    artigo = Article.query.get(artigo_id)
+    if not artigo:
+        return _render_artigo_indisponivel(artigo_id)
+
+    user = User.query.filter_by(username=session['username']).first()
+    if not user_can_view_article(user, artigo):
+        flash('Você não tem permissão para ver este artigo.', 'danger')
+        return redirect(url_for('pagina_inicial'))
+
+    from_id = request.args.get('from', type=int)
+    to_id = request.args.get('to', type=int)
+    if not from_id or not to_id or from_id == to_id:
+        flash('Selecione duas versões diferentes para comparar.', 'warning')
+        return redirect(url_for('historico_versoes_artigo', artigo_id=artigo.id))
+
+    versoes = (
+        ArticleVersion.query
+        .filter(
+            ArticleVersion.article_id == artigo.id,
+            ArticleVersion.id.in_([from_id, to_id]),
+        )
+        .all()
+    )
+    if len(versoes) != 2:
+        flash('Uma ou mais versões selecionadas não pertencem a este artigo.', 'danger')
+        return redirect(url_for('historico_versoes_artigo', artigo_id=artigo.id))
+
+    versoes_por_id = {versao.id: versao for versao in versoes}
+    from_version = versoes_por_id[from_id]
+    to_version = versoes_por_id[to_id]
+    for versao in (from_version, to_version):
+        versao.local_created_at = _local_datetime(versao.created_at)
+
+    comparacao = compare_article_versions(from_version, to_version)
+
+    return render_template(
+        'artigos/comparar_versoes.html',
+        artigo=artigo,
+        from_version=from_version,
+        to_version=to_version,
+        comparacao=comparacao,
         ArticleStatus=ArticleStatus,
     )
 

--- a/core/services/article_versions.py
+++ b/core/services/article_versions.py
@@ -193,6 +193,86 @@ def _drastic_reduction_metrics(text_char_count: int, drastic_reduction_data: dic
     }
 
 
+def _words_for_comparison(text: str | None) -> list[str]:
+    """Normaliza texto legível para comparar palavras entre versões."""
+    plain_text = extract_plain_text_for_count(text).casefold()
+    return re.findall(r"\w+", plain_text, re.UNICODE)
+
+
+def _counter_delta_items(from_words: list[str], to_words: list[str]) -> list[dict[str, int | str]]:
+    from collections import Counter
+
+    removed_counter = Counter(from_words) - Counter(to_words)
+    added_counter = Counter(to_words) - Counter(from_words)
+    words = sorted(set(removed_counter) | set(added_counter))
+    return [
+        {
+            "word": word,
+            "removed": int(removed_counter.get(word, 0)),
+            "added": int(added_counter.get(word, 0)),
+        }
+        for word in words
+    ]
+
+
+def compare_article_versions(from_version: ArticleVersion, to_version: ArticleVersion) -> dict[str, Any]:
+    """Compara dois snapshots do mesmo artigo usando apenas texto e metadados.
+
+    A comparação é propositalmente simples: calcula deltas de caracteres em
+    título/texto, contagens de palavras adicionadas/removidas e uma lista de
+    metadados textuais que mudaram entre os snapshots. Anexos não participam.
+    """
+    if from_version.article_id != to_version.article_id:
+        raise ValueError("As versões comparadas devem pertencer ao mesmo artigo.")
+
+    from_text = from_version.texto or ""
+    to_text = to_version.texto or ""
+    from_title = from_version.titulo or ""
+    to_title = to_version.titulo or ""
+    from_words = _words_for_comparison(from_text)
+    to_words = _words_for_comparison(to_text)
+    word_deltas = _counter_delta_items(from_words, to_words)
+
+    metadata_fields = (
+        ("status", "Status"),
+        ("visibility", "Visibilidade"),
+        ("tipo_id", "Tipo"),
+        ("area_id", "Área"),
+        ("sistema_id", "Sistema"),
+        ("instituicao_id", "Instituição"),
+        ("estabelecimento_id", "Estabelecimento"),
+        ("setor_id", "Setor"),
+        ("vis_celula_id", "Célula de visibilidade"),
+        ("celula_id", "Célula autora"),
+        ("user_id_original_author", "Autor original"),
+    )
+    metadata_changes = []
+    for field, label in metadata_fields:
+        from_value = getattr(from_version, field, None)
+        to_value = getattr(to_version, field, None)
+        if from_value != to_value:
+            metadata_changes.append({
+                "field": field,
+                "label": label,
+                "from": from_value,
+                "to": to_value,
+            })
+
+    return {
+        "char_delta": len(to_text) - len(from_text),
+        "title_char_delta": len(to_title) - len(from_title),
+        "text_char_delta": len(to_text) - len(from_text),
+        "from_text_char_count": len(from_text),
+        "to_text_char_count": len(to_text),
+        "from_title_char_count": len(from_title),
+        "to_title_char_count": len(to_title),
+        "words_added_count": sum(item["added"] for item in word_deltas),
+        "words_removed_count": sum(item["removed"] for item in word_deltas),
+        "word_deltas": word_deltas,
+        "metadata_changes": metadata_changes,
+    }
+
+
 def create_article_version_snapshot(
     article,
     changed_by_user,

--- a/templates/artigos/comparar_versoes.html
+++ b/templates/artigos/comparar_versoes.html
@@ -1,0 +1,203 @@
+{% extends 'base.html' %}
+{% block title %}Comparar versões - {{ artigo.titulo }}{% endblock %}
+
+{% block content %}
+{% set status_labels = {
+  'rascunho': 'Rascunho',
+  'pendente': 'Pendente',
+  'aprovado': 'Aprovado',
+  'rejeitado': 'Rejeitado'
+} %}
+{% set visibility_labels = {
+  'privado': 'Privado',
+  'celula': 'Célula',
+  'setor': 'Setor',
+  'estabelecimento': 'Estabelecimento',
+  'instituicao': 'Instituição',
+  'publico': 'Público'
+} %}
+{% set action_labels = {
+  'create_initial': 'Criação inicial',
+  'initial_create': 'Criação inicial',
+  'submit_for_approval': 'Enviado para aprovação',
+  'edit_after_approved': 'Edição pós-aprovação',
+  'approve': 'Aprovação',
+  'reject': 'Rejeição',
+  'request_revision': 'Solicitação de revisão',
+  'restore_version': 'Restauração de versão'
+} %}
+{% macro version_label(versao) -%}
+v{{ versao.version_number }}.r{{ versao.revision_number }}
+{%- endmacro %}
+{% macro version_metadata(versao) -%}
+<dl class="row small mb-0">
+  <dt class="col-sm-4">Criado em</dt>
+  <dd class="col-sm-8">{% if versao.local_created_at %}{{ versao.local_created_at.strftime('%d/%m/%Y %H:%M') }}{% else %}—{% endif %}</dd>
+  <dt class="col-sm-4">Usuário</dt>
+  <dd class="col-sm-8">{{ versao.changed_by_nome_completo or versao.changed_by_username or 'Não informado' }}</dd>
+  <dt class="col-sm-4">Cargo</dt>
+  <dd class="col-sm-8">{{ versao.changed_by_cargo_nome or 'Cargo não informado' }}</dd>
+  <dt class="col-sm-4">Ação</dt>
+  <dd class="col-sm-8">{{ action_labels.get(versao.change_action, versao.change_action) }}</dd>
+  <dt class="col-sm-4">Status</dt>
+  <dd class="col-sm-8">{{ status_labels.get(versao.status, versao.status) }}</dd>
+  <dt class="col-sm-4">Visibilidade</dt>
+  <dd class="col-sm-8">{{ visibility_labels.get(versao.visibility, versao.visibility) }}</dd>
+  <dt class="col-sm-4">Tamanho</dt>
+  <dd class="col-sm-8">{{ versao.text_char_count }} caracteres • {{ versao.text_word_count }} palavras</dd>
+  {% if versao.change_reason %}
+  <dt class="col-sm-4">Motivo</dt>
+  <dd class="col-sm-8">{{ versao.change_reason }}</dd>
+  {% endif %}
+</dl>
+{%- endmacro %}
+<div class="container-fluid page-root">
+  <div class="row">
+    <div class="col-12 mx-auto">
+      <div class="card shadow-sm mb-3">
+        <div class="card-body">
+          <div class="d-flex flex-wrap justify-content-between align-items-start gap-2">
+            <div>
+              <h3 class="mb-1">Comparar versões</h3>
+              <p class="text-muted mb-0"><strong>Artigo:</strong> {{ artigo.titulo }}</p>
+            </div>
+            <div class="d-flex flex-wrap gap-2">
+              <a href="{{ url_for('historico_versoes_artigo', artigo_id=artigo.id) }}" class="btn btn-app btn-app-secondary">
+                <i class="bi bi-arrow-left" aria-hidden="true"></i> Voltar ao histórico
+              </a>
+              <a href="{{ url_for('artigo', artigo_id=artigo.id) }}" class="btn btn-app btn-app-secondary">
+                <i class="bi bi-file-text" aria-hidden="true"></i> Ver artigo atual
+              </a>
+            </div>
+          </div>
+
+          <hr>
+
+          <div class="row g-3 text-center">
+            <div class="col-md-3">
+              <div class="border rounded p-3 h-100">
+                <div class="text-muted small">Caracteres no texto</div>
+                <div class="fs-4 fw-semibold">{{ comparacao.text_char_delta }}</div>
+              </div>
+            </div>
+            <div class="col-md-3">
+              <div class="border rounded p-3 h-100">
+                <div class="text-muted small">Caracteres no título</div>
+                <div class="fs-4 fw-semibold">{{ comparacao.title_char_delta }}</div>
+              </div>
+            </div>
+            <div class="col-md-3">
+              <div class="border rounded p-3 h-100">
+                <div class="text-muted small">Palavras adicionadas</div>
+                <div class="fs-4 fw-semibold text-success">{{ comparacao.words_added_count }}</div>
+              </div>
+            </div>
+            <div class="col-md-3">
+              <div class="border rounded p-3 h-100">
+                <div class="text-muted small">Palavras removidas</div>
+                <div class="fs-4 fw-semibold text-danger">{{ comparacao.words_removed_count }}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row g-3">
+        <div class="col-lg-6">
+          <div class="card shadow-sm h-100">
+            <div class="card-header bg-light">
+              <strong>De {{ version_label(from_version) }}</strong>
+            </div>
+            <div class="card-body">
+              <h4>{{ from_version.titulo }}</h4>
+              <hr>
+              {{ version_metadata(from_version) }}
+              <hr>
+              <div class="article-version-readonly border rounded p-3 bg-light">
+                {{ from_version.texto.replace('\n', '<br>')|safe }}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-6">
+          <div class="card shadow-sm h-100">
+            <div class="card-header bg-light">
+              <strong>Para {{ version_label(to_version) }}</strong>
+            </div>
+            <div class="card-body">
+              <h4>{{ to_version.titulo }}</h4>
+              <hr>
+              {{ version_metadata(to_version) }}
+              <hr>
+              <div class="article-version-readonly border rounded p-3 bg-light">
+                {{ to_version.texto.replace('\n', '<br>')|safe }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card shadow-sm mt-3">
+        <div class="card-body">
+          <h5>Palavras adicionadas/removidas</h5>
+          {% if comparacao.word_deltas %}
+          <div class="table-responsive">
+            <table class="table table-sm align-middle mb-0">
+              <thead>
+                <tr>
+                  <th>Palavra</th>
+                  <th class="text-end text-danger">Removidas</th>
+                  <th class="text-end text-success">Adicionadas</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for item in comparacao.word_deltas %}
+                <tr>
+                  <td>{{ item.word }}</td>
+                  <td class="text-end text-danger">{{ item.removed }}</td>
+                  <td class="text-end text-success">{{ item.added }}</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% else %}
+          <p class="text-muted mb-0">Nenhuma palavra adicionada ou removida no texto.</p>
+          {% endif %}
+        </div>
+      </div>
+
+      <div class="card shadow-sm mt-3">
+        <div class="card-body">
+          <h5>Metadados alterados</h5>
+          {% if comparacao.metadata_changes %}
+          <div class="table-responsive">
+            <table class="table table-sm align-middle mb-0">
+              <thead>
+                <tr>
+                  <th>Campo</th>
+                  <th>De</th>
+                  <th>Para</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for item in comparacao.metadata_changes %}
+                <tr>
+                  <td>{{ item.label }}</td>
+                  <td>{{ item['from'] if item['from'] is not none else '—' }}</td>
+                  <td>{{ item['to'] if item['to'] is not none else '—' }}</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% else %}
+          <p class="text-muted mb-0">Nenhum metadado textual foi alterado entre as versões selecionadas.</p>
+          {% endif %}
+          <p class="text-muted small mt-3 mb-0">Anexos não são incluídos nesta comparação.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/artigos/historico_versoes.html
+++ b/templates/artigos/historico_versoes.html
@@ -38,6 +38,37 @@
 
           <hr>
 
+          {% if versoes|length >= 2 %}
+          <div class="card bg-light border-0 mb-3">
+            <div class="card-body">
+              <form class="row g-2 align-items-end" method="get" action="{{ url_for('comparar_versoes_artigo', artigo_id=artigo.id) }}">
+                <div class="col-md-5">
+                  <label for="compareFrom" class="form-label">Comparar de</label>
+                  <select class="form-select" id="compareFrom" name="from" required>
+                    {% for versao in versoes %}
+                    <option value="{{ versao.id }}" {% if loop.index0 == 1 %}selected{% endif %}>v{{ versao.version_number }}.r{{ versao.revision_number }} — {% if versao.local_created_at %}{{ versao.local_created_at.strftime('%d/%m/%Y %H:%M') }}{% else %}sem data{% endif %}</option>
+                    {% endfor %}
+                  </select>
+                </div>
+                <div class="col-md-5">
+                  <label for="compareTo" class="form-label">Comparar para</label>
+                  <select class="form-select" id="compareTo" name="to" required>
+                    {% for versao in versoes %}
+                    <option value="{{ versao.id }}">v{{ versao.version_number }}.r{{ versao.revision_number }} — {% if versao.local_created_at %}{{ versao.local_created_at.strftime('%d/%m/%Y %H:%M') }}{% else %}sem data{% endif %}</option>
+                    {% endfor %}
+                  </select>
+                </div>
+                <div class="col-md-2 d-grid">
+                  <button type="submit" class="btn btn-app btn-app-primary">
+                    <i class="bi bi-arrow-left-right" aria-hidden="true"></i> Comparar
+                  </button>
+                </div>
+              </form>
+              <p class="text-muted small mt-2 mb-0">A comparação considera apenas título, texto e metadados; anexos não são incluídos.</p>
+            </div>
+          </div>
+          {% endif %}
+
           {% if versoes %}
           <div class="table-responsive">
             <table class="table table-hover align-middle">

--- a/tests/test_article_version_compare.py
+++ b/tests/test_article_version_compare.py
@@ -1,0 +1,64 @@
+import pytest
+
+from core.models import ArticleVersion
+from core.services.article_versions import compare_article_versions
+
+
+def test_compare_article_versions_text_and_metadata_only():
+    from_version = ArticleVersion(
+        article_id=10,
+        version_number=1,
+        revision_number=0,
+        titulo="Título antigo",
+        texto="Olá mundo antigo",
+        status="rascunho",
+        visibility="celula",
+        change_action="create_initial",
+    )
+    to_version = ArticleVersion(
+        article_id=10,
+        version_number=1,
+        revision_number=1,
+        titulo="Título novo",
+        texto="Olá mundo novo mundo",
+        status="aprovado",
+        visibility="setor",
+        change_action="approve",
+    )
+
+    comparison = compare_article_versions(from_version, to_version)
+
+    assert comparison["text_char_delta"] == len(to_version.texto) - len(from_version.texto)
+    assert comparison["title_char_delta"] == len(to_version.titulo) - len(from_version.titulo)
+    assert comparison["words_added_count"] == 2
+    assert comparison["words_removed_count"] == 1
+    assert {item["word"]: item for item in comparison["word_deltas"]} == {
+        "antigo": {"word": "antigo", "removed": 1, "added": 0},
+        "mundo": {"word": "mundo", "removed": 0, "added": 1},
+        "novo": {"word": "novo", "removed": 0, "added": 1},
+    }
+    assert {
+        change["field"] for change in comparison["metadata_changes"]
+    } >= {"status", "visibility"}
+
+
+def test_compare_article_versions_rejects_different_articles():
+    from_version = ArticleVersion(
+        article_id=1,
+        titulo="A",
+        texto="um",
+        status="rascunho",
+        visibility="celula",
+        change_action="create_initial",
+    )
+    to_version = ArticleVersion(
+        article_id=2,
+        titulo="A",
+        texto="dois",
+        status="rascunho",
+        visibility="celula",
+        change_action="create_initial",
+    )
+
+    with pytest.raises(ValueError, match="mesmo artigo"):
+        compare_article_versions(from_version, to_version)


### PR DESCRIPTION
### Motivation
- Permitir comparar duas snapshots de um mesmo artigo no frontend para ajudar revisão e auditoria sem introduzir comparação de anexos por ora.
- Fornecer uma comparação simples e robusta baseada apenas em texto e metadados para evitar complexidade com binários e formatos externos.

### Description
- Adicionada rota `GET /artigo/<int:artigo_id>/versoes/comparar` em `blueprints/articles.py` com validação de sessão e permissão de visualização, leitura dos parâmetros `from`/`to` e carregamento de duas `ArticleVersion` do mesmo `article_id` antes de renderizar a tela de comparação.
- Implementada a função `compare_article_versions` em `core/services/article_versions.py` junto com helpers `_words_for_comparison` e `_counter_delta_items` para calcular deltas de caracteres, contagens de palavras adicionadas/removidas e mudanças de metadados textuais (sem anexos).
- Criado template `templates/artigos/comparar_versoes.html` que exibe lado a lado título/texto/metadados das duas versões, resumo de métricas (caracteres/palavras) e tabelas de palavras e metadados alterados.
- Atualizada a tela de histórico `templates/artigos/historico_versoes.html` para exibir um formulário de seleção/links para comparar duas versões quando houver ao menos duas entradas.

### Testing
- Rodado `pytest tests/test_article_version_compare.py -q` e os testes do novo helper passaram (`2 passed`).
- Executado `pytest -q` contra a suíte completa e todos os testes passaram (`161 passed, 1 skipped`).
- Compilação estática com `python -m compileall blueprints core tests/test_article_version_compare.py` foi bem-sucedida e os templates foram renderizados manualmente em `app.test_request_context` para verificação visual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4bd678c8832e9129b465244259a6)