### PR TITLE
Preserva autosave na validação da edição de artigos

### DIFF
--- a/templates/artigos/editar_artigo.html
+++ b/templates/artigos/editar_artigo.html
@@ -207,7 +207,8 @@
   const visChecks = document.querySelectorAll('.vis-check');
   const visInput = document.getElementById('visibilityInput');
   const visDisplay = document.getElementById('visibilityDisplay');
-  const STORAGE_KEY = 'draft_editar_artigo_{{ artigo.id }}';
+  const STORAGE_KEY = 'artigo_edicao_autosave_{{ artigo.id }}';
+  const ARTICLE_VIEW_PATH = {{ url_for('artigo', artigo_id=artigo.id) | tojson }};
   const DRASTIC_REDUCTION_MESSAGE = 'Esta alteração reduz significativamente o conteúdo do artigo. Confirme se deseja continuar.';
   const previousArticleCharCount = Number({{ previous_char_count | default(0) | tojson }}) || 0;
 
@@ -390,6 +391,61 @@
     resetProgressMessages();
   };
 
+  function isArticleViewUrl(url, expectedPath = ARTICLE_VIEW_PATH) {
+    if (!url) return false;
+    try {
+      const parsed = new URL(url, window.location.origin);
+      return parsed.pathname === expectedPath;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function hasArticleSaveSuccessMarker(html) {
+    return typeof html === 'string' && (
+      html.includes('data-artigo-save-success="true"') ||
+      html.includes('id="artigo-save-success"') ||
+      html.includes('artigo-save-success')
+    );
+  }
+
+  async function resolveEditSubmitResult(response, expectedPath = ARTICLE_VIEW_PATH) {
+    if (response.redirected) {
+      return {
+        shouldClearAutosave: isArticleViewUrl(response.url, expectedPath),
+        redirectUrl: response.url,
+        html: null
+      };
+    }
+
+    if (!response.ok) {
+      return { shouldClearAutosave: false, redirectUrl: null, html: null };
+    }
+
+    const contentType = response.headers?.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+      let data = null;
+      try {
+        data = await response.json();
+      } catch (e) {
+        return { shouldClearAutosave: false, redirectUrl: null, html: null };
+      }
+      const success = data?.success === true || data?.ok === true || data?.status === 'success';
+      return {
+        shouldClearAutosave: success,
+        redirectUrl: success ? (data.redirect_url || data.redirectUrl || null) : null,
+        html: null
+      };
+    }
+
+    const html = await response.text();
+    return {
+      shouldClearAutosave: hasArticleSaveSuccessMarker(html),
+      redirectUrl: null,
+      html
+    };
+  }
+
   // Sincroniza conteúdo no hidden antes de submeter
   const form = document.querySelector('form');
   if (form) {
@@ -411,7 +467,6 @@
       resetProgressMessages();
       setOverlayState('Salvando artigo e anexos...', 0);
       startProgressPolling(progressId);
-      localStorage.removeItem(STORAGE_KEY);
 
       try {
         const formData = new FormData(form);
@@ -423,19 +478,35 @@
           method: 'POST',
           body: formData
         });
+        const submitResult = await resolveEditSubmitResult(response);
 
-        if (response.redirected) {
+        if (submitResult.shouldClearAutosave) {
+          localStorage.removeItem(STORAGE_KEY);
           completeBar();
-          window.location.href = response.url;
+          if (submitResult.redirectUrl) {
+            window.location.href = submitResult.redirectUrl;
+          } else {
+            setTimeout(() => window.location.reload(), 400);
+          }
+          return;
+        }
+
+        if (submitResult.redirectUrl) {
+          window.location.href = submitResult.redirectUrl;
+          return;
+        }
+
+        if (submitResult.html) {
+          document.open();
+          document.write(submitResult.html);
+          document.close();
           return;
         }
       } catch (err) {
         console.error('Falha ao salvar artigo', err);
       }
 
-      completeBar();
-      stopProgressPolling();
-      setTimeout(() => window.location.reload(), 400);
+      hideOverlay();
     });
   }
 

--- a/tests/test_editar_artigo_autosave_template.py
+++ b/tests/test_editar_artigo_autosave_template.py
@@ -1,0 +1,80 @@
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+TEMPLATE = Path(__file__).resolve().parents[1] / "templates" / "artigos" / "editar_artigo.html"
+
+
+def _template_source():
+    return TEMPLATE.read_text(encoding="utf-8")
+
+
+def test_editar_artigo_usa_chave_autosave_esperada():
+    source = _template_source()
+
+    assert "const STORAGE_KEY = 'artigo_edicao_autosave_{{ artigo.id }}';" in source
+    assert "draft_editar_artigo_{{ artigo.id }}" not in source
+
+
+def test_editar_artigo_nao_remove_autosave_antes_do_fetch():
+    source = _template_source()
+    submit_listener = source[source.index("form.addEventListener('submit'"):]
+    before_fetch, after_fetch = submit_listener.split("const response = await fetch", 1)
+
+    assert "localStorage.removeItem(STORAGE_KEY)" not in before_fetch
+    assert "if (submitResult.shouldClearAutosave)" in after_fetch
+    assert after_fetch.index("if (submitResult.shouldClearAutosave)") < after_fetch.index(
+        "localStorage.removeItem(STORAGE_KEY)"
+    )
+
+
+def test_editar_artigo_resposta_validacao_nao_limpa_autosave():
+    source = _template_source()
+    helpers = re.search(
+        r"function isArticleViewUrl[\s\S]+?\n  // Sincroniza conteúdo no hidden antes de submeter",
+        source,
+    ).group(0).replace("\n  // Sincroniza conteúdo no hidden antes de submeter", "")
+    helpers = helpers.replace("expectedPath = ARTICLE_VIEW_PATH", "expectedPath = '/artigo/123'")
+    node_script = textwrap.dedent(
+        f"""
+        global.window = {{ location: {{ origin: 'https://example.test' }} }};
+        {helpers}
+
+        const storage = {{ artigo_edicao_autosave_123: 'rascunho preservado' }};
+        const validationResponse = {{
+          redirected: false,
+          ok: true,
+          headers: {{ get: () => 'text/html; charset=utf-8' }},
+          text: async () => '<html><body>Erro de validação: título e conteúdo textual são obrigatórios.</body></html>'
+        }};
+
+        resolveEditSubmitResult(validationResponse, '/artigo/123').then((result) => {{
+          if (result.shouldClearAutosave) {{
+            delete storage.artigo_edicao_autosave_123;
+          }}
+          if (result.shouldClearAutosave !== false) {{
+            throw new Error('resposta de validação foi tratada como sucesso');
+          }}
+          if (storage.artigo_edicao_autosave_123 !== 'rascunho preservado') {{
+            throw new Error('draft apagado em erro de validação');
+          }}
+          if (!result.html.includes('Erro de validação')) {{
+            throw new Error('HTML de validação não foi preservado para renderização');
+          }}
+        }}).catch((error) => {{
+          console.error(error);
+          process.exit(1);
+        }});
+        """
+    )
+
+    completed = subprocess.run(
+        ["node", "-e", node_script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr


### PR DESCRIPTION
### Motivation
- Padronizar a chave do autosave durante edição para um identificador previsível por artigo (`artigo_edicao_autosave_{{ artigo.id }}`).
- Evitar remoção prematura do rascunho no `localStorage` antes de sabermos se o envio foi realmente bem-sucedido.
- Limpar o draft somente quando houver confirmação inequívoca de sucesso (redirecionamento para a visualização do artigo, JSON de sucesso ou HTML com marcador de sucesso) e preservar o rascunho em casos de validação/erro.
- Garantir via teste que respostas de validação não apagam o rascunho e que a ordem das operações no handler de submit está correta.

### Description
- Atualiza `templates/artigos/editar_artigo.html` trocando `STORAGE_KEY` para `artigo_edicao_autosave_{{ artigo.id }}` e adicionando `ARTICLE_VIEW_PATH` com `url_for('artigo', ...)`.
- Adiciona helpers JS `isArticleViewUrl`, `hasArticleSaveSuccessMarker` e `resolveEditSubmitResult` para decidir de forma robusta quando considerar um submit como sucesso inequívoco (redirect, JSON success, ou HTML com marcador).
- Remove `localStorage.removeItem(STORAGE_KEY)` antes do `fetch` e passa a limpar o draft somente quando `submitResult.shouldClearAutosave` for verdadeiro; em respostas não-sucesso o HTML recebido é renderizado sem apagar o autosave.
- Adiciona teste de template/JS `tests/test_editar_artigo_autosave_template.py` que verifica a chave esperada, a ordem da limpeza e simula uma resposta de validação (HTML) para garantir que o draft não é apagado.

### Testing
- Executado `pytest -q tests/test_editar_artigo_autosave_template.py` e o teste do template/JS passou (`3 passed`).
- Executado `pytest -q tests/test_required_fields.py tests/test_editar_artigo_autosave_template.py` e ambos passaram sem falhas.
- Executado a suíte completa `pytest -q` e todos os testes relevantes passaram (`182 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb930f1cc0832e81013742d6d050ec)