### PR TITLE
Use PostgreSQL phrase FTS for boletim search

### DIFF
--- a/blueprints/boletins.py
+++ b/blueprints/boletins.py
@@ -4,7 +4,7 @@ import re
 import uuid
 
 from flask import Blueprint, current_app as app, flash, redirect, render_template, request, session, url_for
-from sqlalchemy import and_, func, or_, text
+from sqlalchemy import and_, func, literal_column, or_, text
 from werkzeug.utils import secure_filename
 
 try:
@@ -19,6 +19,23 @@ except ImportError:  # pragma: no cover
     from core.utils import build_like_pattern, strip_accents
 
 boletins_bp = Blueprint('boletins_bp', __name__)
+
+
+BOLETIM_FTS_CONFIG = literal_column("'portuguese'")
+
+
+def _boletim_titulo_ocr_text_expression():
+    return func.coalesce(Boletim.titulo, '') + ' ' + func.coalesce(Boletim.ocr_text, '')
+
+
+def _boletim_tsvector_expression():
+    return func.to_tsvector(BOLETIM_FTS_CONFIG, _boletim_titulo_ocr_text_expression())
+
+
+def _boletim_phrase_tsquery_condition(termo: str):
+    return _boletim_tsvector_expression().op('@@')(
+        func.phraseto_tsquery(BOLETIM_FTS_CONFIG, termo)
+    )
 
 
 def _require_permission(permission_name: str, redirect_endpoint: str = 'pagina_inicial'):
@@ -187,10 +204,13 @@ def buscar_boletins():
 
         titulo_normalizado = _sql_normalize_whitespace(Boletim.titulo)
         ocr_normalizado = _sql_normalize_whitespace(Boletim.ocr_text)
-        conditions = [
+        conditions = []
+        if is_postgresql and '%' not in termo:
+            conditions.append(_boletim_phrase_tsquery_condition(termo_busca))
+        conditions.extend([
             _sql_strip_accents(Boletim.titulo).ilike(like_normalized),
             _sql_strip_accents(Boletim.ocr_text).ilike(like_normalized),
-        ]
+        ])
         if is_postgresql and supports_unaccent:
             conditions.extend([
                 func.unaccent(titulo_normalizado).ilike(like_normalized),

--- a/tests/test_boletins_busca.py
+++ b/tests/test_boletins_busca.py
@@ -207,3 +207,37 @@ def test_busca_boletim_percentual_prefixo_sufixo(client):
     assert resp_sufixo.status_code == 200
     assert b'Comunicado Dia dos pais' in resp_prefixo.data
     assert b'Comunicado Dia dos pais' in resp_sufixo.data
+
+
+def _compile_postgresql_expression(expression):
+    from sqlalchemy.dialects import postgresql
+
+    return str(
+        expression.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={'literal_binds': True},
+        )
+    )
+
+
+def test_boletim_postgresql_fts_usa_phraseto_tsquery_para_termo_sem_percentual():
+    from blueprints.boletins import _boletim_phrase_tsquery_condition
+
+    sql = _compile_postgresql_expression(_boletim_phrase_tsquery_condition('bem acolher'))
+
+    assert "phraseto_tsquery('portuguese', 'bem acolher')" in sql
+    assert 'plainto_tsquery' not in sql
+    assert 'websearch_to_tsquery' not in sql
+    assert "'bem'" not in sql
+    assert "'acolher'" not in sql
+
+
+def test_boletim_postgresql_fts_expression_corresponde_ao_indice():
+    from blueprints.boletins import _boletim_tsvector_expression
+
+    sql = _compile_postgresql_expression(_boletim_tsvector_expression())
+
+    assert sql == (
+        "to_tsvector('portuguese', "
+        "coalesce(boletim.titulo, '') || ' ' || coalesce(boletim.ocr_text, ''))"
+    )


### PR DESCRIPTION
### Motivation

- Improve search accuracy and performance on PostgreSQL by leveraging the existing GIN full-text index for boletins while preserving current ILIKE semantics and wildcard behavior.
- Ensure phrase searches like `q='bem acolher'` are treated as a phrase (not separate terms) when possible and keep `%` as the user-intended wildcard operator.

### Description

- Added PostgreSQL FTS helpers in `blueprints/boletins.py`: `BOLETIM_FTS_CONFIG` (as `literal_column("'portuguese'")`), `_boletim_titulo_ocr_text_expression()`, `_boletim_tsvector_expression()` and `_boletim_phrase_tsquery_condition()` that mirror the indexed expression `to_tsvector('portuguese', coalesce(titulo, '') || ' ' || coalesce(ocr_text, ''))`.
- Updated `buscar_boletins` to append a phrase full-text condition using `phraseto_tsquery` when `is_postgresql` and the query term does not include `%`, while keeping normalized `ILIKE` fallbacks and `unaccent` checks for OCR/substring needs.
- Kept wildcard semantics intact by continuing to use `ILIKE` whenever the user-provided `termo` contains `%`.
- Added unit tests in `tests/test_boletins_busca.py` to assert that the compiled `phraseto_tsquery('portuguese', ...)` is used for phrase queries and that the tsvector expression matches the existing index, plus a small SQL compilation helper used by those tests.

### Testing

- An initial run of the new FTS tests revealed 2 failures related to SQL literal rendering, after which `BOLETIM_FTS_CONFIG` was changed to `literal_column("'portuguese'")` and the tests were re-run successfully.
- Ran `pytest -q tests/test_boletins_busca.py` which passed for the modified file.
- Ran the full test suite with `pytest -q` which completed successfully (`233 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32b5961208832e806db41f09a1b814)