### PR TITLE
Explica edição de artigos pendentes

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -158,7 +158,7 @@ def _render_novo_artigo_form(form_data=None, clear_autosave=False):
     )
 
 
-def _render_editar_artigo_form(artigo, arquivos, can_submit_actions, form_data=None):
+def _render_editar_artigo_form(artigo, arquivos, can_submit_actions, form_data=None, withdrawn_for_edit=False):
     tipos_artigo = ArtigoTipo.query.filter_by(ativo=True).order_by(ArtigoTipo.nome).all()
     areas_artigo = ArtigoArea.query.filter_by(ativo=True).order_by(ArtigoArea.nome).all()
     sistemas_artigo = ArtigoSistema.query.filter_by(ativo=True).order_by(ArtigoSistema.nome).all()
@@ -172,6 +172,7 @@ def _render_editar_artigo_form(artigo, arquivos, can_submit_actions, form_data=N
         can_submit_actions=can_submit_actions,
         previous_char_count=calculate_plain_text_char_count(artigo.texto),
         form_data=form_data,
+        withdrawn_for_edit=withdrawn_for_edit,
     )
 
 def _build_drastic_reduction_data(previous_text, new_text):
@@ -1252,6 +1253,7 @@ def editar_artigo(artigo_id):
             return _render_editar_artigo_form(artigo, json.loads(artigo.arquivos or "[]"), can_submit_actions, form_data)
 
     # GET
+    withdrawn_for_edit = False
     if artigo.status == ArticleStatus.PENDENTE:
         status_before = artigo.status
         status_after = ArticleStatus.EM_AJUSTE
@@ -1266,9 +1268,10 @@ def editar_artigo(artigo_id):
             correlation_id=getattr(g, "request_correlation_id", None),
         )
         db.session.commit()
+        withdrawn_for_edit = True
 
     arquivos = json.loads(artigo.arquivos or "[]")
-    return _render_editar_artigo_form(artigo, arquivos, can_submit_actions)
+    return _render_editar_artigo_form(artigo, arquivos, can_submit_actions, withdrawn_for_edit=withdrawn_for_edit)
 
 @articles_bp.route("/aprovacao", endpoint='aprovacao')
 def aprovacao():

--- a/templates/artigos/artigo.html
+++ b/templates/artigos/artigo.html
@@ -204,10 +204,19 @@
             </form>
           </div>
           {% endif %}
+          {% if can_edit_article and artigo.status == ArticleStatus.PENDENTE %}
+          <div class="alert alert-warning py-2 px-3 small mb-3" role="alert">
+            Ao editar, este artigo sairá temporariamente da fila de aprovação.
+          </div>
+          {% endif %}
           <div class="article-actions-group d-flex flex-wrap gap-2">
           {% if can_edit_article %}
-          <a href="{{ url_for('editar_artigo', artigo_id=artigo.id) }}" class="btn btn-app btn-app-primary">
-            <i class="bi bi-pencil-square" aria-hidden="true"></i> Editar
+          {% set is_pending_edit = artigo.status == ArticleStatus.PENDENTE %}
+          <a href="{{ url_for('editar_artigo', artigo_id=artigo.id) }}"
+             class="btn btn-app btn-app-primary"
+             {% if is_pending_edit %}title="Ao editar, este artigo sairá temporariamente da fila de aprovação."{% endif %}>
+            <i class="bi bi-pencil-square" aria-hidden="true"></i>
+            {{ 'Editar e retirar da aprovação' if is_pending_edit else 'Editar' }}
           </a>
           {% endif %}
 

--- a/templates/artigos/editar_artigo.html
+++ b/templates/artigos/editar_artigo.html
@@ -24,6 +24,11 @@
     <div class="card shadow-sm">
       <div class="card-body">
         <h3>Editar Artigo</h3>
+        {% if withdrawn_for_edit %}
+        <div class="alert alert-warning py-2 px-3 small mb-3" role="alert">
+          Este artigo saiu temporariamente da fila de aprovação para edição. Após terminar, clique em "Enviar para Aprovação" para reenviá-lo.
+        </div>
+        {% endif %}
         <p class="text-muted mb-0">
           <strong>Criado em:</strong>
           {{ artigo.created_at.strftime('%d/%m/%Y %H:%M') }}

--- a/tests/test_required_fields.py
+++ b/tests/test_required_fields.py
@@ -301,3 +301,111 @@ def test_editar_artigo_buttons_visible_for_editor_with_permission(client):
     html = response.get_data(as_text=True)
     assert 'name="acao" value="salvar"' in html
     assert 'name="acao" value="enviar"' in html
+
+def test_artigo_pendente_editavel_exibe_aviso_de_retirada_da_aprovacao(client):
+    author_id = _login_user(client, ['artigo_criar'])
+    with app.app_context():
+        author = User.query.get(author_id)
+        inst = Instituicao.query.first()
+        art = Article(
+            titulo='Artigo pendente editável', texto='Conteúdo', status=ArticleStatus.PENDENTE,
+            user_id=author_id, celula_id=author.celula_id, setor_id=author.setor_id,
+            estabelecimento_id=author.estabelecimento_id, instituicao_id=inst.id,
+        )
+        db.session.add(art)
+        db.session.commit()
+        aid = art.id
+
+    response = client.get(f'/artigo/{aid}')
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert 'Editar e retirar da aprovação' in html
+    assert 'Ao editar, este artigo sairá temporariamente da fila de aprovação.' in html
+
+
+def test_artigo_nao_pendente_editavel_nao_exibe_aviso_de_retirada_da_aprovacao(client):
+    author_id = _login_user(client, ['artigo_criar'])
+    with app.app_context():
+        author = User.query.get(author_id)
+        inst = Instituicao.query.first()
+        art = Article(
+            titulo='Rascunho editável', texto='Conteúdo', status=ArticleStatus.RASCUNHO,
+            user_id=author_id, celula_id=author.celula_id, setor_id=author.setor_id,
+            estabelecimento_id=author.estabelecimento_id, instituicao_id=inst.id,
+        )
+        db.session.add(art)
+        db.session.commit()
+        aid = art.id
+
+    response = client.get(f'/artigo/{aid}')
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert 'Editar e retirar da aprovação' not in html
+    assert 'Ao editar, este artigo sairá temporariamente da fila de aprovação.' not in html
+    assert '<i class="bi bi-pencil-square" aria-hidden="true"></i>\n            Editar' in html
+
+
+def test_artigo_pendente_nao_editavel_nao_exibe_aviso_de_retirada_da_aprovacao(client):
+    ids = client.base_ids
+    with app.app_context():
+        inst = Instituicao.query.first()
+        author = User(
+            username='autor_pendente', email='autor_pendente@test', password_hash='x',
+            estabelecimento_id=ids['est'], setor_id=ids['setor'], celula_id=ids['cel'],
+        )
+        viewer = User(
+            username='visualizador', email='visualizador@test', password_hash='x',
+            estabelecimento_id=ids['est'], setor_id=ids['setor'], celula_id=ids['cel'],
+        )
+        db.session.add_all([author, viewer])
+        db.session.flush()
+        art = Article(
+            titulo='Artigo pendente apenas visível', texto='Conteúdo', status=ArticleStatus.PENDENTE,
+            user_id=author.id, celula_id=author.celula_id, setor_id=author.setor_id,
+            estabelecimento_id=author.estabelecimento_id, instituicao_id=inst.id,
+        )
+        db.session.add(art)
+        db.session.commit()
+        aid = art.id
+        viewer_id = viewer.id
+
+    with client.session_transaction() as sess:
+        sess['user_id'] = viewer_id
+        sess['username'] = 'visualizador'
+
+    response = client.get(f'/artigo/{aid}')
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert 'Editar e retirar da aprovação' not in html
+    assert 'Ao editar, este artigo sairá temporariamente da fila de aprovação.' not in html
+
+
+def test_editar_artigo_retirado_de_pendente_orienta_reenvio_para_aprovacao(client):
+    author_id = _login_user(client, ['artigo_criar'])
+    with app.app_context():
+        author = User.query.get(author_id)
+        inst = Instituicao.query.first()
+        art = Article(
+            titulo='Artigo pendente para edição', texto='Conteúdo', status=ArticleStatus.PENDENTE,
+            user_id=author_id, celula_id=author.celula_id, setor_id=author.setor_id,
+            estabelecimento_id=author.estabelecimento_id, instituicao_id=inst.id,
+        )
+        db.session.add(art)
+        db.session.commit()
+        aid = art.id
+
+    response = client.get(f'/artigo/{aid}/editar')
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert 'Este artigo saiu temporariamente da fila de aprovação para edição.' in html
+    assert 'clique em "Enviar para Aprovação" para reenviá-lo.' in html
+
+    response = client.get(f'/artigo/{aid}/editar')
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert 'Este artigo saiu temporariamente da fila de aprovação para edição.' not in html


### PR DESCRIPTION
### Motivation
- Deixar claro ao usuário que ao editar um artigo com status `PENDENTE` o artigo será temporariamente retirado da fila de aprovação. 
- Evitar confusão sobre próximos passos após a retirada (ou seja, que é preciso clicar em `Enviar para Aprovação` ao terminar a edição).

### Description
- Atualiza o template `templates/artigos/artigo.html` para exibir um aviso Bootstrap quando `can_edit_article` for verdadeiro e `artigo.status == ArticleStatus.PENDENTE`, e altera o CTA de edição para mostrar `Editar e retirar da aprovação` com um `title` explicativo nesses casos.
- Atualiza o template `templates/artigos/editar_artigo.html` para mostrar um alerta informando que o artigo foi retirado temporariamente da fila e que o usuário deve clicar em `Enviar para Aprovação` após concluir.
- Propaga um novo parâmetro `withdrawn_for_edit` no helper `_render_editar_artigo_form` em `blueprints/articles.py` e ajusta a lógica GET de `editar_artigo` para definir esse indicador quando um artigo `PENDENTE` for movido para `EM_AJUSTE` (cria snapshot `withdraw_for_edit`).
- Adiciona testes de template em `tests/test_required_fields.py` cobrindo: artigo pendente editável (aviso + CTA), artigo não pendente (sem aviso), artigo pendente não editável (sem aviso) e exibição da mensagem na tela de edição logo após retirada da fila.

### Testing
- Executei `pytest -q tests/test_article_versioning_lifecycle.py::test_pending_article_opened_for_edit_leaves_approval_queue_and_can_be_resubmitted tests/test_required_fields.py -q`, e ambos os testes relacionados passaram com sucesso.
- Executei a suíte adicionada em `tests/test_required_fields.py` durante desenvolvimento e ela passou sem falhas (apenas avisos de `Query.get()` do SQLAlchemy, não relacionados à mudança).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe0fbcf4ec832e966bbadd4caae707)