### PR TITLE
Mantém tema escuro nos blocos de código salvos

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -890,10 +890,10 @@
 .article-content pre,
 .article-version-readonly pre,
 .ProseMirror pre {
-  background: var(--bs-tertiary-bg, var(--bg-muted));
-  border: 1px solid var(--bs-border-color, var(--border-default));
+  background: var(--bs-dark, #212529);
+  border: 1px solid var(--bs-dark, #212529);
   border-radius: 0.375rem;
-  color: var(--text-default);
+  color: var(--bs-light, #f8f9fa);
   overflow-x: auto;
   padding: 0.75rem;
 }
@@ -914,6 +914,7 @@
 .ProseMirror pre code {
   background: transparent;
   border-radius: 0;
+  color: inherit;
   padding: 0;
 }
 

--- a/tests/test_article_rich_html_rendering.py
+++ b/tests/test_article_rich_html_rendering.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from app import db
 from core.enums import Permissao
 from core.models import (
@@ -154,3 +156,13 @@ def test_rich_article_html_is_preserved_in_view_approval_and_history(client):
         RICH_FROM_VERSION_HTML,
         RICH_TO_VERSION_HTML,
     )
+
+
+def test_rendered_article_code_blocks_keep_tiptap_dark_theme():
+    stylesheet = Path("static/css/custom.css").read_text()
+
+    assert ".article-content pre," in stylesheet
+    assert "background: var(--bs-dark, #212529);" in stylesheet
+    assert "color: var(--bs-light, #f8f9fa);" in stylesheet
+    assert ".article-content pre code," in stylesheet
+    assert "color: inherit;" in stylesheet


### PR DESCRIPTION
### Motivation
- Código inserido no editor TipTap aparece com tema escuro enquanto edito, mas ao salvar o artigo os blocos `<pre>` passam a renderizar com fundo claro, tornando a leitura inconsistente.
- É necessário que o estilo dos blocos de código renderizados em páginas públicas preserve o mesmo visual escuro do editor para evitar regressões de usabilidade.

### Description
- Atualiza `static/css/custom.css` para renderizar `.tiptap-content pre` e `.article-content pre` com `background: var(--bs-dark, #212529)`, borda escura e texto claro, alinhando o visual salvo ao do editor.
- Faz com que o seletor `.article-content pre code` (e equivalentes) herde a cor do bloco com `color: inherit;` para evitar que `<code>` volte a uma cor neutra após salvar.
- Adiciona um teste de regressão `test_rendered_article_code_blocks_keep_tiptap_dark_theme` em `tests/test_article_rich_html_rendering.py` que verifica as regras de CSS relevantes estarem presentes.

### Testing
- Executado `pytest tests/test_article_rich_html_rendering.py -q` e a suíte de testes desse arquivo passou com sucesso (`2 passed`, várias advertências de compatibilidade SQLAlchemy mostradas como warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe4cc74ddc832ea3ae9d6850fb9dcd)