### PR TITLE
Remove global Quill initialization

### DIFF
--- a/templates/artigos/aprovacao_detail.html
+++ b/templates/artigos/aprovacao_detail.html
@@ -107,7 +107,7 @@
             <label for="comentario" class="form-label">
               Comentário <span class="text-danger">*</span>
             </label>
-            <textarea id="comentario" name="comentario" class="form-control no-quill" rows="4" required aria-required="true"
+            <textarea id="comentario" name="comentario" class="form-control" rows="4" required aria-required="true"
               placeholder="Descreva o motivo da aprovação, ajustes ou rejeição…">{{ artigo.review_comment or '' }}</textarea>
             <div class="invalid-feedback">
               O comentário é obrigatório para prosseguir.

--- a/templates/artigos/editar_artigo.html
+++ b/templates/artigos/editar_artigo.html
@@ -182,6 +182,7 @@
 </div>
 {% endblock %}
 {% block extra_js %}
+<script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
 <script>
   document.addEventListener("DOMContentLoaded", () => {
     // Inicializa Quill editor e carrega conteúdo existente

--- a/templates/artigos/novo_artigo.html
+++ b/templates/artigos/novo_artigo.html
@@ -113,6 +113,7 @@
 {% endblock %}
 
 {% block extra_js %}
+<script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   // Inicializa o Quill editor

--- a/templates/artigos/solicitar_revisao.html
+++ b/templates/artigos/solicitar_revisao.html
@@ -16,7 +16,7 @@
           <form method="post" action="{{ url_for('solicitar_revisao', artigo_id=artigo.id) }}">
             <div class="mb-3">
               <label for="comentario" class="form-label">Comentário</label>
-              <textarea id="comentario" name="comentario" class="form-control no-quill" rows="4" required></textarea>
+              <textarea id="comentario" name="comentario" class="form-control" rows="4" required></textarea>
             </div>
             <div class="d-flex gap-2">
               <button type="submit" class="btn btn-warning">Enviar pedido</button>

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,8 +9,6 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet"> {# Bootstrap Icons atualizado #}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
 
-    <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
-    
     <style>
         /* === ESTILOS GLOBAIS PARA LAYOUT COM NAVBAR FIXA E SIDEBAR FIXA/OFFCANVAS === */
         html, body {
@@ -202,10 +200,6 @@
             margin-top: auto;
         }
         #flash-container { margin-bottom: 1.5rem; }
-
-        /* Ajuste para o Quill não ser cortado por z-index da navbar/sidebar */
-        .ql-snow .ql-tooltip { z-index: 1050 !important; }
-        .ql-snow .ql-picker.ql-expanded .ql-picker-options { z-index: 1050 !important; }
 
     </style>
     {% block extra_css %}{% endblock %}
@@ -551,7 +545,6 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
-    <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
     <script>
       document.addEventListener('DOMContentLoaded', function () {
         var consentKey = 'cookie_preferences_v1';
@@ -716,26 +709,6 @@
             if (marketingInput) marketingInput.checked = false;
           });
         }
-
-        document.querySelectorAll('textarea:not(.no-quill)').forEach(function (textarea) {
-          var container = document.createElement('div');
-          container.innerHTML = textarea.value;
-          container.classList.add('editor-container');
-          container.style.display = 'block';
-          // altura reduzida para evitar sobreposição do layout
-          container.style.minHeight = '100px';
-          container.style.maxHeight = '320px';
-          container.style.overflowY = 'auto';
-          textarea.style.display = 'none';
-          textarea.parentNode.insertBefore(container, textarea);
-          var quill = new Quill(container, { theme: 'snow' });
-          var form = textarea.closest('form');
-          if (form) {
-            form.addEventListener('submit', function () {
-              textarea.value = quill.root.innerHTML;
-            });
-          }
-        });
       });
     </script>
     {% block extra_js %}{% endblock %}


### PR DESCRIPTION
### Motivation

- Prevent loading Quill globally and avoid automatically replacing plain `<textarea>` fields with rich editors across the app.
- Keep the rich-text editor scoped only to pages that explicitly require it (article create/edit) and leave comment fields as simple textareas.

### Description

- Removed the global Quill CSS include from `templates/base.html` and deleted the global `.ql-snow` z-index rules from the base stylesheet.
- Removed the global Quill JS include and the script that converted `textarea:not(.no-quill)` into `Quill` instances from `templates/base.html`, leaving the cookie/consent logic intact.
- Restored plain `<textarea>` usage by removing `no-quill` from simple comment fields in `templates/artigos/aprovacao_detail.html` and `templates/artigos/solicitar_revisao.html`.
- Kept Quill assets and explicit initialization in article editor pages by adding the `quill.min.js` include to `templates/artigos/novo_artigo.html` and `templates/artigos/editar_artigo.html` where the editor is intentionally initialized.

### Testing

- Ran `git diff --check` to ensure no whitespace/merge issues and it reported no problems (success).
- Searched templates with `rg -n "no-quill|textarea:not\(" templates` to confirm removal of the `no-quill` usage from comment areas (success).
- Verified base template no longer references Quill with `rg -n "cdn\.quilljs\.com/1\.3\.6/quill\.(snow\.css|min\.js)|ql-snow" templates/base.html` and the command returned no matches (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1d992534832e8164b6582c60c1cb)