### PR TITLE
Ajusta layout da busca de boletins

### DIFF
--- a/templates/boletins/busca.html
+++ b/templates/boletins/busca.html
@@ -6,18 +6,20 @@
       <div class="card shadow-sm mb-4">
         <div class="card-body">
           <h1 class="h2 mb-3">Buscar boletins</h1>
-          <form method="get" class="row g-2 align-items-end">
-            <div class="col-md-10">
+          <form method="get" class="row g-2 align-items-start">
+            <div class="col-md">
               <input class="form-control" type="text" name="q" placeholder="Digite uma frase; use % para busca aproximada" value="{{ termo or '' }}" aria-describedby="busca-help">
-              <div id="busca-help" class="form-text">Ex.: bem acolher busca a frase. Use bem%acolher para permitir termos entre as palavras.</div>
+              <div id="busca-help" class="form-text">Ex.: Unimed São Carlos busca a frase. Use Unimed%Carlos para permitir termos entre as palavras.</div>
             </div>
-            <div class="col-md-2">
-              <label for="per_page" class="form-label mb-1">Por página:</label>
-              <select id="per_page" name="per_page" class="form-select" onchange="this.form.submit()">
-                {% for option in [10, 20, 50, 100] %}
+            <div class="col-md-auto">
+              <div class="d-flex align-items-center gap-2">
+                <label for="per_page" class="form-label mb-0 text-nowrap">Por página:</label>
+                <select id="per_page" name="per_page" class="form-select" style="width: 96px;" onchange="this.form.submit()">
+                  {% for option in [10, 20, 50, 100] %}
                   <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
-                {% endfor %}
-              </select>
+                  {% endfor %}
+                </select>
+              </div>
             </div>
           </form>
         </div>


### PR DESCRIPTION
### Motivation
- Alinhar visualmente o campo de busca e o seletor "Por página" na página de busca de boletins e atualizar o exemplo de pesquisa para usar `Unimed São Carlos` / `Unimed%Carlos` em vez de `bem acolher`.

### Description
- Atualiza `templates/boletins/busca.html` trocando a classe do formulário para `align-items-start`, ajustando o grid para usar `col-md` no campo de busca e `col-md-auto` no seletor, envolvendo o label e o `select` em `d-flex align-items-center gap-2` e definindo a largura do `select` para `96px`, além de alterar o texto de ajuda para o novo exemplo.

### Testing
- Executado `pytest tests/test_boletins_busca.py` com sucesso (`18 passed`, `70 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32deb48418832e90ad57b7e2ea7cae)