### PR TITLE
Normalize boletim search phrases

### DIFF
--- a/blueprints/boletins.py
+++ b/blueprints/boletins.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import os
+import re
 import uuid
 
 from flask import Blueprint, current_app as app, flash, redirect, render_template, request, session, url_for
@@ -144,8 +145,30 @@ def buscar_boletins():
         except Exception:
             supports_unaccent = False
 
+    def _normalize_for_search(value):
+        return strip_accents(re.sub(r'\s+', ' ', value or '').lower())
+
+    if not is_postgresql:
+        try:
+            db.session.connection().connection.create_function('normalize_search', 1, _normalize_for_search)
+        except Exception:
+            pass
+
+    def _sql_normalize_whitespace(expression):
+        coalesced = func.coalesce(expression, '')
+        if is_postgresql:
+            return func.regexp_replace(coalesced, r'\s+', ' ', 'g')
+
+        normalized = coalesced
+        for char in ('\n', '\r', '\t'):
+            normalized = func.replace(normalized, char, ' ')
+        return normalized
+
     def _sql_strip_accents(expression):
-        normalized = func.lower(func.coalesce(expression, ''))
+        if not is_postgresql:
+            return func.normalize_search(expression)
+
+        normalized = func.lower(_sql_normalize_whitespace(expression))
         for accented, plain in (
             ('á', 'a'), ('à', 'a'), ('â', 'a'), ('ã', 'a'), ('ä', 'a'),
             ('é', 'e'), ('è', 'e'), ('ê', 'e'), ('ë', 'e'),
@@ -159,19 +182,19 @@ def buscar_boletins():
 
     query = Boletim.query
     if termo:
-        like = build_like_pattern(termo)
-        like_normalized = build_like_pattern(strip_accents(termo).lower())
+        termo_busca = termo if '%' in termo else re.sub(r'\s+', ' ', termo)
+        like_normalized = build_like_pattern(strip_accents(termo_busca).lower())
 
+        titulo_normalizado = _sql_normalize_whitespace(Boletim.titulo)
+        ocr_normalizado = _sql_normalize_whitespace(Boletim.ocr_text)
         conditions = [
-            Boletim.titulo.ilike(like),
-            Boletim.ocr_text.ilike(like),
             _sql_strip_accents(Boletim.titulo).ilike(like_normalized),
             _sql_strip_accents(Boletim.ocr_text).ilike(like_normalized),
         ]
         if is_postgresql and supports_unaccent:
             conditions.extend([
-                func.unaccent(Boletim.titulo).ilike(like_normalized),
-                func.unaccent(func.coalesce(Boletim.ocr_text, '')).ilike(like_normalized),
+                func.unaccent(titulo_normalizado).ilike(like_normalized),
+                func.unaccent(ocr_normalizado).ilike(like_normalized),
             ])
         query = query.filter(or_(*conditions))
 

--- a/tests/test_boletins_busca.py
+++ b/tests/test_boletins_busca.py
@@ -66,6 +66,19 @@ def test_busca_boletim_match_ocr(client):
     assert b'Atualiza' in resp.data
 
 
+def test_busca_boletim_frase_normalizada_em_ocr(client):
+    with app.app_context():
+        user = _setup_user(client, ['boletim_buscar', 'boletim_visualizar'])
+        _create_boletim(user, 'Programa Social', 'Texto sobre bem\nacolher pessoas', date(2026, 1, 9))
+        _create_boletim(user, 'Programa Social Alternativo', 'Texto sobre bem sempre acolher pessoas', date(2026, 1, 10))
+
+    resp = client.get('/boletins/buscar', query_string={'q': 'bem acolher'})
+
+    assert resp.status_code == 200
+    assert b'Programa Social' in resp.data
+    assert b'Programa Social Alternativo' not in resp.data
+
+
 
 def test_busca_boletim_ignora_acentos(client):
     with app.app_context():


### PR DESCRIPTION
### Motivation
- Searches against `Boletim.titulo` and `Boletim.ocr_text` failed to match user phrases when OCR inserted newlines or irregular whitespace and when accents differed, so results could be incorrect for phrase queries.
- The intent is to normalize whitespace, case and accents for both stored text and the user term so phrase queries like `q=bem acolher` match `bem\nacolher` as a contiguous normalized sequence.

### Description
- Updated `blueprints/boletins.py` to normalize search input and target fields by collapsing whitespace, lowercasing and removing accents before matching; added `import re` and a `termo_busca` normalization using `re.sub(r'\s+', ' ', termo)` when the term does not contain `%`.
- Implemented SQL-side normalization helpers: `_sql_normalize_whitespace` uses `regexp_replace(..., '\\s+', ' ', 'g')` for PostgreSQL and `func.replace` chaining for SQLite, and `_sql_strip_accents` delegates to a SQLite user function `normalize_search` (registered from Python) for non-Postgres connections while keeping the Postgres replacement chain for accents.
- For SQLite/tests, created a local `normalize_search` Python function (registered via `create_function`) to provide equivalent `strip_accents+whitespace+lower` behavior.
- Adjusted the query to filter normalized title/ocr fields and to keep `unaccent`-based checks for Postgres when available, and removed raw `ilike` checks against unnormalized fields so phrase matching is performed against normalized text.
- Added a test `test_busca_boletim_frase_normalizada_em_ocr` in `tests/test_boletins_busca.py` that creates an OCR text containing `bem\nacolher` and asserts that `q='bem acolher'` matches the normalized phrase and does not match other records.

### Testing
- Ran `pytest tests/test_boletins_busca.py` and all tests passed (`11 passed`).
- The new test covers OCR newline normalization and phrase matching and succeeded under the test SQLite backend.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32aaf0a764832ea7e48ff9f56961bc)