### PR TITLE
TipTap: enviar imagens coladas via endpoint em vez de base64

### DIFF
--- a/templates/artigos/editar_artigo.html
+++ b/templates/artigos/editar_artigo.html
@@ -295,20 +295,70 @@ import { FileHandler } from 'https://esm.sh/@tiptap/extension-file-handler@3';
   document.addEventListener("DOMContentLoaded", () => {
     const initialContent = {{ (form_data.get('texto') if form_data else artigo.texto) | tojson | safe }} || '<p></p>';
 
+    const pendingEditorImageUploads = new Set();
+
+    function editorImageFilename(file) {
+      if (file.name) return file.name;
+      const extensionsByMime = {
+        'image/jpeg': 'jpg',
+        'image/png': 'png',
+        'image/webp': 'webp'
+      };
+      return `imagem-colada.${extensionsByMime[file.type] || 'png'}`;
+    }
+
+    async function uploadEditorImage(file) {
+      const formData = new FormData();
+      formData.append('file', file, editorImageFilename(file));
+      const response = await fetch('/artigos/editor-image-upload', {
+        method: 'POST',
+        body: formData
+      });
+      let payload = null;
+      try {
+        payload = await response.json();
+      } catch (e) {
+        // Mantém mensagem genérica quando a resposta não é JSON.
+      }
+      if (!response.ok || !payload?.url) {
+        throw new Error(payload?.error || 'Não foi possível enviar a imagem colada.');
+      }
+      return payload.url;
+    }
+
+    function trackEditorImageUpload(uploadPromise) {
+      pendingEditorImageUploads.add(uploadPromise);
+      uploadPromise.then(
+        () => pendingEditorImageUploads.delete(uploadPromise),
+        () => pendingEditorImageUploads.delete(uploadPromise)
+      );
+      return uploadPromise;
+    }
+
+    async function waitForEditorImageUploads() {
+      if (!pendingEditorImageUploads.size) return;
+      await Promise.all(Array.from(pendingEditorImageUploads));
+    }
+
     const insertImageFiles = (editorInstance, files, pos = null) => {
-      files
+      Array.from(files)
         .filter(file => file.type.startsWith('image/'))
         .forEach(file => {
-          const reader = new FileReader();
-          reader.addEventListener('load', () => {
-            const image = { type: 'image', attrs: { src: reader.result, alt: file.name } };
-            if (typeof pos === 'number') {
-              editorInstance.chain().focus().insertContentAt(pos, image).run();
-              return;
-            }
-            editorInstance.chain().focus().insertContent(image).run();
-          });
-          reader.readAsDataURL(file);
+          const uploadPromise = uploadEditorImage(file)
+            .then((url) => {
+              const image = { type: 'image', attrs: { src: url, alt: file.name } };
+              if (typeof pos === 'number') {
+                editorInstance.chain().focus().insertContentAt(pos, image).run();
+                return;
+              }
+              editorInstance.chain().focus().insertContent(image).run();
+            })
+            .catch((error) => {
+              console.error('Falha ao enviar imagem do editor', error);
+              alert(error.message || 'Não foi possível enviar a imagem colada.');
+              throw error;
+            });
+          trackEditorImageUpload(uploadPromise);
         });
     };
 
@@ -316,7 +366,7 @@ import { FileHandler } from 'https://esm.sh/@tiptap/extension-file-handler@3';
       element: document.querySelector('#tiptap-editor'),
       extensions: [
         StarterKit,
-        Image.configure({ allowBase64: true }),
+        Image.configure({ allowBase64: false }),
         Table.configure({ resizable: true }),
         TableRow,
         TableCell,
@@ -327,7 +377,7 @@ import { FileHandler } from 'https://esm.sh/@tiptap/extension-file-handler@3';
         TextAlign.configure({ types: ['heading', 'paragraph'] }),
         Highlight.configure({ multicolor: true }),
         FileHandler.configure({
-          allowedMimeTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
+          allowedMimeTypes: ['image/jpeg', 'image/png', 'image/webp'],
           onPaste: (editorInstance, files) => insertImageFiles(editorInstance, files),
           onDrop: (editorInstance, files, pos) => insertImageFiles(editorInstance, files, pos)
         })
@@ -636,6 +686,16 @@ import { FileHandler } from 'https://esm.sh/@tiptap/extension-file-handler@3';
   if (form) {
     form.addEventListener('submit', async (event) => {
       event.preventDefault();
+      if (pendingEditorImageUploads.size) {
+        setOverlayState('Enviando imagens coladas no texto...', null);
+        try {
+          await waitForEditorImageUploads();
+        } catch (error) {
+          hideOverlay();
+          return;
+        }
+      }
+
       const hiddenTexto = document.getElementById('hidden-texto');
       if (hiddenTexto) {
         hiddenTexto.value = editor.getHTML();

--- a/templates/artigos/novo_artigo.html
+++ b/templates/artigos/novo_artigo.html
@@ -227,20 +227,70 @@ import { FileHandler } from 'https://esm.sh/@tiptap/extension-file-handler@3';
 document.addEventListener('DOMContentLoaded', () => {
   const initialContent = {{ (form_data or {}).get('texto', '') | tojson | safe }} || '<p></p>';
 
+  const pendingEditorImageUploads = new Set();
+
+  function editorImageFilename(file) {
+    if (file.name) return file.name;
+    const extensionsByMime = {
+      'image/jpeg': 'jpg',
+      'image/png': 'png',
+      'image/webp': 'webp'
+    };
+    return `imagem-colada.${extensionsByMime[file.type] || 'png'}`;
+  }
+
+  async function uploadEditorImage(file) {
+    const formData = new FormData();
+    formData.append('file', file, editorImageFilename(file));
+    const response = await fetch('/artigos/editor-image-upload', {
+      method: 'POST',
+      body: formData
+    });
+    let payload = null;
+    try {
+      payload = await response.json();
+    } catch (e) {
+      // Mantém mensagem genérica quando a resposta não é JSON.
+    }
+    if (!response.ok || !payload?.url) {
+      throw new Error(payload?.error || 'Não foi possível enviar a imagem colada.');
+    }
+    return payload.url;
+  }
+
+  function trackEditorImageUpload(uploadPromise) {
+    pendingEditorImageUploads.add(uploadPromise);
+    uploadPromise.then(
+      () => pendingEditorImageUploads.delete(uploadPromise),
+      () => pendingEditorImageUploads.delete(uploadPromise)
+    );
+    return uploadPromise;
+  }
+
+  async function waitForEditorImageUploads() {
+    if (!pendingEditorImageUploads.size) return;
+    await Promise.all(Array.from(pendingEditorImageUploads));
+  }
+
   const insertImageFiles = (editorInstance, files, pos = null) => {
-    files
+    Array.from(files)
       .filter(file => file.type.startsWith('image/'))
       .forEach(file => {
-        const reader = new FileReader();
-        reader.addEventListener('load', () => {
-          const image = { type: 'image', attrs: { src: reader.result, alt: file.name } };
-          if (typeof pos === 'number') {
-            editorInstance.chain().focus().insertContentAt(pos, image).run();
-            return;
-          }
-          editorInstance.chain().focus().insertContent(image).run();
-        });
-        reader.readAsDataURL(file);
+        const uploadPromise = uploadEditorImage(file)
+          .then((url) => {
+            const image = { type: 'image', attrs: { src: url, alt: file.name } };
+            if (typeof pos === 'number') {
+              editorInstance.chain().focus().insertContentAt(pos, image).run();
+              return;
+            }
+            editorInstance.chain().focus().insertContent(image).run();
+          })
+          .catch((error) => {
+            console.error('Falha ao enviar imagem do editor', error);
+            alert(error.message || 'Não foi possível enviar a imagem colada.');
+            throw error;
+          });
+        trackEditorImageUpload(uploadPromise);
       });
   };
 
@@ -248,7 +298,7 @@ document.addEventListener('DOMContentLoaded', () => {
     element: document.querySelector('#tiptap-editor'),
     extensions: [
       StarterKit,
-      Image.configure({ allowBase64: true }),
+      Image.configure({ allowBase64: false }),
       Table.configure({ resizable: true }),
       TableRow,
       TableCell,
@@ -259,7 +309,7 @@ document.addEventListener('DOMContentLoaded', () => {
       TextAlign.configure({ types: ['heading', 'paragraph'] }),
       Highlight.configure({ multicolor: true }),
       FileHandler.configure({
-        allowedMimeTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
+        allowedMimeTypes: ['image/jpeg', 'image/png', 'image/webp'],
         onPaste: (editorInstance, files) => insertImageFiles(editorInstance, files),
         onDrop: (editorInstance, files, pos) => insertImageFiles(editorInstance, files, pos)
       })
@@ -501,7 +551,25 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const form = document.querySelector('form');
-  form.addEventListener('submit', (event) => {
+  let isResubmittingAfterEditorUploads = false;
+  form.addEventListener('submit', async (event) => {
+    if (isResubmittingAfterEditorUploads) {
+      return;
+    }
+
+    event.preventDefault();
+    const submitter = event.submitter;
+
+    if (pendingEditorImageUploads.size) {
+      setOverlayState('Enviando imagens coladas no texto...', null);
+      try {
+        await waitForEditorImageUploads();
+      } catch (error) {
+        hideOverlay();
+        return;
+      }
+    }
+
     const hiddenTexto = document.getElementById('hidden-texto');
     if (hiddenTexto) {
       hiddenTexto.value = editor.getHTML();
@@ -516,8 +584,15 @@ document.addEventListener('DOMContentLoaded', () => {
     setOverlayState('Enviando artigo e anexos...', 0);
     startProgressPolling(progressId);
 
-    // Observação: submissão nativa do formulário é mantida para preservar
-    // redirects/flash do servidor; em caso de validação, o servidor reidrata o formulário.
+    isResubmittingAfterEditorUploads = true;
+    if (submitter && typeof form.requestSubmit === 'function') {
+      form.requestSubmit(submitter);
+    } else {
+      form.submit();
+    }
+
+    // Observação: a submissão nativa do formulário é preservada após o envio
+    // das imagens coladas para manter redirects/flash do servidor.
   });
 
   // Preview de anexos

--- a/tests/test_article_tiptap_image_upload_template.py
+++ b/tests/test_article_tiptap_image_upload_template.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATES = [
+    ROOT / "templates" / "artigos" / "novo_artigo.html",
+    ROOT / "templates" / "artigos" / "editar_artigo.html",
+]
+
+
+def _template_sources():
+    return {path.name: path.read_text(encoding="utf-8") for path in TEMPLATES}
+
+
+def test_tiptap_cola_imagens_via_upload_em_vez_de_base64():
+    for name, source in _template_sources().items():
+        assert "fetch('/artigos/editor-image-upload'" in source, name
+        assert "formData.append('file', file, editorImageFilename(file))" in source, name
+        assert "const pendingEditorImageUploads = new Set();" in source, name
+        assert "await waitForEditorImageUploads();" in source, name
+        assert "Image.configure({ allowBase64: false })" in source, name
+        assert "readAsDataURL" not in source, name
+        assert "Image.configure({ allowBase64: true })" not in source, name
+
+
+def test_tiptap_mimes_do_cliente_refletem_endpoint_de_upload():
+    for name, source in _template_sources().items():
+        assert "allowedMimeTypes: ['image/jpeg', 'image/png', 'image/webp']" in source, name
+        assert "image/gif" not in source, name


### PR DESCRIPTION
### Motivation
- Imagens coladas/arrastadas estavam sendo inseridas como `base64` no HTML do editor, gerando payloads muito grandes e causando erro de tamanho ao enviar para revisão.
- A intenção é garantir que imagens coladas sejam feitas via upload ao servidor e inseridas como URLs, reduzindo o tamanho do `texto` e evitando rejeição por limite de conteúdo.

### Description
- Atualiza os templates do editor em `templates/artigos/novo_artigo.html` e `templates/artigos/editar_artigo.html` para enviar imagens coladas/arrastadas ao endpoint `POST /artigos/editor-image-upload` antes de inseri-las no conteúdo.
- Adiciona utilitários client-side: `editorImageFilename`, `uploadEditorImage`, `trackEditorImageUpload` e `waitForEditorImageUploads`, e mantém um `Set` de uploads pendentes para aguardar conclusão antes do submit.
- Desabilita `base64` no nó de imagem do TipTap com `Image.configure({ allowBase64: false })` e alinha os MIME types do cliente para `['image/jpeg','image/png','image/webp']` (removendo `image/gif`).
- Garante que o formulário aguarde uploads pendentes e redispare a submissão nativa (usando `requestSubmit` quando disponível), preservando o fluxo de redirects/flash do servidor e comportamento de validação no servidor.
- Adiciona o teste de template `tests/test_article_tiptap_image_upload_template.py` que assegura a presença do novo fluxo (uso do endpoint, ausência de `readAsDataURL`/base64 e configuração de MIME types).

### Testing
- Executei `pytest -q tests/test_article_tiptap_image_upload_template.py tests/test_article_editor_image_upload.py tests/test_article_inline_base64_validation.py` e todos os testes dessa suíte passaram (`17 passed`).
- Executei `pytest -q tests/test_editar_artigo_autosave_template.py` e os testes dessa suíte passaram (`3 passed`).
- Os novos testes de template verificam que os templates usam upload em vez de `readAsDataURL` e que `Image.configure({ allowBase64: false })` está definido, garantindo a não regressão do comportamento.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2e94c0a8832e8693cfaaaeb48b6e)