### PR TITLE
Withdraw pending articles when opened for edit

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -1252,6 +1252,21 @@ def editar_artigo(artigo_id):
             return _render_editar_artigo_form(artigo, json.loads(artigo.arquivos or "[]"), can_submit_actions, form_data)
 
     # GET
+    if artigo.status == ArticleStatus.PENDENTE:
+        status_before = artigo.status
+        status_after = ArticleStatus.EM_AJUSTE
+        artigo.status = status_after
+        artigo.updated_at = datetime.now(timezone.utc)
+        create_article_version_snapshot(
+            artigo,
+            user,
+            "withdraw_for_edit",
+            source_status_before=status_before,
+            source_status_after=status_after,
+            correlation_id=getattr(g, "request_correlation_id", None),
+        )
+        db.session.commit()
+
     arquivos = json.loads(artigo.arquivos or "[]")
     return _render_editar_artigo_form(artigo, arquivos, can_submit_actions)
 

--- a/tests/test_article_versioning_lifecycle.py
+++ b/tests/test_article_versioning_lifecycle.py
@@ -366,3 +366,83 @@ def test_drastic_reduction_snapshot_records_flags_counts_and_percent(article_org
     assert snapshot.new_char_count == 250
     assert snapshot.reduction_percent == 75
     assert snapshot.text_reduction_percent == 75
+
+
+def test_pending_article_opened_for_edit_leaves_approval_queue_and_can_be_resubmitted(
+    app_ctx, client, article_org
+):
+    author = _create_user("autor_withdraw_pending", article_org)
+    reviewer = _create_user(
+        "reviewer_withdraw_pending",
+        article_org,
+        [Permissao.ARTIGO_APROVAR_CELULA],
+    )
+    article = _create_article(
+        author,
+        article_org,
+        titulo="Artigo pendente retirado para edição",
+        texto="Conteúdo pendente original",
+        status=ArticleStatus.PENDENTE,
+    )
+    create_article_version_snapshot(
+        article,
+        author,
+        "submit_for_approval",
+        source_status_before=ArticleStatus.RASCUNHO,
+        source_status_after=ArticleStatus.PENDENTE,
+    )
+    db.session.commit()
+    article_id = article.id
+
+    _login(client, author)
+    response = client.get(f"/artigo/{article_id}/editar")
+
+    assert response.status_code == 200
+    article = Article.query.get(article_id)
+    withdraw_snapshot = _versions(article_id)[-1]
+    assert article.status == ArticleStatus.EM_AJUSTE
+    assert withdraw_snapshot.change_action == "withdraw_for_edit"
+    assert withdraw_snapshot.source_status_before == ArticleStatus.PENDENTE.value
+    assert withdraw_snapshot.source_status_after == ArticleStatus.EM_AJUSTE.value
+
+    _login(client, reviewer)
+    approval_response = client.get("/aprovacao")
+    assert approval_response.status_code == 200
+    assert "Artigo pendente retirado para edição" not in approval_response.get_data(as_text=True)
+
+    _login(client, author)
+    save_response = client.post(
+        f"/artigo/{article_id}/editar",
+        data={
+            "titulo": "Artigo pendente alterado",
+            "texto": "Conteúdo pendente alterado com texto suficiente",
+            "visibility": "celula",
+            "acao": "salvar",
+        },
+    )
+
+    assert save_response.status_code == 302
+    article = Article.query.get(article_id)
+    assert article.status == ArticleStatus.EM_AJUSTE
+    assert article.titulo == "Artigo pendente alterado"
+    assert article.texto == "Conteúdo pendente alterado com texto suficiente"
+
+    submit_response = client.post(
+        f"/artigo/{article_id}/editar",
+        data={
+            "titulo": "Artigo pendente alterado reenviado",
+            "texto": "Conteúdo pendente alterado reenviado com texto suficiente",
+            "visibility": "celula",
+            "acao": "enviar",
+        },
+    )
+
+    assert submit_response.status_code == 302
+    article = Article.query.get(article_id)
+    resubmit_snapshot = _versions(article_id)[-1]
+    assert article.status == ArticleStatus.PENDENTE
+    assert article.titulo == "Artigo pendente alterado reenviado"
+    assert article.texto == "Conteúdo pendente alterado reenviado com texto suficiente"
+    assert resubmit_snapshot.change_action == "submit_for_approval"
+    assert resubmit_snapshot.source_status_before == ArticleStatus.EM_AJUSTE.value
+    assert resubmit_snapshot.source_status_after == ArticleStatus.PENDENTE.value


### PR DESCRIPTION
### Motivation
- Permitir um fluxo explícito para quando um artigo com `ArticleStatus.PENDENTE` é aberto para edição, evitando que ele permaneça na fila de aprovação enquanto o autor faz alterações.

### Description
- Ao entrar na rota `editar_artigo` via `GET`, artigos em `ArticleStatus.PENDENTE` passam para `ArticleStatus.EM_AJUSTE`, recebem `updated_at` atualizado e é criado um snapshot com `create_article_version_snapshot(..., "withdraw_for_edit", source_status_before=ArticleStatus.PENDENTE, source_status_after=ArticleStatus.EM_AJUSTE)` antes de renderizar o formulário em `blueprints/articles.py`.
- A alteração é gravada com `db.session.commit()` imediatamente para garantir que o artigo seja removido da lista de pendentes exibida por `aprovacao` antes de renderizar o formulário.
- O fluxo de submissão existente (`acao == "enviar"`) foi preservado para que o botão “Enviar para Aprovação” continue definindo `artigo.status = ArticleStatus.PENDENTE` e criando o snapshot `submit_for_approval` conforme já implementado.
- Adicionado teste `test_pending_article_opened_for_edit_leaves_approval_queue_and_can_be_resubmitted` em `tests/test_article_versioning_lifecycle.py` cobrindo retirada do fluxo de aprovação, criação do snapshot `withdraw_for_edit`, salvamento das alterações enquanto `EM_AJUSTE` e reenvio para `PENDENTE` com snapshot `submit_for_approval`.

### Testing
- Executado `pytest tests/test_article_versioning_lifecycle.py -q` e o teste novo junto com a suite de versionamento passaram (`12 passed`).
- Executado `pytest tests/test_article_editing.py -q` e a suite relacionada à edição passou (`4 passed`).
- Todos os testes automatizados executados localmente relacionados às mudanças passaram; foram observados avisos de compatibilidade do SQLAlchemy, sem falhas de teste.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdfa4757ac832ea59bae16ce3de69e)