### PR TITLE
Atualiza placeholder e ajuda no formulário de busca de boletins

### DIFF
--- a/templates/boletins/busca.html
+++ b/templates/boletins/busca.html
@@ -8,7 +8,8 @@
           <h1 class="h2 mb-3">Buscar boletins</h1>
           <form method="get" class="row g-2 align-items-end">
             <div class="col-md-10">
-              <input class="form-control" type="text" name="q" placeholder="Título ou texto OCR" value="{{ termo or '' }}">
+              <input class="form-control" type="text" name="q" placeholder="Digite uma frase; use % para busca aproximada" value="{{ termo or '' }}" aria-describedby="busca-help">
+              <div id="busca-help" class="form-text">Ex.: bem acolher busca a frase. Use bem%acolher para permitir termos entre as palavras.</div>
             </div>
             <div class="col-md-2">
               <label for="per_page" class="form-label mb-1">Por página:</label>


### PR DESCRIPTION
### Motivation
- Esclarecer o uso do campo de busca orientando entrada por frase e o uso de `%` para busca aproximada e fornecer um exemplo curto e visível.

### Description
- Atualiza o placeholder para `Digite uma frase; use % para busca aproximada`, adiciona um elemento de ajuda `div id="busca-help" class="form-text"` com exemplo `Ex.: bem acolher busca a frase. Use bem%acolher para permitir termos entre as palavras.` e vincula-o ao input via `aria-describedby="busca-help"`, mantendo o layout responsivo.

### Testing
- Executado `git diff --check` (sem erros) e confirmado o conteúdo do arquivo com `nl` antes de commitar a alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32cd9b3664832e89fb12eba64af347)