### PR TITLE
Replace Quill with Tiptap editor in article create/edit templates

### DIFF
--- a/templates/artigos/editar_artigo.html
+++ b/templates/artigos/editar_artigo.html
@@ -2,7 +2,61 @@
 {% block title %}Editar Artigo{% endblock %}
 
 {% block extra_css %}
-<link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+<style>
+  .tiptap-editor {
+    min-height: 300px;
+    overflow: auto;
+  }
+
+  .tiptap-editor .tiptap {
+    min-height: 300px;
+    padding: 1rem;
+    outline: none;
+  }
+
+  .tiptap-editor .tiptap p.is-editor-empty:first-child::before,
+  .tiptap-editor .tiptap p.is-empty::before {
+    color: #adb5bd;
+    content: attr(data-placeholder);
+    float: left;
+    height: 0;
+    pointer-events: none;
+  }
+
+  .tiptap-editor .tiptap table {
+    border-collapse: collapse;
+    margin: 0.75rem 0;
+    table-layout: fixed;
+    width: 100%;
+  }
+
+  .tiptap-editor .tiptap td,
+  .tiptap-editor .tiptap th {
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    padding: 0.5rem;
+    vertical-align: top;
+  }
+
+  .tiptap-editor .tiptap th {
+    background: var(--bs-tertiary-bg, #f8f9fa);
+    font-weight: 600;
+  }
+
+  .tiptap-editor .tiptap img {
+    max-width: 100%;
+    height: auto;
+  }
+
+  .tiptap-editor .tiptap ul[data-type="taskList"] {
+    list-style: none;
+    padding-left: 0;
+  }
+
+  .tiptap-editor .tiptap ul[data-type="taskList"] li {
+    display: flex;
+    gap: 0.5rem;
+  }
+</style>
 {% endblock %}
 
 {% block content %}
@@ -87,9 +141,8 @@
           </div>
 
           <div class="mb-3">
-            <label class="form-label">Texto</label>
-            <!-- Quill Editor -->
-            <div id="quill-editor" class="border rounded bg-body" style="height:300px; overflow:auto;"></div>
+            <label for="tiptap-editor" class="form-label">Texto</label>
+            <div id="tiptap-editor" class="tiptap-editor border rounded bg-body"></div>
           <input type="hidden" name="texto" id="hidden-texto">
         </div>
 
@@ -182,32 +235,65 @@
 </div>
 {% endblock %}
 {% block extra_js %}
-<script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
-<script>
+<script type="module">
+import { Editor } from 'https://esm.sh/@tiptap/core@3';
+import StarterKit from 'https://esm.sh/@tiptap/starter-kit@3';
+import { Image } from 'https://esm.sh/@tiptap/extension-image@3';
+import { Table, TableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3';
+import { TaskList, TaskItem } from 'https://esm.sh/@tiptap/extension-list@3';
+import { Placeholder } from 'https://esm.sh/@tiptap/extensions@3';
+import { TextAlign } from 'https://esm.sh/@tiptap/extension-text-align@3';
+import { Highlight } from 'https://esm.sh/@tiptap/extension-highlight@3';
+import { FileHandler } from 'https://esm.sh/@tiptap/extension-file-handler@3';
+
   document.addEventListener("DOMContentLoaded", () => {
-    // Inicializa Quill editor e carrega conteúdo existente
-    const editorDiv = document.getElementById('quill-editor');
-    const quill = new Quill(editorDiv, {
-      theme: 'snow',
-      modules: {
-        toolbar: [ // Verifique se não há vírgulas sobrando no final de cada array aqui
-          [{ header: [1, 2, 3, false] }],
-          ['bold', 'italic', 'underline', 'strike'],
-          [{ color: [] }, { background: [] }],
-          [{ list: 'ordered' }, { list: 'bullet' }, { list: 'check' }], // Garanta que não tem vírgula depois de 'check' se for o último
-          [{ indent: '-1' }, { indent: '+1' }],
-          [{ align: [] }],
-          ['link', 'image', 'blockquote', 'code-block'],
-          ['clean']
-        ]
-      }
-    }); // Ponto e vírgula aqui é bom, mas o principal é na linha abaixo
+    const initialContent = {{ (form_data.get('texto') if form_data else artigo.texto) | tojson | safe }} || '<p></p>';
 
-    quill.root.innerHTML = {{ (form_data.get('texto') if form_data else artigo.texto) | tojson | safe }}; // <<< ADICIONADO PONTO E VÍRGULA AQUI
+    const insertImageFiles = (editorInstance, files, pos = null) => {
+      files
+        .filter(file => file.type.startsWith('image/'))
+        .forEach(file => {
+          const reader = new FileReader();
+          reader.addEventListener('load', () => {
+            const image = { type: 'image', attrs: { src: reader.result, alt: file.name } };
+            if (typeof pos === 'number') {
+              editorInstance.chain().focus().insertContentAt(pos, image).run();
+              return;
+            }
+            editorInstance.chain().focus().insertContent(image).run();
+          });
+          reader.readAsDataURL(file);
+        });
+    };
 
-  // A chave }; que o VS Code apontava como erro provavelmente estava correta,
-  // mas a linha anterior sem ponto e vírgula confundia o parser.
-  // O fechamento do addEventListener é só no final do script.
+    const editor = new Editor({
+      element: document.querySelector('#tiptap-editor'),
+      extensions: [
+        StarterKit,
+        Image.configure({ allowBase64: true }),
+        Table.configure({ resizable: true }),
+        TableRow,
+        TableCell,
+        TableHeader,
+        TaskList,
+        TaskItem.configure({ nested: true }),
+        Placeholder.configure({ placeholder: 'Atualize o conteúdo do artigo...' }),
+        TextAlign.configure({ types: ['heading', 'paragraph'] }),
+        Highlight.configure({ multicolor: true }),
+        FileHandler.configure({
+          allowedMimeTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
+          onPaste: (editorInstance, files) => insertImageFiles(editorInstance, files),
+          onDrop: (editorInstance, files, pos) => insertImageFiles(editorInstance, files, pos)
+        })
+      ],
+      content: initialContent,
+      editorProps: {
+        attributes: {
+          class: 'tiptap-content'
+        }
+      },
+      onUpdate: () => saveDraft()
+    });
 
   // Visibilidade por checkboxes
   const visChecks = document.querySelectorAll('.vis-check');
@@ -234,7 +320,7 @@
   }
 
   function updateReductionFields({ confirmed = false } = {}) {
-    const newText = normalizePlainTextForCount(quill.getText ? quill.getText() : plainTextFromHtmlForCount(quill.root.innerHTML));
+    const newText = normalizePlainTextForCount(editor.getText());
     const newCharCount = newText.length;
     const reductionPercent = calculateReductionPercent(previousArticleCharCount, newCharCount);
     document.getElementById('drastic-reduction-confirmed').value = confirmed ? 'true' : 'false';
@@ -248,7 +334,7 @@
       STORAGE_KEY,
       JSON.stringify({
         titulo: document.querySelector('input[name="titulo"]').value,
-        texto: quill.root.innerHTML,
+        texto: editor.getHTML(),
         visibility: visInput.value
       })
     );
@@ -259,7 +345,7 @@
     try {
       const data = JSON.parse(raw);
       if (data.titulo) document.querySelector('input[name="titulo"]').value = data.titulo;
-      if (data.texto) quill.root.innerHTML = data.texto;
+      if (data.texto) editor.commands.setContent(data.texto);
       if (data.visibility) {
         visInput.value = data.visibility;
         const parts = data.visibility.split(',');
@@ -279,7 +365,6 @@
   updateVisibility();
   loadDraft();
   document.querySelector('input[name="titulo"]').addEventListener('input', saveDraft);
-  quill.on('text-change', saveDraft);
   visChecks.forEach(cb => cb.addEventListener('change', saveDraft));
 
   const overlay = document.getElementById('fileLoadingOverlay');
@@ -459,7 +544,7 @@
       event.preventDefault();
       const hiddenTexto = document.getElementById('hidden-texto');
       if (hiddenTexto) {
-        hiddenTexto.value = quill.root.innerHTML;
+        hiddenTexto.value = editor.getHTML();
       }
       const reductionMetrics = updateReductionFields();
       const hasDrasticReduction = reductionMetrics.reductionPercent > 70 || (previousArticleCharCount > 2000 && reductionMetrics.newCharCount < 300);

--- a/templates/artigos/novo_artigo.html
+++ b/templates/artigos/novo_artigo.html
@@ -2,7 +2,61 @@
 {% block title %}Novo Artigo{% endblock %}
 
 {% block extra_css %}
-<link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+<style>
+  .tiptap-editor {
+    min-height: 300px;
+    overflow: auto;
+  }
+
+  .tiptap-editor .tiptap {
+    min-height: 300px;
+    padding: 1rem;
+    outline: none;
+  }
+
+  .tiptap-editor .tiptap p.is-editor-empty:first-child::before,
+  .tiptap-editor .tiptap p.is-empty::before {
+    color: #adb5bd;
+    content: attr(data-placeholder);
+    float: left;
+    height: 0;
+    pointer-events: none;
+  }
+
+  .tiptap-editor .tiptap table {
+    border-collapse: collapse;
+    margin: 0.75rem 0;
+    table-layout: fixed;
+    width: 100%;
+  }
+
+  .tiptap-editor .tiptap td,
+  .tiptap-editor .tiptap th {
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    padding: 0.5rem;
+    vertical-align: top;
+  }
+
+  .tiptap-editor .tiptap th {
+    background: var(--bs-tertiary-bg, #f8f9fa);
+    font-weight: 600;
+  }
+
+  .tiptap-editor .tiptap img {
+    max-width: 100%;
+    height: auto;
+  }
+
+  .tiptap-editor .tiptap ul[data-type="taskList"] {
+    list-style: none;
+    padding-left: 0;
+  }
+
+  .tiptap-editor .tiptap ul[data-type="taskList"] li {
+    display: flex;
+    gap: 0.5rem;
+  }
+</style>
 {% endblock %}
 
 {% block content %}
@@ -64,8 +118,8 @@
           </div>
 
           <div class="mb-3">
-            <label for="quill-editor" class="form-label">Texto</label>
-            <div id="quill-editor" class="border rounded bg-body" style="height:300px; overflow:auto;"></div>
+            <label for="tiptap-editor" class="form-label">Texto</label>
+            <div id="tiptap-editor" class="tiptap-editor border rounded bg-body"></div>
             <input type="hidden" name="texto" id="hidden-texto">
           </div>
 
@@ -113,26 +167,65 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
-<script>
+<script type="module">
+import { Editor } from 'https://esm.sh/@tiptap/core@3';
+import StarterKit from 'https://esm.sh/@tiptap/starter-kit@3';
+import { Image } from 'https://esm.sh/@tiptap/extension-image@3';
+import { Table, TableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3';
+import { TaskList, TaskItem } from 'https://esm.sh/@tiptap/extension-list@3';
+import { Placeholder } from 'https://esm.sh/@tiptap/extensions@3';
+import { TextAlign } from 'https://esm.sh/@tiptap/extension-text-align@3';
+import { Highlight } from 'https://esm.sh/@tiptap/extension-highlight@3';
+import { FileHandler } from 'https://esm.sh/@tiptap/extension-file-handler@3';
+
 document.addEventListener('DOMContentLoaded', () => {
-  // Inicializa o Quill editor
-  const quill = new Quill('#quill-editor', {
-    theme: 'snow',
-    modules: {
-      toolbar: [
-        [{ header: [1, 2, 3, false] }],
-        ['bold', 'italic', 'underline', 'strike'],
-        [{ color: [] }, { background: [] }],
-        [{ list: 'ordered' }, { list: 'bullet' }, { list: 'check' }],
-        [{ indent: '-1' }, { indent: '+1' }],
-        [{ align: [] }],
-        ['link', 'image', 'blockquote', 'code-block'],
-        ['clean']
-      ]
-    }
+  const initialContent = {{ (form_data or {}).get('texto', '') | tojson | safe }} || '<p></p>';
+
+  const insertImageFiles = (editorInstance, files, pos = null) => {
+    files
+      .filter(file => file.type.startsWith('image/'))
+      .forEach(file => {
+        const reader = new FileReader();
+        reader.addEventListener('load', () => {
+          const image = { type: 'image', attrs: { src: reader.result, alt: file.name } };
+          if (typeof pos === 'number') {
+            editorInstance.chain().focus().insertContentAt(pos, image).run();
+            return;
+          }
+          editorInstance.chain().focus().insertContent(image).run();
+        });
+        reader.readAsDataURL(file);
+      });
+  };
+
+  const editor = new Editor({
+    element: document.querySelector('#tiptap-editor'),
+    extensions: [
+      StarterKit,
+      Image.configure({ allowBase64: true }),
+      Table.configure({ resizable: true }),
+      TableRow,
+      TableCell,
+      TableHeader,
+      TaskList,
+      TaskItem.configure({ nested: true }),
+      Placeholder.configure({ placeholder: 'Escreva o conteúdo do artigo...' }),
+      TextAlign.configure({ types: ['heading', 'paragraph'] }),
+      Highlight.configure({ multicolor: true }),
+      FileHandler.configure({
+        allowedMimeTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
+        onPaste: (editorInstance, files) => insertImageFiles(editorInstance, files),
+        onDrop: (editorInstance, files, pos) => insertImageFiles(editorInstance, files, pos)
+      })
+    ],
+    content: initialContent,
+    editorProps: {
+      attributes: {
+        class: 'tiptap-content'
+      }
+    },
+    onUpdate: () => saveDraft()
   });
-  quill.root.innerHTML = {{ (form_data or {}).get('texto', '') | tojson | safe }};
 
   // Visibilidade por checkboxes → atualiza hidden e badges
   const visChecks = document.querySelectorAll('.vis-check');
@@ -154,7 +247,7 @@ document.addEventListener('DOMContentLoaded', () => {
       STORAGE_KEY,
       JSON.stringify({
         titulo: tituloInput.value,
-        texto: quill.root.innerHTML,
+        texto: editor.getHTML(),
         visibility: visInput.value,
         tipo_id: tipoInput.value,
         area_id: areaInput.value,
@@ -170,7 +263,7 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       const data = JSON.parse(raw);
       if (typeof data.titulo === 'string') tituloInput.value = data.titulo;
-      if (typeof data.texto === 'string') quill.root.innerHTML = data.texto;
+      if (typeof data.texto === 'string') editor.commands.setContent(data.texto);
       if (typeof data.tipo_id === 'string') tipoInput.value = data.tipo_id;
       if (typeof data.area_id === 'string') areaInput.value = data.area_id;
       if (typeof data.sistema_id === 'string') sistemaInput.value = data.sistema_id;
@@ -194,10 +287,9 @@ document.addEventListener('DOMContentLoaded', () => {
   loadDraft();
   tituloInput.addEventListener('input', saveDraft);
   [tipoInput, areaInput, sistemaInput].forEach(input => input.addEventListener('change', saveDraft));
-  quill.on('text-change', saveDraft);
   visChecks.forEach(cb => cb.addEventListener('change', saveDraft));
 
-  // Sincroniza conteúdo Quill no campo hidden antes de submeter
+  // Sincroniza conteúdo Tiptap no campo hidden antes de submeter
   const overlay = document.getElementById('fileLoadingOverlay');
   const overlayText = overlay?.querySelector('.file-loading-text');
   const overlayBar = overlay?.querySelector('.progress-bar');
@@ -316,7 +408,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const form = document.querySelector('form');
   form.addEventListener('submit', (event) => {
-    document.getElementById('hidden-texto').value = quill.root.innerHTML;
+    const hiddenTexto = document.getElementById('hidden-texto');
+    if (hiddenTexto) {
+      hiddenTexto.value = editor.getHTML();
+      document.getElementById('hidden-texto').value = hiddenTexto.value;
+    }
     localStorage.removeItem(STORAGE_KEY);
 
     const progressId = progressIdInput?.value || (crypto.randomUUID ? crypto.randomUUID() : String(Date.now()));


### PR DESCRIPTION
### Motivation
- Replace the legacy Quill-based editor with a modern Tiptap 3.x editor to support richer node/mark extensions (images, tables, task lists, paste/drop file handling) while preserving existing autosave and submit behavior.

### Description
- Replaced the Quill containers (`#quill-editor`) with `#tiptap-editor` and removed Quill CDN initialization, adding local CSS to style Tiptap content and placeholders in both `templates/artigos/novo_artigo.html` and `templates/artigos/editar_artigo.html`.
- Initialized Tiptap v3 via ESM CDN and enabled extensions: `StarterKit`, `Image`, `Table`, `TableRow`, `TableCell`, `TableHeader`, `TaskList`, `TaskItem`, `Placeholder`, `TextAlign`, `Highlight` and `FileHandler`, including handlers to insert pasted/dropped images as base64 data URLs.
- Kept the hidden input `name="texto"` and updated submit logic to set `hiddenTexto.value = editor.getHTML()` before sending the form.
- Updated autosave/load to persist `editor.getHTML()` and to restore content with `editor.commands.setContent(...)`, and adapted the reduction/char-count logic to use `editor.getText()`.

### Testing
- Ran `pytest tests/test_editar_artigo_autosave_template.py tests/test_required_fields.py` and all tests passed (`20 passed`, with warnings only).
- Verified the modified templates no longer initialize Quill and that autosave/submit hooks use the Tiptap editor API as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1e7f58c8832e816163b4fe21227e)