### PR TITLE
Atualiza sanitização para HTML do Tiptap

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -1,6 +1,7 @@
 # utils.py
 
 import bleach
+from bleach.css_sanitizer import CSSSanitizer
 import re
 import unicodedata
 from typing import Any, TypedDict
@@ -193,10 +194,28 @@ _SAFE_DATA_IMAGE_RE = re.compile(
     r"^data:image/(?:png|jpeg|gif|webp);base64,[a-z0-9+/=\s]+$",
     re.IGNORECASE,
 )
-_QUILL_CLASS_RE = re.compile(
-    r"^ql-(?:align-(?:center|right|justify)|indent-[1-8]|direction-rtl|list-.+)$"
+_SAFE_EDITOR_CLASS_RE = re.compile(
+    r"^(?:"
+    r"tiptap-content|"
+    r"text-align-(?:left|center|right|justify)|"
+    r"has-text-align-(?:left|center|right|justify)|"
+    r"highlight-(?:yellow|green|blue|red|purple)|"
+    r"language-[a-z0-9_+-]+|"
+    r"task-list|task-item|"
+    r"ql-(?:align-(?:center|right|justify)|indent-[1-8]|direction-rtl|list-.+)"
+    r")$"
 )
 _URL_SCHEME_RE = re.compile(r"^([a-z0-9+.-]+):", re.IGNORECASE)
+_SAFE_UPLOAD_IMAGE_RE = re.compile(
+    r"^/uploads/editor/[A-Za-z0-9][A-Za-z0-9._~!$&'()*+,;=:@%/-]*$"
+)
+_SAFE_CSS_COLOR_RE = re.compile(
+    r"^(?:#[0-9a-f]{3,8}|rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}(?:\s*,\s*(?:0|1|0?\.\d+))?\s*\))$",
+    re.IGNORECASE,
+)
+_EDITOR_CSS_SANITIZER = CSSSanitizer(
+    allowed_css_properties={"text-align", "background-color", "color"}
+)
 
 
 def _url_scheme(value: str) -> str | None:
@@ -213,29 +232,90 @@ def _is_safe_image_src(value: str) -> bool:
     stripped = (value or "").strip()
     if _SAFE_DATA_IMAGE_RE.match(stripped):
         return True
-    return _url_scheme(stripped) in {None, "http", "https"}
+    if _SAFE_UPLOAD_IMAGE_RE.match(stripped):
+        return ".." not in stripped and "\\" not in stripped
+    return _url_scheme(stripped) in {"http", "https"}
 
 
-def _has_only_safe_quill_classes(value: str) -> bool:
+def _is_safe_css_color(value: str) -> bool:
+    return bool(_SAFE_CSS_COLOR_RE.fullmatch((value or "").strip()))
+
+
+def _has_only_safe_editor_classes(value: str) -> bool:
     classes = (value or "").split()
     return bool(classes) and all(
-        _QUILL_CLASS_RE.match(class_name) for class_name in classes
+        _SAFE_EDITOR_CLASS_RE.match(class_name) for class_name in classes
     )
+
+
+def _has_only_safe_editor_styles(tag: str, value: str) -> bool:
+    allowed_properties_by_tag = {
+        "p": {"text-align"},
+        "h1": {"text-align"},
+        "h2": {"text-align"},
+        "h3": {"text-align"},
+        "h4": {"text-align"},
+        "h5": {"text-align"},
+        "h6": {"text-align"},
+        "mark": {"background-color", "color"},
+    }
+    allowed_properties = allowed_properties_by_tag.get(tag)
+    if not allowed_properties:
+        return False
+
+    declarations = [part.strip() for part in (value or "").split(";") if part.strip()]
+    if not declarations:
+        return False
+
+    for declaration in declarations:
+        if ":" not in declaration:
+            return False
+        property_name, property_value = [part.strip() for part in declaration.split(":", 1)]
+        property_name = property_name.lower()
+        normalized_value = property_value.lower()
+        if property_name not in allowed_properties:
+            return False
+        if any(token in normalized_value for token in ("javascript:", "data:", "url(", "expression", "@import")):
+            return False
+        if property_name == "text-align" and normalized_value not in {"left", "center", "right", "justify"}:
+            return False
+        if property_name == "background-color" and not _is_safe_css_color(property_value):
+            return False
+        if property_name == "color" and normalized_value != "inherit":
+            return False
+
+    return True
 
 
 def _sanitize_html_attribute(tag: str, name: str, value: str) -> bool:
     allowed_attrs_by_tag = {
         "a": {"href", "title", "target", "rel"},
         "img": {"src", "alt", "title", "width", "height"},
-        "th": {"colspan", "rowspan"},
-        "td": {"colspan", "rowspan"},
+        "p": {"style"},
+        "h1": {"style"},
+        "h2": {"style"},
+        "h3": {"style"},
+        "h4": {"style"},
+        "h5": {"style"},
+        "h6": {"style"},
+        "code": {"spellcheck"},
+        "mark": {"data-color", "style"},
+        "ul": {"data-type"},
+        "li": {"data-type", "data-checked"},
+        "input": {"type", "checked", "disabled"},
+        "th": {"colspan", "rowspan", "colwidth"},
+        "td": {"colspan", "rowspan", "colwidth"},
+        "col": {"width"},
     }
 
     if name == "class":
-        return _has_only_safe_quill_classes(value)
+        return _has_only_safe_editor_classes(value)
 
     if name not in allowed_attrs_by_tag.get(tag, set()):
         return False
+
+    if name == "style":
+        return _has_only_safe_editor_styles(tag, value)
 
     if tag == "a" and name == "href":
         return _is_safe_link(value)
@@ -249,17 +329,42 @@ def _sanitize_html_attribute(tag: str, name: str, value: str) -> bool:
     if tag == "img" and name in {"width", "height"}:
         return bool(re.fullmatch(r"(?:\d{1,4}|\d{1,3}%)", value or ""))
 
+    if tag == "mark" and name == "data-color":
+        return _is_safe_css_color(value)
+
+    if tag == "ul" and name == "data-type":
+        return value == "taskList"
+
+    if tag == "li" and name == "data-type":
+        return value == "taskItem"
+
+    if tag == "li" and name == "data-checked":
+        return value in {"true", "false"}
+
+    if tag == "input" and name == "type":
+        return value == "checkbox"
+
+    if tag == "input" and name in {"checked", "disabled"}:
+        return value in {"", name, "true", "checked", "disabled"}
+
     if tag in {"th", "td"} and name in {"colspan", "rowspan"}:
         return bool(re.fullmatch(r"\d{1,2}", value or ""))
+
+    if tag in {"th", "td"} and name == "colwidth":
+        return bool(re.fullmatch(r"\d{1,4}(?:,\d{1,4})*", value or ""))
+
+    if tag == "col" and name == "width":
+        return bool(re.fullmatch(r"(?:\d{1,4}|\d{1,3}%)", value or ""))
 
     return True
 
 
 def sanitize_html(text: str) -> str:
     allowed_tags = [
-        "h1", "h2", "h3", "p", "br", "ul", "ol", "li",
-        "strong", "b", "em", "i", "u", "blockquote", "a", "img",
-        "table", "thead", "tbody", "tr", "th", "td",
+        "h1", "h2", "h3", "h4", "h5", "h6", "p", "br", "pre", "code",
+        "ul", "ol", "li", "strong", "b", "em", "i", "u", "s", "mark",
+        "blockquote", "a", "img", "table", "thead", "tbody", "tfoot", "tr",
+        "th", "td", "colgroup", "col", "label", "input",
     ]
 
     return bleach.clean(
@@ -268,6 +373,7 @@ def sanitize_html(text: str) -> str:
         attributes=_sanitize_html_attribute,
         strip=True,
         protocols=["http", "https", "mailto", "data"],
+        css_sanitizer=_EDITOR_CSS_SANITIZER,
     )
 
 """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,28 +22,88 @@ def test_sanitize_html_removes_disallowed_tags():
     assert "<div" not in cleaned
 
 
-def test_sanitize_html_allows_quill_headings_lists_and_formatting():
+def test_sanitize_html_allows_tiptap_headings_lists_and_formatting():
     html = (
-        '<h1>Título</h1><h2>Seção</h2><h3>Subseção</h3>'
-        '<p class="ql-align-center">Texto <b>negrito</b> '
+        '<h1 style="text-align: center">Título</h1><h2>Seção</h2><h3>Subseção</h3>'
+        '<p style="text-align: right">Texto <b>negrito</b> '
         '<i>itálico</i> <u>sublinhado</u></p>'
-        '<ul><li class="ql-indent-1">Item</li></ul>'
+        '<ul><li>Item</li></ul>'
         '<ol><li>Primeiro</li></ol>'
         '<blockquote>Citação</blockquote>'
     )
 
     cleaned = sanitize_html(html)
 
-    assert '<h1>Título</h1>' in cleaned
+    assert '<h1 style="text-align: center;">Título</h1>' in cleaned
     assert '<h2>Seção</h2>' in cleaned
     assert '<h3>Subseção</h3>' in cleaned
     assert (
-        '<p class="ql-align-center">Texto <b>negrito</b> '
+        '<p style="text-align: right;">Texto <b>negrito</b> '
         '<i>itálico</i> <u>sublinhado</u></p>'
     ) in cleaned
-    assert '<ul><li class="ql-indent-1">Item</li></ul>' in cleaned
+    assert '<ul><li>Item</li></ul>' in cleaned
     assert '<ol><li>Primeiro</li></ol>' in cleaned
     assert '<blockquote>Citação</blockquote>' in cleaned
+
+
+def test_sanitize_html_allows_tiptap_code_block_and_highlight():
+    html = (
+        '<pre><code class="language-python">print(&quot;ok&quot;)</code></pre>'
+        '<p>Texto <mark data-color="#ffe066" '
+        'style="background-color: #ffe066; color: inherit">marcado</mark></p>'
+    )
+
+    cleaned = sanitize_html(html)
+
+    assert '<pre><code class="language-python">print(&quot;ok&quot;)</code></pre>' in cleaned
+    assert (
+        '<mark data-color="#ffe066" '
+        'style="background-color: #ffe066; color: inherit;">marcado</mark>'
+    ) in cleaned
+
+
+def test_sanitize_html_allows_tiptap_checklist():
+    html = (
+        '<ul data-type="taskList"><li data-type="taskItem" data-checked="true">'
+        '<label><input type="checkbox" checked="checked" disabled="disabled">'
+        '<span></span></label><div><p>Tarefa concluída</p></div></li></ul>'
+    )
+
+    cleaned = sanitize_html(html)
+
+    assert '<ul data-type="taskList">' in cleaned
+    assert '<li data-type="taskItem" data-checked="true">' in cleaned
+    assert '<input type="checkbox" checked disabled>' in cleaned
+    assert '<p>Tarefa concluída</p>' in cleaned
+
+
+def test_sanitize_html_allows_tiptap_table():
+    html = (
+        '<table><tbody><tr>'
+        '<th colspan="1" rowspan="1"><p>Cabeçalho</p></th>'
+        '<td colspan="2" rowspan="1"><p>Célula</p></td>'
+        '</tr></tbody></table>'
+    )
+
+    cleaned = sanitize_html(html)
+
+    assert '<table><tbody><tr>' in cleaned
+    assert '<th colspan="1" rowspan="1"><p>Cabeçalho</p></th>' in cleaned
+    assert '<td colspan="2" rowspan="1"><p>Célula</p></td>' in cleaned
+
+
+def test_sanitize_html_allows_tiptap_uploaded_editor_image():
+    html = (
+        '<img src="/uploads/editor/artigo-1/imagem.png" alt="Imagem" title="Upload">'
+        '<img src="/uploads/not-editor/imagem.png" alt="Fora">'
+        '<img src="/uploads/editor/../secret.png" alt="Traversal">'
+    )
+
+    cleaned = sanitize_html(html)
+
+    assert '<img src="/uploads/editor/artigo-1/imagem.png" alt="Imagem" title="Upload">' in cleaned
+    assert '<img alt="Fora">' in cleaned
+    assert '<img alt="Traversal">' in cleaned
 
 
 def test_sanitize_html_allows_safe_links_and_blocks_javascript():


### PR DESCRIPTION
### Motivation
- Suportar e preservar HTML gerado pelo editor Tiptap (códigos, destaques, checklist, tabelas, imagens uploadadas) mantendo proteção contra vetores XSS e atributos perigosos.
- Substituir a validação específica de classes do Quill por uma validação neutra/mais ampla para classes de editor.

### Description
- Renomeia e amplia `_has_only_safe_quill_classes` para `_has_only_safe_editor_classes` com novo regex que cobre classes do Tiptap (alinhamento, highlight, language-*, task list, além de compatibilidade com `ql-*`).
- Adiciona validação de fontes de imagem aceitas incluindo data URLs seguros e caminho restrito `/uploads/editor/...` e previne traversal (`..`/barra invertida).
- Introduz validação de cores CSS seguras e um `CSSSanitizer` limitado (`text-align`, `background-color`, `color`) para permitir estilos controlados; adiciona função `_has_only_safe_editor_styles` para permitir apenas propriedades/valores seguros em tags específicas (ex.: `text-align` em headings/paragraph e `background-color` em `mark`).
- Expande a whitelist de tags e atributos no `sanitize_html` para incluir `pre`, `code`, `mark`, headings `h1`–`h6`, listas, tabelas, `label`/`input` e atributos Tiptap como `data-type`, `data-checked`, `colwidth` e `data-color`.
- Mantém bloqueios importantes: remoção de `<script>`, atributos `on*`, URLs `javascript:` e `data:text/html`, SVG inline e estilos/expression/imports perigosos.
- Atualiza `tests/test_utils.py`: renomeia testes com “quill” para “tiptap” e adiciona novos testes cobrindo code block, mark/highlight, checklist, tabela e imagem em `/uploads/editor/...`.

### Testing
- Executado `pytest -q tests/test_utils.py`, que passou com os testes atualizados (incluindo os novos casos de Tiptap).
- Executado `pytest -q` (suite completa), resultando em sucesso da suíte no ambiente: `196 passed, 1 skipped` (diversos warnings legados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe208f06c0832ea43f7312d7921349)