### PR TITLE
Adicionar diagnóstico e validação para imagens coladas no editor

### DIFF
--- a/templates/artigos/editar_artigo.html
+++ b/templates/artigos/editar_artigo.html
@@ -296,6 +296,27 @@ import { FileHandler } from 'https://esm.sh/@tiptap/extension-file-handler@3';
     const initialContent = {{ (form_data.get('texto') if form_data else artigo.texto) | tojson | safe }} || '<p></p>';
 
     const pendingEditorImageUploads = new Set();
+    const EDITOR_IMAGE_ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+    const EDITOR_IMAGE_UPLOAD_TIMEOUT_MS = 30000;
+    const EDITOR_IMAGE_MAX_BYTES = Number({{ config.get('EDITOR_IMAGE_MAX_CONTENT_LENGTH', config.get('EDITOR_IMAGE_MAX_BYTES', 2097152)) | tojson }}) || 2097152;
+
+    function describeEditorImageFile(file) {
+      return {
+        name: file.name || 'imagem-colada',
+        type: file.type || 'sem-mime',
+        size: file.size || 0
+      };
+    }
+
+    function validateEditorImageFile(file) {
+      if (!EDITOR_IMAGE_ALLOWED_MIME_TYPES.includes(file.type)) {
+        throw new Error('Tipo de imagem inválido. Envie apenas PNG, JPG/JPEG ou WebP.');
+      }
+      if (EDITOR_IMAGE_MAX_BYTES > 0 && file.size > EDITOR_IMAGE_MAX_BYTES) {
+        const limitMb = (EDITOR_IMAGE_MAX_BYTES / 1024 / 1024).toFixed(1).replace('.0', '');
+        throw new Error(`Imagem acima do limite permitido (${limitMb} MB). Reduza o print ou envie como anexo.`);
+      }
+    }
 
     function editorImageFilename(file) {
       if (file.name) return file.name;
@@ -308,22 +329,45 @@ import { FileHandler } from 'https://esm.sh/@tiptap/extension-file-handler@3';
     }
 
     async function uploadEditorImage(file) {
-      const formData = new FormData();
-      formData.append('file', file, editorImageFilename(file));
-      const response = await fetch('/artigos/editor-image-upload', {
-        method: 'POST',
-        body: formData
-      });
-      let payload = null;
+      validateEditorImageFile(file);
+      const uploadStartedAt = performance.now();
+      const fileInfo = describeEditorImageFile(file);
+      console.info('[editor-image-upload:start]', fileInfo);
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), EDITOR_IMAGE_UPLOAD_TIMEOUT_MS);
+
       try {
-        payload = await response.json();
-      } catch (e) {
-        // Mantém mensagem genérica quando a resposta não é JSON.
+        const formData = new FormData();
+        formData.append('file', file, editorImageFilename(file));
+        const response = await fetch('/artigos/editor-image-upload', {
+          method: 'POST',
+          body: formData,
+          headers: { Accept: 'application/json' },
+          signal: controller.signal
+        });
+        let payload = null;
+        try {
+          payload = await response.json();
+        } catch (e) {
+          // Mantém mensagem genérica quando a resposta não é JSON.
+        }
+        if (!response.ok || !payload?.url) {
+          throw new Error(payload?.error || 'Não foi possível enviar a imagem colada.');
+        }
+        return payload.url;
+      } catch (error) {
+        if (error.name === 'AbortError') {
+          throw new Error('Tempo esgotado ao enviar a imagem colada. Tente novamente com uma imagem menor ou use anexos.');
+        }
+        throw error;
+      } finally {
+        clearTimeout(timeoutId);
+        console.info('[editor-image-upload:end]', {
+          ...fileInfo,
+          durationMs: Math.round(performance.now() - uploadStartedAt)
+        });
       }
-      if (!response.ok || !payload?.url) {
-        throw new Error(payload?.error || 'Não foi possível enviar a imagem colada.');
-      }
-      return payload.url;
     }
 
     function trackEditorImageUpload(uploadPromise) {

--- a/templates/artigos/novo_artigo.html
+++ b/templates/artigos/novo_artigo.html
@@ -228,6 +228,27 @@ document.addEventListener('DOMContentLoaded', () => {
   const initialContent = {{ (form_data or {}).get('texto', '') | tojson | safe }} || '<p></p>';
 
   const pendingEditorImageUploads = new Set();
+  const EDITOR_IMAGE_ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+  const EDITOR_IMAGE_UPLOAD_TIMEOUT_MS = 30000;
+  const EDITOR_IMAGE_MAX_BYTES = Number({{ config.get('EDITOR_IMAGE_MAX_CONTENT_LENGTH', config.get('EDITOR_IMAGE_MAX_BYTES', 2097152)) | tojson }}) || 2097152;
+
+  function describeEditorImageFile(file) {
+    return {
+      name: file.name || 'imagem-colada',
+      type: file.type || 'sem-mime',
+      size: file.size || 0
+    };
+  }
+
+  function validateEditorImageFile(file) {
+    if (!EDITOR_IMAGE_ALLOWED_MIME_TYPES.includes(file.type)) {
+      throw new Error('Tipo de imagem inválido. Envie apenas PNG, JPG/JPEG ou WebP.');
+    }
+    if (EDITOR_IMAGE_MAX_BYTES > 0 && file.size > EDITOR_IMAGE_MAX_BYTES) {
+      const limitMb = (EDITOR_IMAGE_MAX_BYTES / 1024 / 1024).toFixed(1).replace('.0', '');
+      throw new Error(`Imagem acima do limite permitido (${limitMb} MB). Reduza o print ou envie como anexo.`);
+    }
+  }
 
   function editorImageFilename(file) {
     if (file.name) return file.name;
@@ -240,22 +261,45 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   async function uploadEditorImage(file) {
-    const formData = new FormData();
-    formData.append('file', file, editorImageFilename(file));
-    const response = await fetch('/artigos/editor-image-upload', {
-      method: 'POST',
-      body: formData
-    });
-    let payload = null;
+    validateEditorImageFile(file);
+    const uploadStartedAt = performance.now();
+    const fileInfo = describeEditorImageFile(file);
+    console.info('[editor-image-upload:start]', fileInfo);
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), EDITOR_IMAGE_UPLOAD_TIMEOUT_MS);
+
     try {
-      payload = await response.json();
-    } catch (e) {
-      // Mantém mensagem genérica quando a resposta não é JSON.
+      const formData = new FormData();
+      formData.append('file', file, editorImageFilename(file));
+      const response = await fetch('/artigos/editor-image-upload', {
+        method: 'POST',
+        body: formData,
+        headers: { Accept: 'application/json' },
+        signal: controller.signal
+      });
+      let payload = null;
+      try {
+        payload = await response.json();
+      } catch (e) {
+        // Mantém mensagem genérica quando a resposta não é JSON.
+      }
+      if (!response.ok || !payload?.url) {
+        throw new Error(payload?.error || 'Não foi possível enviar a imagem colada.');
+      }
+      return payload.url;
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        throw new Error('Tempo esgotado ao enviar a imagem colada. Tente novamente com uma imagem menor ou use anexos.');
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+      console.info('[editor-image-upload:end]', {
+        ...fileInfo,
+        durationMs: Math.round(performance.now() - uploadStartedAt)
+      });
     }
-    if (!response.ok || !payload?.url) {
-      throw new Error(payload?.error || 'Não foi possível enviar a imagem colada.');
-    }
-    return payload.url;
   }
 
   function trackEditorImageUpload(uploadPromise) {

--- a/tests/test_article_tiptap_image_upload_template.py
+++ b/tests/test_article_tiptap_image_upload_template.py
@@ -16,6 +16,7 @@ def test_tiptap_cola_imagens_via_upload_em_vez_de_base64():
     for name, source in _template_sources().items():
         assert "fetch('/artigos/editor-image-upload'" in source, name
         assert "formData.append('file', file, editorImageFilename(file))" in source, name
+        assert "headers: { Accept: 'application/json' }" in source, name
         assert "const pendingEditorImageUploads = new Set();" in source, name
         assert "await waitForEditorImageUploads();" in source, name
         assert "Image.configure({ allowBase64: false })" in source, name
@@ -25,5 +26,18 @@ def test_tiptap_cola_imagens_via_upload_em_vez_de_base64():
 
 def test_tiptap_mimes_do_cliente_refletem_endpoint_de_upload():
     for name, source in _template_sources().items():
+        assert "EDITOR_IMAGE_ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp']" in source, name
         assert "allowedMimeTypes: ['image/jpeg', 'image/png', 'image/webp']" in source, name
         assert "image/gif" not in source, name
+
+
+def test_tiptap_upload_de_imagem_tem_diagnostico_e_timeout():
+    for name, source in _template_sources().items():
+        assert "const EDITOR_IMAGE_UPLOAD_TIMEOUT_MS = 30000;" in source, name
+        assert "const EDITOR_IMAGE_MAX_BYTES = Number" in source, name
+        assert "const controller = new AbortController();" in source, name
+        assert "signal: controller.signal" in source, name
+        assert "[editor-image-upload:start]" in source, name
+        assert "[editor-image-upload:end]" in source, name
+        assert "Tempo esgotado ao enviar a imagem colada" in source, name
+        assert "Reduza o print ou envie como anexo" in source, name


### PR DESCRIPTION
### Motivation
- Evitar loops/infinita espera ao colar prints grandes ou em formatos não suportados e facilitar diagnóstico quando o envio trava. 
- Reduzir carga sobre o servidor verificando limites no cliente antes de iniciar upload. 
- Aumentar observabilidade do fluxo de upload de imagens coladas para agilizar correção de problemas de rede/endpoint.

### Description
- Adiciona validação cliente em `templates/artigos/novo_artigo.html` e `templates/artigos/editar_artigo.html` para bloquear MIME fora de `['image/jpeg','image/png','image/webp']` e arquivos acima do limite configurado (`EDITOR_IMAGE_MAX_BYTES`).
- Introduz `describeEditorImageFile` e `validateEditorImageFile`, envio do header `Accept: application/json`, e mensagens de erro informativas que orientam a reduzir o print ou usar anexos quando necessário.
- Inclui timeout de upload com `AbortController` (`EDITOR_IMAGE_UPLOAD_TIMEOUT_MS = 30000`) e logs de diagnóstico no console (`[editor-image-upload:start]` e `[editor-image-upload:end]` com duração), para identificar facilmente se o problema é timeout, tipo inválido ou tamanho.
- Atualiza `tests/test_article_tiptap_image_upload_template.py` para conferir as mudanças de template (headers, MIME list, timeout, abort/sinais e mensagens de diagnóstico).

### Testing
- Executei `pytest tests/test_article_tiptap_image_upload_template.py -q` e o teste de template atualizado passou com sucesso.
- Executei os testes focados `tests/test_article_tiptap_image_upload_template.py`, `tests/test_article_editor_image_upload.py` e `tests/test_article_inline_base64_validation.py` e todos passaram (sem falhas nas interações de upload/validação).
- Executei a suíte completa com `pytest -q` e obteve-se sucesso geral: `217 passed, 1 skipped` (com warnings de compatibilidade do ORM apenas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe33183ef4832ea46ae227670ab29f)