### PR TITLE
Remove stale approval notifications

### DIFF
--- a/app.py
+++ b/app.py
@@ -574,6 +574,33 @@ def send_password_email(user: User, action: str) -> None:
     html = render_template('email/password_email.html', user=user, url=url, action=action_text)
     send_email(user.email, 'Definição de Senha', html)
 
+
+def _pending_review_article_id_from_notification_url(url):
+    """Extrai o ID de URLs de notificação da tela de aprovação."""
+    path = urlsplit(url or '').path
+    match = re.search(r'/(?:aprovacao)/(\d+)$', path)
+    return int(match.group(1)) if match else None
+
+
+def _is_visible_notification(notification):
+    """Oculta pendências de aprovação que já saíram da fila."""
+    article_id = _pending_review_article_id_from_notification_url(notification.url)
+    if article_id is None:
+        return True
+
+    article = db.session.get(Article, article_id)
+    return bool(article and article.status == ArticleStatus.PENDENTE)
+
+
+def _visible_general_notifications(user_id):
+    notifications = (
+        Notification.query
+        .filter_by(user_id=user_id, tipo='geral')
+        .order_by(Notification.created_at.desc())
+        .all()
+    )
+    return [n for n in notifications if _is_visible_notification(n)]
+
 # -------------------------------------------------------------------------
 # NOTIFICAÇÕES - API
 # -------------------------------------------------------------------------
@@ -585,14 +612,7 @@ def api_notifications():
 
     offset = int(request.args.get('offset', 0))
     limit = int(request.args.get('limit', 10))
-    notifs = (
-        Notification.query
-        .filter_by(user_id=session['user_id'], tipo='geral')
-        .order_by(Notification.created_at.desc())
-        .offset(offset)
-        .limit(limit)
-        .all()
-    )
+    notifs = _visible_general_notifications(session['user_id'])[offset:offset + limit]
 
     return jsonify([
         {'id': n.id, 'message': n.message, 'url': n.url, 'lido': n.lido}
@@ -629,16 +649,9 @@ def inject_notificacoes():
     if 'user_id' in session: # Usar user_id é mais seguro que username para buscar no banco
         user = User.query.get(session['user_id']) # Usar .get() é mais direto para PK
         if user:
-            q_general_unread = Notification.query.filter_by(user_id=user.id, lido=False, tipo='geral')
-            general_count = q_general_unread.count()
-
-            general_list = (
-                Notification.query
-                .filter_by(user_id=user.id, tipo='geral')
-                .order_by(Notification.created_at.desc())
-                .limit(10)
-                .all()
-            )
+            visible_notifications = _visible_general_notifications(user.id)
+            general_count = sum(1 for n in visible_notifications if not n.lido)
+            general_list = visible_notifications[:10]
 
             return {
                 'notificacoes': general_count,

--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -175,6 +175,19 @@ def _render_editar_artigo_form(artigo, arquivos, can_submit_actions, form_data=N
         withdrawn_for_edit=withdrawn_for_edit,
     )
 
+
+def _delete_pending_review_notifications(artigo):
+    """Remove notificações de aprovadores para uma pendência que não existe mais."""
+    if not artigo or not getattr(artigo, "id", None):
+        return 0
+
+    review_url = url_for('aprovacao_detail', artigo_id=artigo.id)
+    return (
+        Notification.query
+        .filter_by(url=review_url, tipo='geral')
+        .delete(synchronize_session=False)
+    )
+
 def _build_drastic_reduction_data(previous_text, new_text):
     previous_char_count = calculate_plain_text_char_count(previous_text)
     new_char_count = calculate_plain_text_char_count(new_text)
@@ -1164,6 +1177,7 @@ def editar_artigo(artigo_id):
             # se usuário clicou “Enviar para revisão”
             if acao == "enviar":
                 artigo.status = ArticleStatus.PENDENTE
+                _delete_pending_review_notifications(artigo)
                 # 🔔 notifica responsáveis / admins
                 destinatarios = eligible_review_notification_users(artigo)
                 for dest in destinatarios:
@@ -1267,6 +1281,7 @@ def editar_artigo(artigo_id):
             source_status_after=status_after,
             correlation_id=getattr(g, "request_correlation_id", None),
         )
+        _delete_pending_review_notifications(artigo)
         db.session.commit()
         withdrawn_for_edit = True
 
@@ -1450,6 +1465,8 @@ def aprovacao_detail(artigo_id):
             texto     = comentario
         )
         db.session.add(novo_comment)
+
+        _delete_pending_review_notifications(artigo)
 
         # 3) Notifica autor com o status correto ------------------------------
         notif = Notification(

--- a/tests/test_notification_filtering.py
+++ b/tests/test_notification_filtering.py
@@ -102,3 +102,64 @@ def test_novo_artigo_sem_acao_fica_rascunho(client_with_users):
     n2 = Notification.query.filter_by(user_id=data['ap2'].id).count()
     assert n1 == 0
     assert n2 == 0
+
+
+def test_pending_review_notifications_removed_when_author_edits_pending_article(client_with_users):
+    client, data = client_with_users
+    login(client, data['author'])
+    resp = client.post('/novo-artigo', data={
+        'titulo': 'Sai da pendencia',
+        'texto': '<p>x</p>',
+        'acao': 'enviar',
+        'visibility': 'celula'
+    })
+    assert resp.status_code == 302
+
+    artigo = Article.query.filter_by(titulo='Sai da pendencia').first()
+    assert artigo is not None
+    assert Notification.query.filter_by(user_id=data['ap1'].id).count() == 1
+
+    resp = client.get(f'/artigo/{artigo.id}/editar')
+    assert resp.status_code == 200
+
+    db.session.refresh(artigo)
+    assert artigo.status == ArticleStatus.EM_AJUSTE
+    assert Notification.query.filter_by(user_id=data['ap1'].id).count() == 0
+
+    login(client, data['ap1'])
+    api_resp = client.get('/api/notifications')
+    assert api_resp.status_code == 200
+    assert api_resp.get_json() == []
+
+
+def test_stale_pending_review_notifications_are_hidden_from_badge_and_api(client_with_users):
+    client, data = client_with_users
+    with app.app_context():
+        artigo = Article(
+            titulo='Ja saiu da fila',
+            texto='x',
+            status=ArticleStatus.EM_AJUSTE,
+            user_id=data['author'].id,
+            celula_id=data['author'].celula_id,
+            estabelecimento_id=data['author'].estabelecimento_id,
+            setor_id=data['author'].setor_id,
+            instituicao_id=data['author'].estabelecimento.instituicao_id,
+        )
+        db.session.add(artigo)
+        db.session.flush()
+        db.session.add(Notification(
+            user_id=data['ap1'].id,
+            message='Novo artigo pendente para revisão: “Ja saiu da fila”',
+            url=f'/aprovacao/{artigo.id}',
+        ))
+        db.session.commit()
+
+    login(client, data['ap1'])
+    api_resp = client.get('/api/notifications')
+    assert api_resp.status_code == 200
+    assert api_resp.get_json() == []
+
+    page_resp = client.get('/aprovacao')
+    assert page_resp.status_code == 200
+    assert b'data-server-count="0"' in page_resp.data
+    assert b'Ja saiu da fila' not in page_resp.data


### PR DESCRIPTION
### Motivation
- Evitar que notificações de aprovação apontando para um artigo que já saiu da fila causem erro ao clicar ou apareçam no sino/API.
- Remover notificações de aprovadores quando o artigo é retirado da fila para edição ou quando o fluxo de aprovação as torna obsoletas.

### Description
- Adiciona utilitários em `app.py`: `._pending_review_article_id_from_notification_url`, `._is_visible_notification` e `._visible_general_notifications` para detectar e filtrar notificações de aprovação obsoletas.
- Atualiza a API de notificações `GET /api/notifications` e o context processor `inject_notificacoes` para usar `_visible_general_notifications` ao retornar lista e contagem do sino.
- Cria `blueprints/articles.py::_delete_pending_review_notifications(artigo)` e chama essa função quando um artigo é reenviado para aprovação, quando é retirado da fila ao abrir edição, e após decisões no fluxo de aprovação para remover notificações pendentes relacionadas.
- Adiciona testes em `tests/test_notification_filtering.py` que verificam remoção de notificações ao editar/retirar da fila e ocultação de notificações obsoletas no badge/API.

### Testing
- Executado `pytest -q` (suite completa) com resultado: `191 passed, 1 skipped`.
- Executados testes focados `pytest -q tests/test_notification_filtering.py tests/test_notification_pagination.py` e ambos passaram (`6 passed` para o subset inicial e posteriores runs bem-sucedidos durante validação).
- Verificações adicionais: `python -m py_compile` nos módulos modificados e checagem de diff (`git diff --check`) não apontaram erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe14b6405c832ebd48400d739a8d6b)