### PR TITLE
Fix new article submit action after TipTap uploads

### DIFF
--- a/templates/artigos/novo_artigo.html
+++ b/templates/artigos/novo_artigo.html
@@ -98,6 +98,7 @@
           {% set f = form_data or {} %}
           {% set selected_visibility = (f.get('visibility') or 'celula').split(',') %}
           <input type="hidden" name="progress_id" id="progress-id">
+          <input type="hidden" id="submit-action" value="rascunho">
           <div class="mb-3">
             <label for="titulo" class="form-label">Título</label>
             <input type="text" class="form-control" id="titulo" name="titulo" value="{{ f.get('titulo', '') }}" required>
@@ -614,6 +615,12 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const form = document.querySelector('form');
+  let lastSubmitter = null;
+  form?.querySelectorAll('button[type="submit"], input[type="submit"]').forEach((button) => {
+    button.addEventListener('click', () => {
+      lastSubmitter = button;
+    });
+  });
   const setSubmitButtonsDisabled = (disabled) => {
     form?.querySelectorAll('button[type="submit"], input[type="submit"]').forEach((button) => {
       button.disabled = disabled;
@@ -626,7 +633,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     event.preventDefault();
-    const submitter = event.submitter;
+    const submitter = event.submitter || lastSubmitter;
 
     if (pendingEditorImageUploads.size) {
       setOverlayState('Enviando imagens coladas no texto...', null);
@@ -655,16 +662,20 @@ document.addEventListener('DOMContentLoaded', () => {
       startProgressPolling(progressId);
     }
 
-    setSubmitButtonsDisabled(true);
-    isResubmittingAfterEditorUploads = true;
-    if (submitter && typeof form.requestSubmit === 'function') {
-      form.requestSubmit(submitter);
-    } else {
-      form.submit();
+    const submitActionInput = document.getElementById('submit-action');
+    if (submitActionInput) {
+      submitActionInput.name = 'acao';
+      submitActionInput.value = submitter?.name === 'acao' ? submitter.value : 'rascunho';
     }
 
+    setSubmitButtonsDisabled(true);
+    isResubmittingAfterEditorUploads = true;
+    form.submit();
+
     // Observação: a submissão nativa do formulário é preservada após o envio
-    // das imagens coladas para manter redirects/flash do servidor.
+    // das imagens coladas para manter redirects/flash do servidor. A ação do
+    // botão é copiada para um hidden antes de desabilitar os botões, pois
+    // controles desabilitados não são enviados no POST.
   });
 
   // Preview de anexos

--- a/tests/test_article_tiptap_image_upload_template.py
+++ b/tests/test_article_tiptap_image_upload_template.py
@@ -57,3 +57,18 @@ def test_tiptap_evita_upload_duplicado_e_inicializacao_repetida():
         assert "activeEditorImageUploadKeys.has(uploadKey)" in source, name
         assert ".finally(() => activeEditorImageUploadKeys.delete(uploadKey))" in source, name
         assert "setSubmitButtonsDisabled(true);" in source, name
+
+
+def test_novo_artigo_preserva_acao_apos_uploads_do_tiptap():
+    source = (ROOT / "templates" / "artigos" / "novo_artigo.html").read_text(encoding="utf-8")
+    submit_listener = source[source.index("form.addEventListener('submit'"):]
+
+    assert 'id="submit-action"' in source
+    assert 'name="acao" id="submit-action"' not in source
+    assert "let lastSubmitter = null;" in source
+    assert "const submitter = event.submitter || lastSubmitter;" in submit_listener
+    assert "submitActionInput.name = 'acao';" in submit_listener
+    assert "submitActionInput.value = submitter?.name === 'acao' ? submitter.value : 'rascunho';" in submit_listener
+    assert submit_listener.index("submitActionInput.value") < submit_listener.index("setSubmitButtonsDisabled(true);")
+    assert "form.requestSubmit(submitter);" not in submit_listener
+    assert "form.submit();" in submit_listener


### PR DESCRIPTION
### Motivation
- The TipTap migration changed how editor image uploads are awaited and submit buttons get disabled, which caused the clicked submit action (`acao=enviar`) to be lost and produced a submit loop or articles stuck as drafts.
- Disabled submit controls are not sent in the POST, so the server could not tell if the user clicked `Enviar para Revisão` versus `Salvar Rascunho`.
- The submit flow also relied on `requestSubmit(submitter)` which became fragile after controls are disabled and when `event.submitter` is not available (e.g. when submission is triggered programmatically). 

### Description
- Added a hidden field (`<input id="submit-action">`) in `templates/artigos/novo_artigo.html` and populate it with `name='acao'` and the clicked button value before disabling buttons so the chosen action is always included in the POST.
- Track the last clicked submit button (`lastSubmitter`) and use `event.submitter || lastSubmitter` as a fallback to determine which action to preserve when `event.submitter` is unavailable.
- Replace reliance on `form.requestSubmit(submitter)` with a plain `form.submit()` after copying the action to the hidden field to avoid request re-dispatch or loop issues once buttons are disabled.
- Added a new unit test `test_novo_artigo_preserva_acao_apos_uploads_do_tiptap` in `tests/test_article_tiptap_image_upload_template.py` to assert the template contains the new behavior and updated the template-related assertions accordingly.

### Testing
- Ran `pytest -q tests/test_article_tiptap_image_upload_template.py tests/test_required_fields.py::test_novo_artigo_remove_autosave_ao_submeter` and the tests passed (`7 passed`).
- Ran `pytest -q tests/test_notification_filtering.py tests/test_required_fields.py::test_novo_artigo_requires_fields tests/test_required_fields.py::test_novo_artigo_persiste_campos_no_html_em_erro_validacao` and the suite passed (`6 passed`, warnings only).
- The modified template and added test were exercised by the above test runs and no regressions were observed in the related article submission tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe43135e70832e9f9382eb4a0c6647)