### PR TITLE
Fix article version imports for package loading

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -10,9 +10,9 @@ except ImportError:
     from core.database import db
 
 try:
-    from ..core.models import Article, Attachment, Comment, Notification, User, RevisionRequest, ArtigoTipo, ArtigoArea, ArtigoSistema, ArticleDeletionAudit, ProcessoEtapa, Processo, processo_etapa_article
+    from ..core.models import Article, Attachment, Comment, Notification, User, RevisionRequest, ArtigoTipo, ArtigoArea, ArtigoSistema, ArticleDeletionAudit, ProcessoEtapa, Processo, processo_etapa_article, ArticleVersion
 except ImportError:
-    from core.models import Article, Attachment, Comment, Notification, User, RevisionRequest, ArtigoTipo, ArtigoArea, ArtigoSistema, ArticleDeletionAudit, ProcessoEtapa, Processo, processo_etapa_article
+    from core.models import Article, Attachment, Comment, Notification, User, RevisionRequest, ArtigoTipo, ArtigoArea, ArtigoSistema, ArticleDeletionAudit, ProcessoEtapa, Processo, processo_etapa_article, ArticleVersion
 
 try:
     from ..core.enums import ArticleStatus, ArticleVisibility, Permissao
@@ -31,6 +31,7 @@ try:
         log_article_exception,
         build_like_pattern,
         strip_accents,
+        user_can_restore_article_version,
     )
 except ImportError:  # pragma: no cover - fallback for direct execution
     from core.utils import (
@@ -44,6 +45,7 @@ except ImportError:  # pragma: no cover - fallback for direct execution
         log_article_exception,
         build_like_pattern,
         strip_accents,
+        user_can_restore_article_version,
     )
 try:
     from ..core.services.ocr_queue import (
@@ -77,11 +79,6 @@ except ImportError:  # pragma: no cover
         is_drastic_content_reduction,
     )
 
-
-# Importados separadamente após a definição/carregamento dos modelos para evitar
-# acoplamento com a lista principal de modelos do blueprint.
-from core.models import ArticleVersion
-from core.utils import user_can_restore_article_version
 
 try:
     from ..core.progress import (


### PR DESCRIPTION
### Motivation
- Prevent ImportError when the app is imported as a package (e.g. during `flask db upgrade`) caused by new absolute imports for article versioning that break package-relative resolution.
- Keep the blueprint import style consistent with the project's existing relative/fallback pattern so blueprints load in both direct and package import modes.

### Description
- Moved `ArticleVersion` into the existing `..core.models` relative/fallback import block in `blueprints/articles.py` so it is imported via the same try/except pattern as other models.
- Added `user_can_restore_article_version` to the existing `..core.utils` relative/fallback import block and removed the separate absolute imports that were placed later in the file.
- Removed the duplicate absolute imports at the end of the earlier change so the blueprint no longer relies on bare `from core...`/`from blueprints...` imports outside the fallback blocks.

### Testing
- Ran `python -m py_compile blueprints/articles.py` and it completed successfully.
- Verified package import with `SECRET_KEY=... PASSWORD_RESET_SECRET=... DATABASE_URI=sqlite:////tmp/orquetask_import_check.db ALLOW_SQLITE_FOR_TESTS=1 PYTHONPATH=/workspace python -c "import repositorio_equipe.app"` which succeeded and printed confirmation.
- Ran `pytest tests/test_article_version_compare.py tests/test_article_version_reduction.py tests/test_artigo_restaurar_versao_permission.py` and all tests passed (`5 passed`).
- Attempted `flask db upgrade` in a local SQLite verification to exercise the `db` command, which opened the app successfully but the upgrade failed due to migrations using PostgreSQL-specific `CREATE TYPE` syntax when run against SQLite (expected for this verification and not a regression of this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5272b468832e99d15d6f4602671a)