### PR TITLE
test: cover boletim OCR search patterns

### DIFF
--- a/tests/test_boletins_busca.py
+++ b/tests/test_boletins_busca.py
@@ -69,15 +69,53 @@ def test_busca_boletim_match_ocr(client):
 def test_busca_boletim_frase_normalizada_em_ocr(client):
     with app.app_context():
         user = _setup_user(client, ['boletim_buscar', 'boletim_visualizar'])
-        _create_boletim(user, 'Programa Social', 'Texto sobre bem\nacolher pessoas', date(2026, 1, 9))
-        _create_boletim(user, 'Programa Social Alternativo', 'Texto sobre bem sempre acolher pessoas', date(2026, 1, 10))
+        _create_boletim(user, 'Boletim OCR Primeiro', 'programa bem acolher foi divulgado', date(2026, 1, 9))
+        _create_boletim(user, 'Boletim OCR Segundo', 'programa bem rapidamente acolher famílias', date(2026, 1, 10))
 
     resp = client.get('/boletins/buscar', query_string={'q': 'bem acolher'})
 
     assert resp.status_code == 200
-    assert b'Programa Social' in resp.data
-    assert b'Programa Social Alternativo' not in resp.data
+    assert b'Boletim OCR Primeiro' in resp.data
+    assert b'Boletim OCR Segundo' not in resp.data
 
+
+def test_busca_boletim_percentual_sem_bordas_em_ocr(client):
+    with app.app_context():
+        user = _setup_user(client, ['boletim_buscar', 'boletim_visualizar'])
+        _create_boletim(user, 'Boletim OCR Exato', 'programa bem acolher foi divulgado', date(2026, 1, 11))
+        _create_boletim(user, 'Boletim OCR Separado', 'programa bem rapidamente acolher famílias', date(2026, 1, 12))
+
+    resp = client.get('/boletins/buscar', query_string={'q': 'bem%acolher'})
+
+    assert resp.status_code == 200
+    assert b'Boletim OCR Exato' in resp.data
+    assert b'Boletim OCR Separado' in resp.data
+
+
+def test_busca_boletim_percentual_com_bordas_em_ocr(client):
+    with app.app_context():
+        user = _setup_user(client, ['boletim_buscar', 'boletim_visualizar'])
+        _create_boletim(user, 'Boletim OCR Borda Exato', 'programa bem acolher foi divulgado', date(2026, 1, 13))
+        _create_boletim(user, 'Boletim OCR Borda Separado', 'programa bem rapidamente acolher famílias', date(2026, 1, 14))
+
+    resp = client.get('/boletins/buscar', query_string={'q': '%bem%acolher%'})
+
+    assert resp.status_code == 200
+    assert b'Boletim OCR Borda Exato' in resp.data
+    assert b'Boletim OCR Borda Separado' in resp.data
+
+
+def test_busca_boletim_ignora_acentos_em_ocr(client):
+    with app.app_context():
+        user = _setup_user(client, ['boletim_buscar', 'boletim_visualizar'])
+        _create_boletim(user, 'Boletim OCR Acentuado', 'relatório sobre ação integrada', date(2026, 1, 15))
+        _create_boletim(user, 'Boletim OCR Sem Acento', 'relatorio sobre acao integrada', date(2026, 1, 16))
+
+    resp = client.get('/boletins/buscar', query_string={'q': 'acao integrada'})
+
+    assert resp.status_code == 200
+    assert b'Boletim OCR Acentuado' in resp.data
+    assert b'Boletim OCR Sem Acento' in resp.data
 
 
 def test_busca_boletim_ignora_acentos(client):


### PR DESCRIPTION
### Motivation

- Ensure the `/boletins/buscar` search correctly matches against `Boletim.ocr_text` for phrase searches, wildcard (`%`) patterns and accent-insensitive queries.
- Add focused tests that exercise the existing normalization and LIKE-building logic for OCR text so regressions are caught.

### Description

- Updated `tests/test_boletins_busca.py` to replace the previous OCR normalization scenario with explicit `ocr_text` values used to validate phrase matching behavior.
- Added `test_busca_boletim_percentual_sem_bordas_em_ocr`, `test_busca_boletim_percentual_com_bordas_em_ocr`, and `test_busca_boletim_ignora_acentos_em_ocr` to cover interior/bounded wildcard matching and accent normalization when searching `Boletim.ocr_text`.
- All new tests create `Boletim` records with controlled `ocr_text` content and assert the `/boletins/buscar` responses contain or omit the expected items.

### Testing

- Ran `pytest tests/test_boletins_busca.py -q` which completed successfully with `14 passed`.
- The test run produced SQLAlchemy legacy warnings but no test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32b3ddf53c832eacf08a58404853b9)