### PR TITLE
Add Tiptap toolbar to article forms and fix accessibility label

### DIFF
--- a/templates/artigos/editar_artigo.html
+++ b/templates/artigos/editar_artigo.html
@@ -3,6 +3,22 @@
 
 {% block extra_css %}
 <style>
+  .tiptap-toolbar {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .tiptap-toolbar .btn {
+    --bs-btn-padding-y: 0.25rem;
+    --bs-btn-padding-x: 0.5rem;
+  }
+
+  .tiptap-toolbar .btn.active {
+    color: var(--bs-primary);
+    background-color: var(--bs-primary-bg-subtle);
+    border-color: var(--bs-primary);
+  }
+
   .tiptap-editor {
     min-height: 300px;
     overflow: auto;
@@ -141,10 +157,40 @@
           </div>
 
           <div class="mb-3">
-            <label for="tiptap-editor" class="form-label">Texto</label>
-            <div id="tiptap-editor" class="tiptap-editor border rounded bg-body"></div>
-          <input type="hidden" name="texto" id="hidden-texto">
-        </div>
+            <label id="tiptap-editor-label" class="form-label">Texto</label>
+            <div class="tiptap-toolbar btn-toolbar gap-2 border rounded-top bg-body-tertiary p-2" role="toolbar" aria-label="Ferramentas de formatação do texto">
+              <div class="btn-group btn-group-sm" role="group" aria-label="Estilos de texto">
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="bold" aria-label="Negrito"><i class="bi bi-type-bold" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="italic" aria-label="Itálico"><i class="bi bi-type-italic" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="strike" aria-label="Tachado"><i class="bi bi-type-strikethrough" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="highlight" aria-label="Destacar texto"><i class="bi bi-highlighter" aria-hidden="true"></i></button>
+              </div>
+              <div class="btn-group btn-group-sm" role="group" aria-label="Blocos">
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="paragraph">Parágrafo</button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="heading2">Título</button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="blockquote" aria-label="Citação"><i class="bi bi-blockquote-left" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="codeBlock" aria-label="Bloco de código"><i class="bi bi-code-square" aria-hidden="true"></i></button>
+              </div>
+              <div class="btn-group btn-group-sm" role="group" aria-label="Listas">
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="bulletList" aria-label="Lista com marcadores"><i class="bi bi-list-ul" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="orderedList" aria-label="Lista numerada"><i class="bi bi-list-ol" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="taskList" aria-label="Lista de tarefas"><i class="bi bi-check2-square" aria-hidden="true"></i></button>
+              </div>
+              <div class="btn-group btn-group-sm" role="group" aria-label="Alinhamento">
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="alignLeft" aria-label="Alinhar à esquerda"><i class="bi bi-text-left" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="alignCenter" aria-label="Centralizar"><i class="bi bi-text-center" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="alignRight" aria-label="Alinhar à direita"><i class="bi bi-text-right" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="alignJustify" aria-label="Justificar"><i class="bi bi-justify" aria-hidden="true"></i></button>
+              </div>
+              <div class="btn-group btn-group-sm" role="group" aria-label="Tabela e histórico">
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="insertTable" aria-label="Inserir tabela"><i class="bi bi-table" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="undo" aria-label="Desfazer"><i class="bi bi-arrow-counterclockwise" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="redo" aria-label="Refazer"><i class="bi bi-arrow-clockwise" aria-hidden="true"></i></button>
+              </div>
+            </div>
+            <div id="tiptap-editor" class="tiptap-editor border border-top-0 rounded-bottom bg-body" aria-labelledby="tiptap-editor-label"></div>
+            <input type="hidden" name="texto" id="hidden-texto">
+          </div>
 
           <div class="mb-3">
             <label class="form-label">Visibilidade</label>
@@ -289,11 +335,59 @@ import { FileHandler } from 'https://esm.sh/@tiptap/extension-file-handler@3';
       content: initialContent,
       editorProps: {
         attributes: {
-          class: 'tiptap-content'
+          class: 'tiptap-content',
+          'aria-labelledby': 'tiptap-editor-label'
         }
       },
-      onUpdate: () => saveDraft()
+      onUpdate: () => saveDraft(),
+      onSelectionUpdate: ({ editor }) => updateToolbarState(editor),
+      onTransaction: ({ editor }) => updateToolbarState(editor)
     });
+
+  const toolbarButtons = document.querySelectorAll('[data-editor-command]');
+  const runEditorCommand = (command) => {
+    const chain = editor.chain().focus();
+    const commands = {
+      bold: () => chain.toggleBold().run(),
+      italic: () => chain.toggleItalic().run(),
+      strike: () => chain.toggleStrike().run(),
+      highlight: () => chain.toggleHighlight({ color: '#fff3cd' }).run(),
+      paragraph: () => chain.setParagraph().run(),
+      heading2: () => chain.toggleHeading({ level: 2 }).run(),
+      blockquote: () => chain.toggleBlockquote().run(),
+      codeBlock: () => chain.toggleCodeBlock().run(),
+      bulletList: () => chain.toggleBulletList().run(),
+      orderedList: () => chain.toggleOrderedList().run(),
+      taskList: () => chain.toggleTaskList().run(),
+      alignLeft: () => chain.setTextAlign('left').run(),
+      alignCenter: () => chain.setTextAlign('center').run(),
+      alignRight: () => chain.setTextAlign('right').run(),
+      alignJustify: () => chain.setTextAlign('justify').run(),
+      insertTable: () => chain.insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(),
+      undo: () => chain.undo().run(),
+      redo: () => chain.redo().run()
+    };
+    commands[command]?.();
+  };
+
+  function updateToolbarState(editorInstance = editor) {
+    document.querySelectorAll('[data-editor-command]').forEach((button) => {
+      const command = button.dataset.editorCommand;
+      const active = (command === 'heading2' && editorInstance.isActive('heading', { level: 2 })) ||
+        (command === 'alignLeft' && editorInstance.isActive({ textAlign: 'left' })) ||
+        (command === 'alignCenter' && editorInstance.isActive({ textAlign: 'center' })) ||
+        (command === 'alignRight' && editorInstance.isActive({ textAlign: 'right' })) ||
+        (command === 'alignJustify' && editorInstance.isActive({ textAlign: 'justify' })) ||
+        (!['paragraph', 'heading2', 'alignLeft', 'alignCenter', 'alignRight', 'alignJustify', 'insertTable', 'undo', 'redo'].includes(command) && editorInstance.isActive(command));
+      button.classList.toggle('active', Boolean(active));
+      button.setAttribute('aria-pressed', Boolean(active).toString());
+    });
+  }
+
+  toolbarButtons.forEach((button) => {
+    button.addEventListener('click', () => runEditorCommand(button.dataset.editorCommand));
+  });
+  updateToolbarState();
 
   // Visibilidade por checkboxes
   const visChecks = document.querySelectorAll('.vis-check');

--- a/templates/artigos/novo_artigo.html
+++ b/templates/artigos/novo_artigo.html
@@ -3,6 +3,22 @@
 
 {% block extra_css %}
 <style>
+  .tiptap-toolbar {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .tiptap-toolbar .btn {
+    --bs-btn-padding-y: 0.25rem;
+    --bs-btn-padding-x: 0.5rem;
+  }
+
+  .tiptap-toolbar .btn.active {
+    color: var(--bs-primary);
+    background-color: var(--bs-primary-bg-subtle);
+    border-color: var(--bs-primary);
+  }
+
   .tiptap-editor {
     min-height: 300px;
     overflow: auto;
@@ -118,8 +134,38 @@
           </div>
 
           <div class="mb-3">
-            <label for="tiptap-editor" class="form-label">Texto</label>
-            <div id="tiptap-editor" class="tiptap-editor border rounded bg-body"></div>
+            <label id="tiptap-editor-label" class="form-label">Texto</label>
+            <div class="tiptap-toolbar btn-toolbar gap-2 border rounded-top bg-body-tertiary p-2" role="toolbar" aria-label="Ferramentas de formatação do texto">
+              <div class="btn-group btn-group-sm" role="group" aria-label="Estilos de texto">
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="bold" aria-label="Negrito"><i class="bi bi-type-bold" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="italic" aria-label="Itálico"><i class="bi bi-type-italic" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="strike" aria-label="Tachado"><i class="bi bi-type-strikethrough" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="highlight" aria-label="Destacar texto"><i class="bi bi-highlighter" aria-hidden="true"></i></button>
+              </div>
+              <div class="btn-group btn-group-sm" role="group" aria-label="Blocos">
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="paragraph">Parágrafo</button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="heading2">Título</button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="blockquote" aria-label="Citação"><i class="bi bi-blockquote-left" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="codeBlock" aria-label="Bloco de código"><i class="bi bi-code-square" aria-hidden="true"></i></button>
+              </div>
+              <div class="btn-group btn-group-sm" role="group" aria-label="Listas">
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="bulletList" aria-label="Lista com marcadores"><i class="bi bi-list-ul" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="orderedList" aria-label="Lista numerada"><i class="bi bi-list-ol" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="taskList" aria-label="Lista de tarefas"><i class="bi bi-check2-square" aria-hidden="true"></i></button>
+              </div>
+              <div class="btn-group btn-group-sm" role="group" aria-label="Alinhamento">
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="alignLeft" aria-label="Alinhar à esquerda"><i class="bi bi-text-left" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="alignCenter" aria-label="Centralizar"><i class="bi bi-text-center" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="alignRight" aria-label="Alinhar à direita"><i class="bi bi-text-right" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="alignJustify" aria-label="Justificar"><i class="bi bi-justify" aria-hidden="true"></i></button>
+              </div>
+              <div class="btn-group btn-group-sm" role="group" aria-label="Tabela e histórico">
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="insertTable" aria-label="Inserir tabela"><i class="bi bi-table" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="undo" aria-label="Desfazer"><i class="bi bi-arrow-counterclockwise" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-outline-secondary" data-editor-command="redo" aria-label="Refazer"><i class="bi bi-arrow-clockwise" aria-hidden="true"></i></button>
+              </div>
+            </div>
+            <div id="tiptap-editor" class="tiptap-editor border border-top-0 rounded-bottom bg-body" aria-labelledby="tiptap-editor-label"></div>
             <input type="hidden" name="texto" id="hidden-texto">
           </div>
 
@@ -221,11 +267,59 @@ document.addEventListener('DOMContentLoaded', () => {
     content: initialContent,
     editorProps: {
       attributes: {
-        class: 'tiptap-content'
+        class: 'tiptap-content',
+        'aria-labelledby': 'tiptap-editor-label'
       }
     },
-    onUpdate: () => saveDraft()
+    onUpdate: () => saveDraft(),
+    onSelectionUpdate: ({ editor }) => updateToolbarState(editor),
+    onTransaction: ({ editor }) => updateToolbarState(editor)
   });
+
+  const toolbarButtons = document.querySelectorAll('[data-editor-command]');
+  const runEditorCommand = (command) => {
+    const chain = editor.chain().focus();
+    const commands = {
+      bold: () => chain.toggleBold().run(),
+      italic: () => chain.toggleItalic().run(),
+      strike: () => chain.toggleStrike().run(),
+      highlight: () => chain.toggleHighlight({ color: '#fff3cd' }).run(),
+      paragraph: () => chain.setParagraph().run(),
+      heading2: () => chain.toggleHeading({ level: 2 }).run(),
+      blockquote: () => chain.toggleBlockquote().run(),
+      codeBlock: () => chain.toggleCodeBlock().run(),
+      bulletList: () => chain.toggleBulletList().run(),
+      orderedList: () => chain.toggleOrderedList().run(),
+      taskList: () => chain.toggleTaskList().run(),
+      alignLeft: () => chain.setTextAlign('left').run(),
+      alignCenter: () => chain.setTextAlign('center').run(),
+      alignRight: () => chain.setTextAlign('right').run(),
+      alignJustify: () => chain.setTextAlign('justify').run(),
+      insertTable: () => chain.insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(),
+      undo: () => chain.undo().run(),
+      redo: () => chain.redo().run()
+    };
+    commands[command]?.();
+  };
+
+  function updateToolbarState(editorInstance = editor) {
+    document.querySelectorAll('[data-editor-command]').forEach((button) => {
+      const command = button.dataset.editorCommand;
+      const active = (command === 'heading2' && editorInstance.isActive('heading', { level: 2 })) ||
+        (command === 'alignLeft' && editorInstance.isActive({ textAlign: 'left' })) ||
+        (command === 'alignCenter' && editorInstance.isActive({ textAlign: 'center' })) ||
+        (command === 'alignRight' && editorInstance.isActive({ textAlign: 'right' })) ||
+        (command === 'alignJustify' && editorInstance.isActive({ textAlign: 'justify' })) ||
+        (!['paragraph', 'heading2', 'alignLeft', 'alignCenter', 'alignRight', 'alignJustify', 'insertTable', 'undo', 'redo'].includes(command) && editorInstance.isActive(command));
+      button.classList.toggle('active', Boolean(active));
+      button.setAttribute('aria-pressed', Boolean(active).toString());
+    });
+  }
+
+  toolbarButtons.forEach((button) => {
+    button.addEventListener('click', () => runEditorCommand(button.dataset.editorCommand));
+  });
+  updateToolbarState();
 
   // Visibilidade por checkboxes → atualiza hidden e badges
   const visChecks = document.querySelectorAll('.vis-check');


### PR DESCRIPTION
### Motivation
- The Tiptap editor had no visible formatting toolbar on the New/Edit article screens and produced a browser accessibility warning about an incorrect `label for=FORM_ELEMENT` reference.
- Provide in-UI formatting controls and fix the invalid `label` usage so screen readers and autofill tools work correctly.

### Description
- Added a visible toolbar markup to `templates/artigos/novo_artigo.html` and `templates/artigos/editar_artigo.html` with buttons for bold/italic/strike/highlight, paragraph/heading/blockquote/code-block, lists (bullet/ordered/task), alignment, table insertion, undo and redo, and appropriate ARIA attributes.
- Replaced the invalid `label for="tiptap-editor"` usage with a `label` element and linked the editor via `aria-labelledby` and the editor `editorProps` attribute to remove the accessibility warning.
- Implemented toolbar wiring in-page: toolbar buttons call Tiptap commands (via `editor.chain().focus()`), and toolbar state is kept in sync with selection using `onSelectionUpdate`/`onTransaction` and an `updateToolbarState` helper.
- Added small toolbar styling in the templates so buttons show active state and match the editor layout.

### Testing
- Ran the article-related unit tests with `pytest tests/test_required_fields.py` and all tests passed (`17 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2b5dc920832ead76fc62aa1be3e9)