### PR TITLE
Limpa autosave ao submeter novo artigo

### DIFF
--- a/templates/artigos/novo_artigo.html
+++ b/templates/artigos/novo_artigo.html
@@ -316,6 +316,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const form = document.querySelector('form');
   form.addEventListener('submit', (event) => {
     document.getElementById('hidden-texto').value = quill.root.innerHTML;
+    localStorage.removeItem(STORAGE_KEY);
 
     const progressId = progressIdInput?.value || (crypto.randomUUID ? crypto.randomUUID() : String(Date.now()));
     if (progressIdInput) progressIdInput.value = progressId;
@@ -325,7 +326,7 @@ document.addEventListener('DOMContentLoaded', () => {
     startProgressPolling(progressId);
 
     // Observação: submissão nativa do formulário é mantida para preservar
-    // redirects/flash do servidor e evitar perder estado em caso de erro.
+    // redirects/flash do servidor; em caso de validação, o servidor reidrata o formulário.
   });
 
   // Preview de anexos

--- a/tests/test_required_fields.py
+++ b/tests/test_required_fields.py
@@ -1,5 +1,6 @@
 import pytest
 from io import BytesIO
+from pathlib import Path
 from app import app, db
 from core.models import (
     Instituicao,
@@ -160,6 +161,22 @@ def test_novo_artigo_erro_validacao_nao_sinaliza_limpeza_autosave(client):
     assert 'const SHOULD_CLEAR_AUTOSAVE = false;' in html
     with client.session_transaction() as sess:
         assert 'artigo_novo_autosave_sucesso' not in sess
+
+
+def test_novo_artigo_remove_autosave_ao_submeter():
+    source = (
+        Path(__file__).resolve().parents[1] / "templates" / "artigos" / "novo_artigo.html"
+    ).read_text(encoding="utf-8")
+    submit_listener = source[source.index("form.addEventListener('submit'"):]
+
+    assert "localStorage.removeItem(STORAGE_KEY);" in submit_listener
+    assert submit_listener.index("document.getElementById('hidden-texto').value") < submit_listener.index(
+        "localStorage.removeItem(STORAGE_KEY);"
+    )
+    assert submit_listener.index("localStorage.removeItem(STORAGE_KEY);") < submit_listener.index(
+        "const progressId ="
+    )
+
 
 def test_novo_artigo_rejects_attachment_without_text(client):
     _login_user(client, ['artigo_criar'])


### PR DESCRIPTION
### Motivation
- Evitar que o formulário de "Novo Artigo" seja preenchido com o rascunho anterior depois de enviar um artigo para revisão ou salvar rascunho.

### Description
- Remove `localStorage` do rascunho ao submeter o formulário ao adicionar `localStorage.removeItem(STORAGE_KEY);` em `templates/artigos/novo_artigo.html` imediatamente após sincronizar o conteúdo do Quill para o campo hidden.
- Ajusta comentário no template para deixar explícito que o servidor reidrata o formulário em caso de validação.
- Adiciona o teste `test_novo_artigo_remove_autosave_ao_submeter` em `tests/test_required_fields.py` que verifica a presença e posição da chamada a `localStorage.removeItem(STORAGE_KEY);` no listener de `submit`.

### Testing
- Executei `pytest -q tests/test_required_fields.py tests/test_article_logging.py` e ambos os conjuntos passaram com sucesso (`21 passed`), com apenas warnings existentes de `LegacyAPIWarning` do SQLAlchemy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe18fba09c832ebf8035f87618774f)