### PR TITLE
Oculta e bloqueia botão "Solicitar Revisão" para o autor do artigo

### DIFF
--- a/blueprints/articles.py
+++ b/blueprints/articles.py
@@ -712,6 +712,11 @@ def artigo(artigo_id):
         artigo=artigo,
         arquivos=arquivos,
         can_edit_article=user_can_edit_article(user, artigo),
+        can_request_revision=bool(
+            user
+            and artigo.status == ArticleStatus.APROVADO
+            and user.id != artigo.user_id
+        ),
         can_reprocess_ocr=can_reprocess_ocr,
         can_delete_definitive=can_delete_definitive,
     )
@@ -1598,6 +1603,10 @@ def solicitar_revisao(artigo_id):
         return redirect(url_for('login'))
     artigo = Article.query.get_or_404(artigo_id)
     user    = User.query.filter_by(username=session['username']).first()
+
+    if user and user.id == artigo.user_id:
+        flash('Você é o autor deste artigo. Use o botão Editar para fazer ajustes.', 'info')
+        return redirect(url_for('artigo', artigo_id=artigo.id))
 
     if request.method=='POST':
         comentario = request.form.get('comentario','').strip()

--- a/templates/artigos/artigo.html
+++ b/templates/artigos/artigo.html
@@ -220,7 +220,7 @@
           </a>
           {% endif %}
 
-        {% if session.get('username') and artigo.status == ArticleStatus.APROVADO %}
+        {% if can_request_revision %}
         <a href="{{ url_for('solicitar_revisao', artigo_id=artigo.id) }}" class="btn btn-app btn-app-secondary">
           <i class="bi bi-chat-left-text" aria-hidden="true"></i> Solicitar Revisão
         </a>

--- a/tests/test_article_approval_review.py
+++ b/tests/test_article_approval_review.py
@@ -450,3 +450,88 @@ def test_aprovacao_detail_shows_adjustment_and_revision_history(app_ctx, client)
     assert b'Precisa ajustar introdu\xc3\xa7\xc3\xa3o' in resp.data
     assert b'Hist\xc3\xb3rico de Solicita\xc3\xa7\xc3\xb5es de Revis\xc3\xa3o' in resp.data
     assert b'Solicito nova revis\xc3\xa3o ap\xc3\xb3s ajustes' in resp.data
+
+
+def _create_approved_article_with_viewer():
+    inst = Instituicao(codigo='I1', nome='Inst')
+    est = Estabelecimento(codigo='E1', nome_fantasia='Est', instituicao=inst)
+    setor = Setor(nome='S', estabelecimento=est)
+    cel = Celula(nome='C', estabelecimento=est, setor=setor)
+    db.session.add_all([inst, est, setor, cel])
+    db.session.flush()
+
+    autor = User(
+        username='autor', email='a@test', password_hash='x',
+        estabelecimento=est, setor=setor, celula=cel
+    )
+    leitor = User(
+        username='leitor', email='l@test', password_hash='x',
+        estabelecimento=est, setor=setor, celula=cel
+    )
+    db.session.add_all([autor, leitor])
+    db.session.flush()
+
+    art = Article(
+        titulo='Titulo aprovado', texto='Conteudo aprovado', status=ArticleStatus.APROVADO,
+        user_id=autor.id, celula_id=cel.id, estabelecimento_id=est.id,
+        setor_id=setor.id, instituicao_id=inst.id, visibility=ArticleVisibility.CELULA,
+    )
+    db.session.add(art)
+    db.session.commit()
+    return autor.id, leitor.id, art.id
+
+
+def test_author_does_not_see_request_revision_button_on_own_approved_article(app_ctx, client):
+    with app.app_context():
+        autor_id, _, art_id = _create_approved_article_with_viewer()
+
+    with client.session_transaction() as sess:
+        sess['user_id'] = autor_id
+        sess['username'] = 'autor'
+
+    resp = client.get(f'/artigo/{art_id}')
+
+    assert resp.status_code == 200
+    assert b'Editar' in resp.data
+    assert b'Solicitar Revisao' not in resp.data
+    assert b'Solicitar Revis\xc3\xa3o' not in resp.data
+
+
+def test_non_author_still_sees_request_revision_button_on_approved_article(app_ctx, client):
+    with app.app_context():
+        _, leitor_id, art_id = _create_approved_article_with_viewer()
+
+    with client.session_transaction() as sess:
+        sess['user_id'] = leitor_id
+        sess['username'] = 'leitor'
+
+    resp = client.get(f'/artigo/{art_id}')
+
+    assert resp.status_code == 200
+    assert b'Solicitar Revis\xc3\xa3o' in resp.data
+
+
+def test_author_cannot_request_revision_of_own_article_directly(app_ctx, client):
+    with app.app_context():
+        autor_id, _, art_id = _create_approved_article_with_viewer()
+
+    with client.session_transaction() as sess:
+        sess['user_id'] = autor_id
+        sess['username'] = 'autor'
+
+    resp = client.post(
+        f'/solicitar_revisao/{art_id}',
+        data={'comentario': 'Quero revisar meu artigo'},
+    )
+
+    assert resp.status_code == 302
+    assert resp.location.endswith(f'/artigo/{art_id}')
+    with client.session_transaction() as sess:
+        assert (
+            'info',
+            'Você é o autor deste artigo. Use o botão Editar para fazer ajustes.',
+        ) in sess['_flashes']
+
+    with app.app_context():
+        assert RevisionRequest.query.count() == 0
+        assert Article.query.get(art_id).status == ArticleStatus.APROVADO

--- a/tests/test_article_versioning_lifecycle.py
+++ b/tests/test_article_versioning_lifecycle.py
@@ -265,10 +265,11 @@ def test_adjustment_and_rejection_snapshots_store_source_status_before_and_after
 
 def test_revision_request_snapshot_stores_source_status_before_and_after(app_ctx, client, article_org):
     author = _create_user("autor_revision_request", article_org)
+    requester = _create_user("requester_revision_request", article_org)
     article = _create_article(author, article_org, status=ArticleStatus.APROVADO)
     create_article_version_snapshot(article, author, "create_initial")
     db.session.commit()
-    _login(client, author)
+    _login(client, requester)
 
     response = client.post(
         f"/solicitar_revisao/{article.id}",


### PR DESCRIPTION
### Motivation
- Evitar que o autor de um artigo aprovado veja e use o botão "Solicitar Revisão", pois o botão "Editar" já permite ao autor fazer alterações e reenviar; o pedido de revisão é uma ação pensada para terceiros.

### Description
- Calcula e passa `can_request_revision` para o template apenas quando o usuário autenticado existe, o artigo está em `ArticleStatus.APROVADO` e o usuário não é o autor (`user.id != artigo.user_id`).
- Ajusta o template `templates/artigos/artigo.html` para exibir o botão "Solicitar Revisão" somente quando `can_request_revision` for verdadeiro.
- Protege a rota `/solicitar_revisao/<int:artigo_id>` bloqueando solicitações diretas feitas pelo próprio autor e exibindo uma mensagem orientando o uso do botão "Editar".
- Adiciona testes que verificam que o autor não vê o botão, que outros usuários ainda o veem, que o autor não pode acessar a rota de solicitação diretamente, e adapta um teste de versionamento para usar um solicitante distinto.

### Testing
- Rodei `pytest -q` e a suíte principal foi executada com sucesso, resultado: `214 passed, 1 skipped` (vários warnings de compatibilidade com SQLAlchemy exibidos, sem impacto nos testes).
- Novos/alterados testes: `tests/test_article_approval_review.py` (adições de casos) e `tests/test_article_versioning_lifecycle.py` (ajuste do caso de solicitação de revisão); ambos validados na execução do `pytest`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2e1c1954832eb9b91880822c096a)