### PR TITLE
Remove link de recuperação de senha da tela de login

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -428,15 +428,6 @@
   box-shadow: none;
 }
 
-.login-forgot {
-  color: var(--primary);
-}
-
-.login-forgot:hover {
-  color: var(--primary);
-  text-decoration: underline;
-}
-
 @media (max-width: 576px) {
   .login-page {
     padding: 0.25rem;

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -73,14 +73,13 @@ data-remembered-username="{{ remembered_user.username if remembered_user else ''
             </div>
           </div>
 
-          <div class="d-flex flex-wrap align-items-center justify-content-between mb-3 gap-2">
+          <div class="d-flex flex-wrap align-items-center mb-3 gap-2">
             <div class="form-check mb-0">
               <input class="form-check-input" type="checkbox" value="1" id="remember" name="remember">
               <label class="form-check-label" for="remember">
                 Manter conectado
               </label>
             </div>
-            <a href="{{ url_for('forgot_password') }}" class="small text-decoration-none fw-semibold login-forgot">Esqueci minha senha</a>
           </div>
 
           <button type="submit" class="btn btn-primary w-100 fw-bold py-2">Entrar</button>

--- a/tests/test_login_template.py
+++ b/tests/test_login_template.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LOGIN_TEMPLATE = ROOT / "templates" / "auth" / "login.html"
+
+
+def test_login_template_does_not_show_forgot_password_link():
+    source = LOGIN_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "Esqueci minha senha" not in source
+    assert "forgot_password" not in source


### PR DESCRIPTION
### Motivation
- O link de recuperação de senha (`Esqueci minha senha`) foi removido porque o fluxo de envio de e-mail não está sendo utilizado (causava erro ao acionar o recurso) e queremos evitar expor a opção na tela de login.

### Description
- Remove o link de recuperação de senha do template `templates/auth/login.html` deixando apenas a opção `Manter conectado` antes do botão de login.
- Remove as regras CSS específicas do seletor `.login-forgot` em `static/css/custom.css` que passaram a ser desnecessárias.
- Adiciona o teste `tests/test_login_template.py` que verifica que o template de login não contém o texto nem o endpoint de recuperação de senha.

### Testing
- Executado `pytest tests/test_login_template.py tests/test_cookie_pixel_template.py` e ambos os testes passaram com sucesso.
- Os templates foram validados por leitura direta no teste e não exibem mais o link/endpoint de recuperação de senha.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a294d07961c832e8defc9dffb7f5dc1)