### PR TITLE
Limpa autosave de novo artigo após sucesso

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -141,7 +141,7 @@ def _new_article_form_defaults():
     }
 
 
-def _render_novo_artigo_form(form_data=None):
+def _render_novo_artigo_form(form_data=None, clear_autosave=False):
     data = _new_article_form_defaults()
     if form_data:
         data.update(form_data)
@@ -154,6 +154,7 @@ def _render_novo_artigo_form(form_data=None):
         areas_artigo=areas_artigo,
         sistemas_artigo=sistemas_artigo,
         form_data=data,
+        clear_novo_artigo_autosave=clear_autosave,
     )
 
 
@@ -471,11 +472,13 @@ def novo_artigo():
             else 'Artigo criado e enviado para revisão!',
             'success'
         )
+        session['artigo_novo_autosave_sucesso'] = True
         time.sleep(1)
         return redirect(url_for('meus_artigos'))
 
     # GET → exibe formulário
-    return _render_novo_artigo_form()
+    clear_autosave = bool(session.pop('artigo_novo_autosave_sucesso', False))
+    return _render_novo_artigo_form(clear_autosave=clear_autosave)
 
 @articles_bp.route('/meus-artigos', endpoint='meus_artigos')
 def meus_artigos():

--- a/templates/artigos/novo_artigo.html
+++ b/templates/artigos/novo_artigo.html
@@ -35,8 +35,8 @@
 
           <div class="row">
             <div class="col-md-6 mb-3">
-              <label class="form-label">Tipo de artigo</label>
-              <select name="tipo_id" class="form-select">
+              <label class="form-label" for="tipo-id">Tipo de artigo</label>
+              <select name="tipo_id" id="tipo-id" class="form-select">
                 <option value="">Selecione</option>
                 {% for tipo in tipos_artigo %}
                 <option value="{{ tipo.id }}" {% if f.get('tipo_id')|string == tipo.id|string %}selected{% endif %}>{{ tipo.nome }}</option>
@@ -44,8 +44,8 @@
               </select>
             </div>
             <div class="col-md-6 mb-3">
-              <label class="form-label">Área</label>
-              <select name="area_id" class="form-select">
+              <label class="form-label" for="area-id">Área</label>
+              <select name="area_id" id="area-id" class="form-select">
                 <option value="">Selecione</option>
                 {% for area in areas_artigo %}
                 <option value="{{ area.id }}" {% if f.get('area_id')|string == area.id|string %}selected{% endif %}>{{ area.nome }}</option>
@@ -53,8 +53,8 @@
               </select>
             </div>
             <div class="col-md-6 mb-3">
-              <label class="form-label">Sistema</label>
-              <select name="sistema_id" class="form-select">
+              <label class="form-label" for="sistema-id">Sistema</label>
+              <select name="sistema_id" id="sistema-id" class="form-select">
                 <option value="">Selecione</option>
                 {% for sistema in sistemas_artigo %}
                 <option value="{{ sistema.id }}" {% if f.get('sistema_id')|string == sistema.id|string %}selected{% endif %}>{{ sistema.nome }}</option>
@@ -137,24 +137,42 @@ document.addEventListener('DOMContentLoaded', () => {
   const visChecks = document.querySelectorAll('.vis-check');
   const visInput = document.getElementById('visibilityInput');
   const visDisplay = document.getElementById('visibilityDisplay');
-  const STORAGE_KEY = 'draft_novo_artigo';
+  const tituloInput = document.getElementById('titulo');
+  const tipoInput = document.getElementById('tipo-id');
+  const areaInput = document.getElementById('area-id');
+  const sistemaInput = document.getElementById('sistema-id');
+  const STORAGE_KEY = 'artigo_novo_autosave';
+  const SHOULD_CLEAR_AUTOSAVE = {{ clear_novo_artigo_autosave | default(false) | tojson }};
+
+  if (SHOULD_CLEAR_AUTOSAVE) {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+
   function saveDraft() {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        titulo: document.getElementById('titulo').value,
+        titulo: tituloInput.value,
         texto: quill.root.innerHTML,
-        visibility: visInput.value
+        visibility: visInput.value,
+        tipo_id: tipoInput.value,
+        area_id: areaInput.value,
+        sistema_id: sistemaInput.value
       })
     );
   }
   function loadDraft() {
+    if (SHOULD_CLEAR_AUTOSAVE) return;
+
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return;
     try {
       const data = JSON.parse(raw);
-      if (data.titulo) document.getElementById('titulo').value = data.titulo;
-      if (data.texto) quill.root.innerHTML = data.texto;
+      if (typeof data.titulo === 'string') tituloInput.value = data.titulo;
+      if (typeof data.texto === 'string') quill.root.innerHTML = data.texto;
+      if (typeof data.tipo_id === 'string') tipoInput.value = data.tipo_id;
+      if (typeof data.area_id === 'string') areaInput.value = data.area_id;
+      if (typeof data.sistema_id === 'string') sistemaInput.value = data.sistema_id;
       if (data.visibility) {
         visInput.value = data.visibility;
         const parts = data.visibility.split(',');
@@ -173,7 +191,8 @@ document.addEventListener('DOMContentLoaded', () => {
   visChecks.forEach(cb => cb.addEventListener('change', updateVisibility));
   updateVisibility();
   loadDraft();
-  document.getElementById('titulo').addEventListener('input', saveDraft);
+  tituloInput.addEventListener('input', saveDraft);
+  [tipoInput, areaInput, sistemaInput].forEach(input => input.addEventListener('change', saveDraft));
   quill.on('text-change', saveDraft);
   visChecks.forEach(cb => cb.addEventListener('change', saveDraft));
 

--- a/tests/test_required_fields.py
+++ b/tests/test_required_fields.py
@@ -114,6 +114,53 @@ def test_novo_artigo_persiste_campos_no_html_em_erro_validacao(client):
 
 
 
+
+def test_novo_artigo_sinaliza_limpeza_autosave_apenas_apos_sucesso(client, monkeypatch):
+    monkeypatch.setattr('blueprints.articles.time.sleep', lambda _seconds: None)
+    _login_user(client, ['artigo_criar'])
+
+    response = client.post('/novo-artigo', data={
+        'titulo': 'Artigo com sucesso',
+        'texto': '<p>Conteúdo válido</p>',
+        'tipo_id': '',
+        'area_id': '',
+        'sistema_id': '',
+        'visibility': 'celula',
+        'acao': 'rascunho',
+    }, follow_redirects=False)
+
+    assert response.status_code == 302
+    with client.session_transaction() as sess:
+        assert sess.get('artigo_novo_autosave_sucesso') is True
+
+    response = client.get('/novo-artigo')
+    html = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'const SHOULD_CLEAR_AUTOSAVE = true;' in html
+    with client.session_transaction() as sess:
+        assert 'artigo_novo_autosave_sucesso' not in sess
+
+
+def test_novo_artigo_erro_validacao_nao_sinaliza_limpeza_autosave(client):
+    _login_user(client, ['artigo_criar'])
+
+    response = client.post('/novo-artigo', data={
+        'titulo': 'Sem texto válido',
+        'texto': '',
+        'tipo_id': '',
+        'area_id': '',
+        'sistema_id': '',
+        'visibility': 'celula',
+        'acao': 'enviar',
+    }, follow_redirects=False)
+    html = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'const SHOULD_CLEAR_AUTOSAVE = false;' in html
+    with client.session_transaction() as sess:
+        assert 'artigo_novo_autosave_sucesso' not in sess
+
 def test_novo_artigo_rejects_attachment_without_text(client):
     _login_user(client, ['artigo_criar'])
     response = client.post('/novo-artigo', data={


### PR DESCRIPTION
### Motivation
- Evitar que o rascunho salvo em `localStorage` seja removido em casos de erro/validação e somente limpar o autosave quando o artigo for efetivamente persistido com sucesso.
- Garantir que o autosave inclua todos os campos relevantes do formulário (título, texto, visibilidade e metadados: `tipo_id`, `area_id`, `sistema_id`) para restauração completa do rascunho.

### Description
- Backend: adiciona a flag de sessão `artigo_novo_autosave_sucesso` após o `db.session.commit()` e altera `_render_novo_artigo_form` para receber `clear_autosave` e expor `clear_novo_artigo_autosave` ao template.
- Frontend/template: renomeia a chave de `localStorage` para `artigo_novo_autosave`, adiciona os `id`s `tipo-id`, `area-id` e `sistema-id` aos selects e inclui `tipo_id`, `area_id` e `sistema_id` no payload do autosave.
- Limpeza condicional: a template define `SHOULD_CLEAR_AUTOSAVE` a partir de `clear_novo_artigo_autosave` e chama `localStorage.removeItem('artigo_novo_autosave')` somente quando a flag de sucesso está presente; em retornos de validação/erro a chave não é removida.
- Testes: adiciona cenários em `tests/test_required_fields.py` cobrindo que a limpeza é sinalizada apenas após sucesso e que não é sinalizada em erro de validação.

### Testing
- `python -m py_compile blueprints/articles.py` ran successfully.
- `pytest -q tests/test_required_fields.py tests/test_article_logging.py` executed and passed (`16 passed`, with warnings unrelated to the changes).
- New tests added in `tests/test_required_fields.py` passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb90cac004832e960941ca784cc3a5)