### PR TITLE
Toolbar do TipTap: sticky com offset configurável

### DIFF
--- a/templates/artigos/editar_artigo.html
+++ b/templates/artigos/editar_artigo.html
@@ -3,7 +3,14 @@
 
 {% block extra_css %}
 <style>
+  :root {
+    --editor-toolbar-offset: 72px;
+  }
+
   .tiptap-toolbar {
+    position: sticky;
+    top: var(--editor-toolbar-offset, 72px);
+    z-index: 20;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
   }

--- a/templates/artigos/novo_artigo.html
+++ b/templates/artigos/novo_artigo.html
@@ -3,7 +3,14 @@
 
 {% block extra_css %}
 <style>
+  :root {
+    --editor-toolbar-offset: 72px;
+  }
+
   .tiptap-toolbar {
+    position: sticky;
+    top: var(--editor-toolbar-offset, 72px);
+    z-index: 20;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
   }


### PR DESCRIPTION
### Motivation
- Permitir que a barra de ferramentas do editor fique fixa ao rolar sem cobrir cabeçalhos fixos e permitir ajuste do deslocamento vertical via variável CSS.

### Description
- Adiciona `:root { --editor-toolbar-offset: 72px; }` e altera `.tiptap-toolbar` para usar `position: sticky; top: var(--editor-toolbar-offset, 72px); z-index: 20;` em `templates/artigos/novo_artigo.html` e `templates/artigos/editar_artigo.html` mantendo o fundo opaco do Bootstrap.

### Testing
- Localmente foi verificado com buscas (`rg`) e inspeção de arquivos (`sed`/`nl`), as alterações foram aplicadas por script e revistas com `git diff`, `git status` e commit; todos os comandos automatizados concluíram com sucesso.
- Validação visual em navegador (scroll longo para confirmar comportamento sticky e offset) não foi executada neste ambiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e0be7a424832eb06737adb1871c27)