### PR TITLE
Valida imagens inline em base64 em artigos

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -22,6 +22,7 @@ except ImportError:
 try:
     from ..core.utils import (
         sanitize_html,
+        validate_article_html_inline_images,
         eligible_review_notification_users,
         user_can_view_article,
         user_can_edit_article,
@@ -36,6 +37,7 @@ try:
 except ImportError:  # pragma: no cover - fallback for direct execution
     from core.utils import (
         sanitize_html,
+        validate_article_html_inline_images,
         eligible_review_notification_users,
         user_can_view_article,
         user_can_edit_article,
@@ -345,6 +347,12 @@ def novo_artigo():
             'visibility': request.form.get('visibility') or 'celula',
         }
 
+        html_valido, mensagem_html = validate_article_html_inline_images(texto_raw)
+        if not html_valido:
+            flash(mensagem_html, 'warning')
+            flash('Se você selecionou anexos, será necessário reenviá-los após corrigir o formulário (limitação de multipart).', 'info')
+            return _render_novo_artigo_form(form_data)
+
         # Campos obrigatórios: título e conteúdo textual sanitizado
         if not titulo or not _has_required_text_content(texto_limpo):
             flash('Erro de validação: título e conteúdo textual são obrigatórios.', 'warning')
@@ -612,6 +620,10 @@ def artigo(artigo_id):
         novo_titulo = request.form['titulo'].strip()
         novo_texto_raw = request.form['texto']
         novo_texto = sanitize_html(novo_texto_raw).strip()
+        html_valido, mensagem_html = validate_article_html_inline_images(novo_texto_raw)
+        if not html_valido:
+            flash(mensagem_html, 'warning')
+            return redirect(url_for('artigo', artigo_id=artigo_id))
         if not novo_titulo or not _has_required_text_content(novo_texto):
             flash('Erro de validação: título e conteúdo textual são obrigatórios.', 'warning')
             return redirect(url_for('artigo', artigo_id=artigo_id))
@@ -1115,6 +1127,11 @@ def editar_artigo(artigo_id):
             'sistema_id': request.form.get('sistema_id') or '',
             'visibility': request.form.get('visibility') or artigo.visibility.value,
         }
+        html_valido, mensagem_html = validate_article_html_inline_images(texto_raw)
+        if not html_valido:
+            flash(mensagem_html, 'warning')
+            flash('Se você selecionou anexos, será necessário reenviá-los após corrigir o formulário (limitação de multipart).', 'info')
+            return _render_editar_artigo_form(artigo, json.loads(artigo.arquivos or "[]"), can_submit_actions, form_data)
         if not titulo or not _has_required_text_content(texto):
             flash('Erro de validação: título e conteúdo textual são obrigatórios.', 'warning')
             flash('Se você selecionou anexos, será necessário reenviá-los após corrigir o formulário (limitação de multipart).', 'info')

--- a/core/utils.py
+++ b/core/utils.py
@@ -194,6 +194,47 @@ _SAFE_DATA_IMAGE_RE = re.compile(
     r"^data:image/(?:png|jpeg|gif|webp);base64,[a-z0-9+/=\s]+$",
     re.IGNORECASE,
 )
+
+_INLINE_DATA_IMAGE_RE = re.compile(
+    r"data:image/[a-z0-9.+-]+;base64,([a-z0-9+/=\s]+)",
+    re.IGNORECASE,
+)
+ARTICLE_INLINE_IMAGE_BASE64_MAX_CHARS = 4096
+ARTICLE_INLINE_IMAGE_BASE64_MESSAGE = (
+    "A imagem colada no texto é muito grande para salvar diretamente no artigo. "
+    "Cole novamente a imagem ou anexe o arquivo pelo botão de upload."
+)
+
+
+def article_html_has_large_inline_base64_image(
+    html_text: str,
+    *,
+    max_base64_chars: int = ARTICLE_INLINE_IMAGE_BASE64_MAX_CHARS,
+) -> bool:
+    """Retorna True quando o HTML recebido contém imagem inline base64 acima do limite."""
+    if max_base64_chars < 0:
+        return False
+
+    for match in _INLINE_DATA_IMAGE_RE.finditer(html_text or ""):
+        payload = re.sub(r"\s+", "", match.group(1) or "")
+        if len(payload) > max_base64_chars:
+            return True
+    return False
+
+
+def validate_article_html_inline_images(
+    html_text: str,
+    *,
+    max_base64_chars: int = ARTICLE_INLINE_IMAGE_BASE64_MAX_CHARS,
+) -> tuple[bool, str | None]:
+    """Valida imagens base64 coladas no HTML antes de persistir artigos."""
+    if article_html_has_large_inline_base64_image(
+        html_text,
+        max_base64_chars=max_base64_chars,
+    ):
+        return False, ARTICLE_INLINE_IMAGE_BASE64_MESSAGE
+    return True, None
+
 _SAFE_EDITOR_CLASS_RE = re.compile(
     r"^(?:"
     r"tiptap-content|"

--- a/tests/test_article_inline_base64_validation.py
+++ b/tests/test_article_inline_base64_validation.py
@@ -1,0 +1,198 @@
+from app import db
+from core.enums import ArticleStatus, ArticleVisibility, Permissao
+from core.models import (
+    Article,
+    Celula,
+    Estabelecimento,
+    Funcao,
+    Instituicao,
+    Setor,
+    User,
+)
+
+
+FRIENDLY_MESSAGE = "A imagem colada no texto é muito grande"
+
+
+def _add_permission(user, code):
+    if isinstance(code, Permissao):
+        code = code.value
+    funcao = Funcao.query.filter_by(codigo=code).first()
+    if not funcao:
+        funcao = Funcao(codigo=code, nome=code)
+        db.session.add(funcao)
+        db.session.flush()
+    user.permissoes_personalizadas.append(funcao)
+
+
+def _create_author(username="autor_inline_base64", permissions=("artigo_criar",)):
+    inst = Instituicao(codigo=f"I-{username[:8]}", nome="Instituição Inline")
+    est = Estabelecimento(codigo=f"E-{username[:8]}", nome_fantasia="Est Inline", instituicao=inst)
+    setor = Setor(nome=f"Setor {username}", estabelecimento=est)
+    celula = Celula(nome=f"Célula {username}", estabelecimento=est, setor=setor)
+    db.session.add_all([inst, est, setor, celula])
+    db.session.flush()
+
+    user = User(
+        username=username,
+        email=f"{username}@example.test",
+        password_hash="x",
+        estabelecimento=est,
+        setor=setor,
+        celula=celula,
+    )
+    db.session.add(user)
+    db.session.flush()
+    for permission in permissions:
+        _add_permission(user, permission)
+    db.session.commit()
+    return user, {"inst": inst, "est": est, "setor": setor, "celula": celula}
+
+
+def _login(client, user):
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+        sess["username"] = user.username
+
+
+def _large_inline_image_html():
+    payload = "A" * 4097
+    return f'<p>Conteúdo com texto suficiente.</p><img src="data:image/png;base64,{payload}" alt="colada">'
+
+
+def _uploaded_editor_image_html():
+    return '<p>Conteúdo com imagem enviada.</p><img src="/uploads/editor/imagem.png" alt="enviada">'
+
+
+def test_criacao_recusa_html_com_base64_grande(client):
+    author, _org = _create_author("autor_cria_inline")
+    _login(client, author)
+
+    response = client.post(
+        "/novo-artigo",
+        data={
+            "titulo": "Criação com base64 grande",
+            "texto": _large_inline_image_html(),
+            "visibility": "celula",
+            "acao": "rascunho",
+        },
+    )
+
+    assert response.status_code == 200
+    assert FRIENDLY_MESSAGE in response.get_data(as_text=True)
+    assert Article.query.filter_by(titulo="Criação com base64 grande").count() == 0
+
+
+def test_criacao_aceita_html_com_uploads_editor(client):
+    author, _org = _create_author("autor_cria_upload")
+    _login(client, author)
+
+    response = client.post(
+        "/novo-artigo",
+        data={
+            "titulo": "Criação com upload editor",
+            "texto": _uploaded_editor_image_html(),
+            "visibility": "celula",
+            "acao": "rascunho",
+        },
+    )
+
+    assert response.status_code == 302
+    article = Article.query.filter_by(titulo="Criação com upload editor").one()
+    assert '/uploads/editor/imagem.png' in article.texto
+
+
+def test_edicao_recusa_html_com_base64_grande(client):
+    author, org = _create_author("autor_edita_inline")
+    article = Article(
+        titulo="Artigo antes do base64",
+        texto="Conteúdo original suficiente para o teste.",
+        status=ArticleStatus.RASCUNHO,
+        user_id=author.id,
+        celula_id=org["celula"].id,
+        vis_celula_id=org["celula"].id,
+        setor_id=org["setor"].id,
+        estabelecimento_id=org["est"].id,
+        instituicao_id=org["inst"].id,
+        visibility=ArticleVisibility.CELULA,
+    )
+    db.session.add(article)
+    db.session.commit()
+    article_id = article.id
+    _login(client, author)
+
+    response = client.post(
+        f"/artigo/{article_id}/editar",
+        data={
+            "titulo": "Artigo depois do base64",
+            "texto": _large_inline_image_html(),
+            "visibility": "celula",
+            "acao": "salvar",
+        },
+    )
+
+    assert response.status_code == 200
+    assert FRIENDLY_MESSAGE in response.get_data(as_text=True)
+    unchanged = Article.query.get(article_id)
+    assert unchanged.titulo == "Artigo antes do base64"
+    assert unchanged.texto == "Conteúdo original suficiente para o teste."
+
+
+def test_edicao_aceita_html_com_uploads_editor(client):
+    author, org = _create_author("autor_edita_upload")
+    article = Article(
+        titulo="Artigo antes do upload",
+        texto="Conteúdo original suficiente para editar.",
+        status=ArticleStatus.RASCUNHO,
+        user_id=author.id,
+        celula_id=org["celula"].id,
+        vis_celula_id=org["celula"].id,
+        setor_id=org["setor"].id,
+        estabelecimento_id=org["est"].id,
+        instituicao_id=org["inst"].id,
+        visibility=ArticleVisibility.CELULA,
+    )
+    db.session.add(article)
+    db.session.commit()
+    article_id = article.id
+    _login(client, author)
+
+    response = client.post(
+        f"/artigo/{article_id}/editar",
+        data={
+            "titulo": "Artigo depois do upload",
+            "texto": _uploaded_editor_image_html(),
+            "visibility": "celula",
+            "acao": "salvar",
+        },
+    )
+
+    assert response.status_code == 302
+    updated = Article.query.get(article_id)
+    assert updated.titulo == "Artigo depois do upload"
+    assert '/uploads/editor/imagem.png' in updated.texto
+
+
+def test_visualizacao_simples_de_artigo_antigo_com_base64_continua_funcionando(client):
+    author, org = _create_author("autor_visualiza_inline")
+    old_html = _large_inline_image_html()
+    article = Article(
+        titulo="Artigo antigo com base64",
+        texto=old_html,
+        status=ArticleStatus.RASCUNHO,
+        user_id=author.id,
+        celula_id=org["celula"].id,
+        vis_celula_id=org["celula"].id,
+        setor_id=org["setor"].id,
+        estabelecimento_id=org["est"].id,
+        instituicao_id=org["inst"].id,
+        visibility=ArticleVisibility.CELULA,
+    )
+    db.session.add(article)
+    db.session.commit()
+    _login(client, author)
+
+    response = client.get(f"/artigo/{article.id}")
+
+    assert response.status_code == 200
+    assert 'data:image/png;base64,' in response.get_data(as_text=True)


### PR DESCRIPTION
### Motivation
- Evitar que HTML enviado com imagens coladas em `data:image/...;base64` com payloads muito grandes seja persistido no artigo.
- Exibir uma mensagem amigável orientando o usuário a colar novamente ou anexar o arquivo quando o payload for grande.
- Não interromper a visualização simples de artigos antigos que já contenham imagens em base64.

### Description
- Adiciona em `core/utils.py` a validação centralizada com `_INLINE_DATA_IMAGE_RE`, `article_html_has_large_inline_base64_image` e `validate_article_html_inline_images`, com limite padrão de 4096 caracteres e mensagem amigável.
- Importa e aplica `validate_article_html_inline_images` em `blueprints/articles.py` antes de persistir o campo `texto` nas rotas de criação (`/novo-artigo`), edição via visualização (`POST /artigo/<id>`) e edição dedicada (`/artigo/<id>/editar`), retornando `flash` e reexibindo o formulário/rota quando a validação falha.
- Adiciona testes em `tests/test_article_inline_base64_validation.py` cobrindo rejeição de HTML com base64 grande, aceitação de HTML com imagens apontando para `/uploads/editor/...` e visualização de artigos legados contendo base64.
- Pequeno ajuste nos testes para usar o código de permissão como string na fixture de criação de usuário para compatibilidade.

### Testing
- Executado: `pytest -q tests/test_article_inline_base64_validation.py tests/test_article_editor_image_upload.py tests/test_article_rich_html_rendering.py`.
- Resultado: todos os testes passaram (`16 passed`) com warnings não bloqueantes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe27c7a8bc832eb9c9adf04b97f8d3)