### PR TITLE
Evita polling infinito ao salvar artigo sem anexos

### DIFF
--- a/templates/artigos/editar_artigo.html
+++ b/templates/artigos/editar_artigo.html
@@ -659,6 +659,8 @@ import { FileHandler } from 'https://esm.sh/@tiptap/extension-file-handler@3';
       overlayBar.setAttribute('aria-valuenow', value);
     }
   };
+  const hasPendingAttachmentFiles = () => Boolean(document.getElementById('files')?.files?.length);
+
   const hideOverlay = () => {
     completeBar();
     if (overlay) overlay.style.display = 'none';
@@ -755,7 +757,9 @@ import { FileHandler } from 'https://esm.sh/@tiptap/extension-file-handler@3';
       if (progressIdInput) progressIdInput.value = progressId;
       resetProgressMessages();
       setOverlayState('Salvando artigo e anexos...', 0);
-      startProgressPolling(progressId);
+      if (hasPendingAttachmentFiles()) {
+        startProgressPolling(progressId);
+      }
 
       try {
         const formData = new FormData(form);

--- a/templates/artigos/novo_artigo.html
+++ b/templates/artigos/novo_artigo.html
@@ -583,6 +583,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   };
 
+  const hasPendingAttachmentFiles = () => Boolean(document.getElementById('files')?.files?.length);
+
   const hideOverlay = () => {
     completeBar();
     if (overlay) overlay.style.display = 'none';
@@ -626,7 +628,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     resetProgressMessages();
     setOverlayState('Enviando artigo e anexos...', 0);
-    startProgressPolling(progressId);
+    if (hasPendingAttachmentFiles()) {
+      startProgressPolling(progressId);
+    }
 
     isResubmittingAfterEditorUploads = true;
     if (submitter && typeof form.requestSubmit === 'function') {

--- a/tests/test_article_tiptap_image_upload_template.py
+++ b/tests/test_article_tiptap_image_upload_template.py
@@ -41,3 +41,10 @@ def test_tiptap_upload_de_imagem_tem_diagnostico_e_timeout():
         assert "[editor-image-upload:end]" in source, name
         assert "Tempo esgotado ao enviar a imagem colada" in source, name
         assert "Reduza o print ou envie como anexo" in source, name
+
+
+def test_progresso_de_upload_so_consulta_endpoint_quando_ha_anexos():
+    for name, source in _template_sources().items():
+        assert "const hasPendingAttachmentFiles = () => Boolean(document.getElementById('files')?.files?.length);" in source, name
+        assert "if (hasPendingAttachmentFiles()) {" in source, name
+        assert "startProgressPolling(progressId);" in source, name


### PR DESCRIPTION
### Motivation
- O formulário de criação/edição de artigos iniciava polling para `/upload-progress/<id>` mesmo quando não havia anexos no campo de arquivos, causando requisições repetidas quando o usuário apenas colava imagens inline no editor. 

### Description
- Adiciona a função `hasPendingAttachmentFiles` em `templates/artigos/novo_artigo.html` e `templates/artigos/editar_artigo.html` para verificar se existem arquivos no campo `#files` antes de iniciar o polling. 
- Altera as chamadas para só executar `startProgressPolling(progressId)` quando `hasPendingAttachmentFiles()` retornar `true`. 
- Adiciona o teste `test_progresso_de_upload_so_consulta_endpoint_quando_ha_anexos` em `tests/test_article_tiptap_image_upload_template.py` para garantir que o template contenha a nova verificação. 

### Testing
- Executado `pytest tests/test_article_tiptap_image_upload_template.py -q` e o teste passou (`4 passed`).
- Executado `pytest tests/test_article_tiptap_image_upload_template.py tests/test_required_fields.py -q` e os testes passaram (`20 passed`).
- Executado a suíte completa com `pytest -q` e todos os testes automatizados passaram (`218 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe351ad734832e86b36e13d7d71bca)