### PR TITLE
Serve authenticated editor uploads from UPLOAD_FOLDER/editor with safe filename validation

### DIFF
--- a/blueprints/auth.py
+++ b/blueprints/auth.py
@@ -322,6 +322,33 @@ def profile_pics(filename):
         return abort(401)
     return send_from_directory(app.config['PROFILE_PICS_FOLDER'], filename)
 
+def _is_safe_upload_filename(filename):
+    if not filename or '\x00' in filename:
+        return False
+    if filename.startswith('/') or filename.startswith('\\'):
+        return False
+    if '\\' in filename:
+        return False
+
+    parts = filename.split('/')
+    if not parts or any(part in {'', '.', '..'} for part in parts):
+        return False
+
+    return all(part == secure_filename(part) for part in parts)
+
+
+@auth_bp.route('/uploads/editor/<path:filename>', endpoint='uploaded_editor_file')
+def uploaded_editor_file(filename):
+    if 'user_id' not in session:
+        app.logger.warning("Tentativa anônima de acesso a upload do editor: %s", filename)
+        return abort(401)
+    if not _is_safe_upload_filename(filename):
+        app.logger.warning("Tentativa de acesso a upload do editor com caminho inválido: %s", filename)
+        return abort(404)
+    editor_folder = os.path.join(app.config['UPLOAD_FOLDER'], 'editor')
+    return send_from_directory(editor_folder, filename)
+
+
 @auth_bp.route('/uploads/<filename>', endpoint='uploaded_file')
 def uploaded_file(filename):
     if 'user_id' not in session:

--- a/tests/test_article_editor_image_upload.py
+++ b/tests/test_article_editor_image_upload.py
@@ -119,3 +119,48 @@ def test_editor_image_upload_handles_missing_file(logged_client):
     assert response.status_code == 400
     assert response.is_json
     assert 'nenhum arquivo' in response.get_json()['error'].lower()
+
+
+def test_uploaded_editor_file_serves_logged_user_from_editor_folder(upload_app, logged_client):
+    editor_folder = os.path.join(upload_app.config['UPLOAD_FOLDER'], 'editor')
+    os.makedirs(editor_folder, exist_ok=True)
+    image_path = os.path.join(editor_folder, 'inline.png')
+    with open(image_path, 'wb') as image_file:
+        image_file.write(b'inline image')
+
+    response = logged_client.get('/uploads/editor/inline.png')
+
+    assert response.status_code == 200
+    assert response.data == b'inline image'
+
+
+def test_uploaded_editor_file_serves_nested_legacy_inline_images(upload_app, logged_client):
+    legacy_folder = os.path.join(upload_app.config['UPLOAD_FOLDER'], 'editor', 'artigo-1')
+    os.makedirs(legacy_folder, exist_ok=True)
+    image_path = os.path.join(legacy_folder, 'imagem.png')
+    with open(image_path, 'wb') as image_file:
+        image_file.write(b'legacy inline image')
+
+    response = logged_client.get('/uploads/editor/artigo-1/imagem.png')
+
+    assert response.status_code == 200
+    assert response.data == b'legacy inline image'
+
+
+def test_uploaded_editor_file_blocks_anonymous_user(client, upload_app):
+    response = client.get('/uploads/editor/inline.png')
+
+    assert response.status_code == 401
+
+
+def test_uploaded_editor_file_blocks_path_traversal(upload_app, logged_client):
+    editor_folder = os.path.join(upload_app.config['UPLOAD_FOLDER'], 'editor')
+    os.makedirs(editor_folder, exist_ok=True)
+    secret_path = os.path.join(upload_app.config['UPLOAD_FOLDER'], 'secret.png')
+    with open(secret_path, 'wb') as secret_file:
+        secret_file.write(b'secret image')
+
+    response = logged_client.get('/uploads/editor/%2e%2e/secret.png')
+
+    assert response.status_code == 404
+    assert response.data != b'secret image'


### PR DESCRIPTION
### Motivation
- Serve images uploaded by the rich-text editor from a dedicated path so inline images and legacy nested editor paths are resolved correctly.
- Prevent path traversal and unsafe filenames while keeping the current authentication behavior for uploads.

### Description
- Added `_is_safe_upload_filename` helper to validate `filename` (rejects empty/nul bytes, absolute paths, backslashes, `.`/`..` segments and names that don't match `secure_filename`) in `blueprints/auth.py`.
- Added route `@auth_bp.route('/uploads/editor/<path:filename>', endpoint='uploaded_editor_file')` that returns files with `send_from_directory(os.path.join(app.config['UPLOAD_FOLDER'], 'editor'), filename)` after validation and authentication.
- Preserved existing behavior where anonymous requests receive `401` and invalid/traversal filenames are rejected with `404`.
- Added tests in `tests/test_article_editor_image_upload.py` covering serving inline editor images, nested legacy paths, anonymous access denial and path traversal blocking.

### Testing
- Ran `pytest -q tests/test_article_editor_image_upload.py` which passed.
- Ran `pytest -q tests/test_article_editor_image_upload.py tests/test_utils.py` which completed with all tests passing (`21 passed, 1 skipped`) and warnings only about a legacy SQLAlchemy API.
- No automated tests failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe254f7370832ead3aead3555d78c4)