### PR TITLE
Preservar permissões personalizadas ao abrir modal de edição

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -292,7 +292,8 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 
-  function applyCargoDefaults(prefix, cargoId) {
+  function applyCargoDefaults(prefix, cargoId, options = {}) {
+    const { preserveFuncoesChecked = false } = options;
     const defs = cargoDefaults[cargoId] || { estabelecimentos: [], setores: [], celulas: [], funcoes: [] };
     const form = prefix === 'edit_' ? document.getElementById('edit_cargo_id')?.closest('form') : document.getElementById('create-user-form');
     const hiddenEstabelecimento = document.getElementById(`${prefix}hidden_estabelecimento_id`);
@@ -334,11 +335,15 @@ document.addEventListener("DOMContentLoaded", function () {
     document.querySelectorAll(`input[id^='${prefix}celula']`).forEach((chk) => {
       chk.checked = defs.celulas.includes(parseInt(chk.value));
     });
-    document.querySelectorAll(`input[id^='${prefix}func']`).forEach((chk) => {
-      const isDefault = defs.funcoes.includes(parseInt(chk.value));
-      chk.checked = isDefault;
-      chk.disabled = isDefault;
-    });
+    if (preserveFuncoesChecked && prefix === 'edit_') {
+      setCargoFuncoesDisabled(prefix, cargoId);
+    } else {
+      document.querySelectorAll(`input[id^='${prefix}func']`).forEach((chk) => {
+        const isDefault = defs.funcoes.includes(parseInt(chk.value));
+        chk.checked = isDefault;
+        chk.disabled = isDefault;
+      });
+    }
 
     if (prefix === '') {
       validateCreateUserForm();
@@ -358,7 +363,7 @@ document.addEventListener("DOMContentLoaded", function () {
   }
   const selectedCargoEdit = document.getElementById('edit_cargo_id')?.value;
   if (selectedCargoEdit) {
-    applyCargoDefaults('edit_', selectedCargoEdit);
+    applyCargoDefaults('edit_', selectedCargoEdit, { preserveFuncoesChecked: true });
   }
 
   // Expose helper for inline scripts


### PR DESCRIPTION
### Motivation
- Evitar que o carregamento inicial da tela de edição sobrescreva checkboxes de permissões já renderizados pelo backend. 
- Manter a desabilitação de permissões herdadas para o cargo sem forçar o estado `checked` durante a abertura do modal. 
- Continuar aplicando os defaults completos quando o usuário altera manualmente o `select` de cargo. 

### Description
- Atualiza a assinatura de `applyCargoDefaults` em `static/js/main.js` para aceitar `options = { preserveFuncoesChecked }`. 
- Quando `preserveFuncoesChecked` é verdadeiro e `prefix === 'edit_'`, a função apenas chama `setCargoFuncoesDisabled(prefix, cargoId)` em vez de sobrescrever `checked` nas `input[id^='edit_func']`. 
- O carregamento inicial de edição agora chama `applyCargoDefaults('edit_', selectedCargoEdit, { preserveFuncoesChecked: true })`, enquanto o listener de `change` no `#edit_cargo_id` continua chamando a função sem a opção para aplicar todos os defaults. 
- Alterações feitas em `static/js/main.js` preservam o comportamento existente para criação de usuário e validação de formulário. 

### Testing
- Executado `node --check static/js/main.js` e retornou sucesso. 
- Executado `git diff --check` e não foram encontrados problemas de formatação ou espaços finais.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a297325d590832ea63dba582c653c47)