### PR TITLE
Fix article POST version snapshot timing

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -526,31 +526,23 @@ def artigo(artigo_id):
             return redirect(url_for('artigo', artigo_id=artigo_id))
 
         status_before = artigo.status
-        if article_relevant_state_changed(
+        status_after = ArticleStatus.PENDENTE
+        relevant_change = article_relevant_state_changed(
             artigo,
             titulo=novo_titulo,
             texto=novo_texto,
-            status=ArticleStatus.PENDENTE,
-        ):
-            snapshot_action = (
-                "edit_after_approved"
-                if status_before is ArticleStatus.APROVADO
-                else "submit_for_approval"
-            )
-            create_article_version_snapshot(
-                artigo,
-                user,
-                snapshot_action,
-                source_status_before=status_before,
-                source_status_after=ArticleStatus.PENDENTE,
-                correlation_id=getattr(g, "request_correlation_id", None),
-                drastic_reduction_data={
-                    "previous_text_char_count": calculate_text_char_count(artigo.texto),
-                },
-            )
+            status=status_after,
+        )
+        previous_text_char_count = calculate_text_char_count(artigo.texto)
+        snapshot_action = (
+            "edit_after_approved"
+            if status_before is ArticleStatus.APROVADO
+            else "submit_for_approval"
+        )
+
         artigo.titulo = novo_titulo
         artigo.texto  = novo_texto
-        artigo.status = ArticleStatus.PENDENTE
+        artigo.status = status_after
         artigo.updated_at = datetime.now(timezone.utc)
 
         # 2) arquivos existentes
@@ -581,6 +573,19 @@ def artigo(artigo_id):
                 existing.append(original)
 
         artigo.arquivos = json.dumps(existing) if existing else None
+
+        if relevant_change:
+            create_article_version_snapshot(
+                artigo,
+                user,
+                snapshot_action,
+                source_status_before=status_before,
+                source_status_after=status_after,
+                correlation_id=getattr(g, "request_correlation_id", None),
+                drastic_reduction_data={
+                    "previous_text_char_count": previous_text_char_count,
+                },
+            )
 
         db.session.commit()
         flash('Artigo enviado para revisão!', 'success')

--- a/tests/test_article_versioning_lifecycle.py
+++ b/tests/test_article_versioning_lifecycle.py
@@ -13,6 +13,7 @@ from core.models import (
     User,
 )
 from core.services.article_versions import create_article_version_snapshot
+from core.utils import sanitize_html
 
 
 @pytest.fixture
@@ -132,6 +133,45 @@ def test_article_creation_route_creates_initial_snapshot(app_ctx, client, articl
     assert (snapshots[0].version_number, snapshots[0].revision_number) == (0, 1)
     assert snapshots[0].titulo == article.titulo
     assert snapshots[0].texto == "<p>Conteúdo inicial do artigo.</p>"
+
+
+def test_artigo_post_edit_submission_snapshots_new_sanitized_rich_html(app_ctx, client, article_org):
+    author = _create_user("autor_artigo_post_rich_html", article_org)
+    previous_html = "<p>Texto anterior que não deve ir para o snapshot de edição.</p>"
+    article = _create_article(author, article_org, texto=previous_html)
+    create_article_version_snapshot(article, author, "create_initial")
+    db.session.commit()
+    _login(client, author)
+
+    new_rich_html = (
+        '<h2>Novo HTML</h2>'
+        '<p><strong>Conteúdo</strong> <em>rico</em> '
+        '<a href="javascript:alert(1)" onclick="alert(1)">link</a></p>'
+        '<ul><li>Item novo</li></ul>'
+        '<img src="https://example.test/imagem.png" onerror="alert(1)">'
+    )
+    expected_sanitized_html = sanitize_html(new_rich_html).strip()
+
+    response = client.post(
+        f"/artigo/{article.id}",
+        data={
+            "titulo": "Título com HTML rico atualizado",
+            "texto": new_rich_html,
+        },
+    )
+
+    assert response.status_code == 302
+    article = Article.query.get(article.id)
+    latest_snapshot = _versions(article.id)[-1]
+    assert article.status == ArticleStatus.PENDENTE
+    assert article.texto == expected_sanitized_html
+    assert latest_snapshot.change_action == "submit_for_approval"
+    assert latest_snapshot.source_status_before == ArticleStatus.RASCUNHO.value
+    assert latest_snapshot.source_status_after == ArticleStatus.PENDENTE.value
+    assert latest_snapshot.texto == expected_sanitized_html
+    assert previous_html not in latest_snapshot.texto
+    assert 'href="javascript:' not in latest_snapshot.texto
+    assert "onerror" not in latest_snapshot.texto
 
 
 def test_editing_title_text_and_metadata_snapshots_state_before_overwrite_and_increments_revision(article_org):


### PR DESCRIPTION
### Motivation
- The POST flow for `/artigo/<id>` created version snapshots before the Article object and its attachments were updated, causing snapshots to capture stale text and metadata.
- The change ensures `ArticleVersion` snapshots reflect the new sanitized rich HTML and correct `source_status_before`/`source_status_after` values.

### Description
- In `blueprints/articles.py` compute `status_before`, `status_after` and `relevant_change` and capture `previous_text_char_count` before mutating the `Article` object, and determine `snapshot_action` early using those values.
- Apply updates to the article fields (`titulo`, `texto`, `status`, timestamps and related metadata) and attachments first, then call `create_article_version_snapshot(...)` so the snapshot uses the updated article state and include `drastic_reduction_data` with `previous_text_char_count` and the correlation id.
- Preserve and pass `source_status_before` and `source_status_after` into the snapshot call so stored status transitions remain accurate.
- Add regression test `test_artigo_post_edit_submission_snapshots_new_sanitized_rich_html` in `tests/test_article_versioning_lifecycle.py` which posts rich HTML to `/artigo/<id>` and asserts that `Article.texto` and `ArticleVersion.texto` contain the new sanitized HTML (and not the previous content or unsafe attributes).

### Testing
- Ran `pytest -q tests/test_article_editing.py tests/test_article_versioning_lifecycle.py` and the test suite passed (15 passed, with warnings only); the new regression test executed successfully.
- Also ran the single-file run `pytest -q tests/test_article_versioning_lifecycle.py` during development and all tests in that file passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8f4beccc832e83424b76c0e1975e)