### PR TITLE
Add authenticated editor image upload

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -240,6 +240,80 @@ def upload_progress(progress_id):
     if state.done:
         clear_progress(progress_id)
     return jsonify(payload)
+
+EDITOR_IMAGE_ALLOWED_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.webp'}
+EDITOR_IMAGE_ALLOWED_MIMES = {'image/png', 'image/jpeg', 'image/webp'}
+EDITOR_IMAGE_DEFAULT_MAX_BYTES = 2 * 1024 * 1024
+
+
+def _json_error(message, status_code):
+    response = jsonify({'error': message})
+    response.status_code = status_code
+    return response
+
+
+def _editor_image_max_bytes():
+    configured_limit = app.config.get(
+        'EDITOR_IMAGE_MAX_CONTENT_LENGTH',
+        app.config.get('EDITOR_IMAGE_MAX_BYTES', EDITOR_IMAGE_DEFAULT_MAX_BYTES),
+    )
+    try:
+        return int(configured_limit)
+    except (TypeError, ValueError):
+        return EDITOR_IMAGE_DEFAULT_MAX_BYTES
+
+
+def _editor_upload_file_from_request():
+    upload = request.files.get('file') or request.files.get('upload')
+    if upload is not None:
+        return upload
+    if request.files:
+        return next(iter(request.files.values()))
+    return None
+
+
+def _is_allowed_editor_image(upload):
+    filename = secure_filename(upload.filename or '')
+    _, extension = os.path.splitext(filename.lower())
+    mimetype = (upload.mimetype or '').lower()
+    return extension in EDITOR_IMAGE_ALLOWED_EXTENSIONS and mimetype in EDITOR_IMAGE_ALLOWED_MIMES
+
+
+@articles_bp.route('/artigos/editor-image-upload', methods=['POST'])
+def editor_image_upload():
+    if 'user_id' not in session:
+        return _json_error('Faça login para enviar imagens.', 401)
+
+    user = db.session.get(User, session['user_id'])
+    if user is None:
+        session.pop('user_id', None)
+        session.pop('username', None)
+        return _json_error('Sessão inválida ou expirada. Faça login novamente.', 401)
+
+    upload = _editor_upload_file_from_request()
+    if upload is None or not upload.filename:
+        return _json_error('Nenhum arquivo de imagem foi enviado.', 400)
+
+    original_filename = secure_filename(upload.filename)
+    if not _is_allowed_editor_image(upload):
+        return _json_error('Tipo de imagem inválido. Envie apenas PNG, JPG/JPEG ou WebP.', 415)
+
+    image_bytes = upload.read()
+    upload.stream.seek(0)
+    max_bytes = _editor_image_max_bytes()
+    if max_bytes > 0 and len(image_bytes) > max_bytes:
+        return _json_error('Imagem acima do limite permitido.', 413)
+
+    _, extension = os.path.splitext(original_filename.lower())
+    unique_filename = f'{uuid.uuid4().hex}{extension}'
+    editor_folder = os.path.join(app.config['UPLOAD_FOLDER'], 'editor')
+    os.makedirs(editor_folder, exist_ok=True)
+    destination = os.path.join(editor_folder, unique_filename)
+    with open(destination, 'wb') as image_file:
+        image_file.write(image_bytes)
+
+    return jsonify({'url': f'/uploads/editor/{unique_filename}'})
+
 @articles_bp.route('/novo-artigo', methods=['GET', 'POST'], endpoint='novo_artigo')
 def novo_artigo():
     if 'user_id' not in session:

--- a/tests/test_article_editor_image_upload.py
+++ b/tests/test_article_editor_image_upload.py
@@ -1,0 +1,121 @@
+import io
+import os
+
+import pytest
+
+from app import db
+from core.models import User
+
+
+EDITOR_UPLOAD_URL = '/artigos/editor-image-upload'
+
+
+@pytest.fixture
+def upload_app(app_ctx, tmp_path):
+    original_upload_folder = app_ctx.config.get('UPLOAD_FOLDER')
+    original_editor_limit = app_ctx.config.get('EDITOR_IMAGE_MAX_BYTES')
+    original_editor_content_limit = app_ctx.config.get('EDITOR_IMAGE_MAX_CONTENT_LENGTH')
+    app_ctx.config['UPLOAD_FOLDER'] = str(tmp_path)
+    app_ctx.config['EDITOR_IMAGE_MAX_BYTES'] = 1024
+    app_ctx.config.pop('EDITOR_IMAGE_MAX_CONTENT_LENGTH', None)
+    yield app_ctx
+    app_ctx.config['UPLOAD_FOLDER'] = original_upload_folder
+    if original_editor_limit is None:
+        app_ctx.config.pop('EDITOR_IMAGE_MAX_BYTES', None)
+    else:
+        app_ctx.config['EDITOR_IMAGE_MAX_BYTES'] = original_editor_limit
+    if original_editor_content_limit is None:
+        app_ctx.config.pop('EDITOR_IMAGE_MAX_CONTENT_LENGTH', None)
+    else:
+        app_ctx.config['EDITOR_IMAGE_MAX_CONTENT_LENGTH'] = original_editor_content_limit
+
+
+@pytest.fixture
+def logged_client(upload_app, client):
+    user = User(username='editor_upload', email='editor-upload@example.com', password_hash='x')
+    db.session.add(user)
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess['user_id'] = user.id
+        sess['username'] = user.username
+    return client
+
+
+def _upload(client, filename, content, content_type):
+    return client.post(
+        EDITOR_UPLOAD_URL,
+        data={'file': (io.BytesIO(content), filename, content_type)},
+        content_type='multipart/form-data',
+    )
+
+
+def _saved_path(upload_app, url):
+    return os.path.join(upload_app.config['UPLOAD_FOLDER'], url.removeprefix('/uploads/'))
+
+
+def test_valid_editor_image_upload_saves_file_and_returns_json_url(upload_app, logged_client):
+    response = _upload(logged_client, 'foto.png', b'valid png content', 'image/png')
+
+    assert response.status_code == 200
+    assert response.is_json
+    payload = response.get_json()
+    assert set(payload) == {'url'}
+    assert payload['url'].startswith('/uploads/editor/')
+    assert payload['url'].endswith('.png')
+    assert os.path.exists(_saved_path(upload_app, payload['url']))
+
+
+def test_editor_image_upload_blocks_svg_even_with_image_mime(upload_app, logged_client):
+    response = _upload(
+        logged_client,
+        'icone.svg',
+        b'<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+        'image/svg+xml',
+    )
+
+    assert response.status_code == 415
+    assert response.is_json
+    assert 'inválido' in response.get_json()['error'].lower()
+    assert not os.path.exists(os.path.join(upload_app.config['UPLOAD_FOLDER'], 'editor'))
+
+
+def test_editor_image_upload_blocks_file_above_limit(upload_app, logged_client):
+    upload_app.config['EDITOR_IMAGE_MAX_BYTES'] = 10
+
+    response = _upload(logged_client, 'foto.jpg', b'x' * 11, 'image/jpeg')
+
+    assert response.status_code == 413
+    assert response.is_json
+    assert 'limite' in response.get_json()['error'].lower()
+    assert not os.path.exists(os.path.join(upload_app.config['UPLOAD_FOLDER'], 'editor'))
+
+
+def test_editor_image_upload_blocks_anonymous_user(client, upload_app):
+    response = _upload(client, 'foto.webp', b'webp content', 'image/webp')
+
+    assert response.status_code == 401
+    assert response.is_json
+    assert 'login' in response.get_json()['error'].lower()
+
+
+def test_editor_image_upload_generates_unique_names(upload_app, logged_client):
+    first_response = _upload(logged_client, 'foto.jpeg', b'first image', 'image/jpeg')
+    second_response = _upload(logged_client, 'foto.jpeg', b'second image', 'image/jpeg')
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    first_url = first_response.get_json()['url']
+    second_url = second_response.get_json()['url']
+    assert first_url != second_url
+    assert first_url.startswith('/uploads/editor/')
+    assert second_url.startswith('/uploads/editor/')
+    assert os.path.exists(_saved_path(upload_app, first_url))
+    assert os.path.exists(_saved_path(upload_app, second_url))
+
+
+def test_editor_image_upload_handles_missing_file(logged_client):
+    response = logged_client.post(EDITOR_UPLOAD_URL, data={}, content_type='multipart/form-data')
+
+    assert response.status_code == 400
+    assert response.is_json
+    assert 'nenhum arquivo' in response.get_json()['error'].lower()


### PR DESCRIPTION
### Motivation
- Provide a small authenticated JSON endpoint for WYSIWYG/editor image uploads so editors can insert images safely from the article editor. 

### Description
- Added `POST /artigos/editor-image-upload` which requires a logged session and returns JSON `{ "url": "/uploads/editor/<arquivo>" }` for accepted images. 
- Enforced allowlist validation by extension and MIME for PNG, JPG/JPEG and WebP while explicitly blocking SVG, with per-file size limit controlled by `EDITOR_IMAGE_MAX_BYTES` or `EDITOR_IMAGE_MAX_CONTENT_LENGTH` and a sane default. 
- Generates UUID-based unique filenames, creates `UPLOAD_FOLDER/editor/`, saves the file there and returns the upload URL. 
- Added friendly JSON error responses for missing file, invalid type, oversized image, and anonymous/expired session and included a test module `tests/test_article_editor_image_upload.py` that covers the required scenarios. 

### Testing
- Ran `pytest -q tests/test_article_editor_image_upload.py` and the new test file passed (all editor-image tests succeeded). 
- Ran the full test suite with `pytest -q` and the suite completed successfully (`202 passed, 1 skipped`), confirming no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe22a4d378832eafae289003e429ce)