### PR TITLE
Improve TipTap toolbar horizontal scrolling behavior

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1155,6 +1155,17 @@
   z-index: 20;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
+  -webkit-overflow-scrolling: touch;
+}
+
+.tiptap-toolbar .btn-group {
+  display: inline-flex;
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  white-space: nowrap;
 }
 
 .tiptap-toolbar .btn {


### PR DESCRIPTION
### Motivation
- Make the TipTap editor toolbar usable when there are many button groups by enabling horizontal scrolling and preventing controls from wrapping. 
- Preserve the existing sticky toolbar behavior while improving accessibility on small viewports and touch devices. 

### Description
- Changed `static/css/custom.css` to add horizontal scrolling to `.tiptap-toolbar` with `overflow-x: auto`, `overflow-y: hidden`, `white-space: nowrap`, and `-webkit-overflow-scrolling: touch` to improve touch scrolling. 
- Prevented button groups from breaking by adding `.tiptap-toolbar .btn-group { display: inline-flex; flex: 0 0 auto; flex-wrap: nowrap; white-space: nowrap; }`. 
- Kept existing sticky positioning and button styling intact so current behavior and visual states remain unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e0e2ab858832e8d1079a1b439f318)