### PR TITLE
Ordena busca de boletins por data mais recente

### DIFF
--- a/blueprints/boletins.py
+++ b/blueprints/boletins.py
@@ -198,7 +198,7 @@ def buscar_boletins():
         return normalized
 
     query = Boletim.query
-    order_by = [Boletim.data_boletim.desc(), Boletim.created_at.desc()]
+    order_by = [Boletim.data_boletim.desc(), Boletim.id.desc()]
     if termo:
         has_wildcard = '%' in termo
         termo_busca = termo if has_wildcard else re.sub(r'\s+', ' ', termo)
@@ -227,7 +227,7 @@ def buscar_boletins():
         query = query.filter(or_(*conditions))
 
         # Ranking simples: título exato/normalizado, OCR exato/normalizado,
-        # match aproximado com %, e por fim boletim mais recente como desempate.
+        # match aproximado com %, usado apenas como desempate entre boletins da mesma data.
         titulo_exact_match = false() if has_wildcard else titulo_sem_acento.ilike(exact_like_normalized)
         ocr_exact_match = false() if has_wildcard else ocr_sem_acento.ilike(exact_like_normalized)
         titulo_approx_match = titulo_sem_acento.ilike(like_normalized)
@@ -242,7 +242,7 @@ def buscar_boletins():
         if is_postgresql and phrase_tsquery is not None:
             relevance_score = relevance_score + func.ts_rank_cd(_boletim_tsvector_expression(), phrase_tsquery)
 
-        order_by = [relevance_score.desc(), *order_by]
+        order_by = [Boletim.data_boletim.desc(), relevance_score.desc(), Boletim.id.desc()]
 
     pagination = query.order_by(*order_by).paginate(page=page, per_page=per_page, error_out=False)
     return render_template(

--- a/tests/test_boletins_busca.py
+++ b/tests/test_boletins_busca.py
@@ -129,7 +129,7 @@ def test_busca_boletim_ignora_acentos(client):
     assert b'Boletim de A' in resp.data
 
 
-def test_busca_boletim_prioriza_titulo_antes_de_ocr_mesmo_mais_antigo(client):
+def test_busca_boletim_prioriza_data_mais_recente_antes_do_ranking(client):
     with app.app_context():
         user = _setup_user(client, ['boletim_buscar', 'boletim_visualizar'])
         _create_boletim(user, 'Resumo Operacional', 'Texto com comunicado interno', date(2026, 1, 20))
@@ -138,10 +138,10 @@ def test_busca_boletim_prioriza_titulo_antes_de_ocr_mesmo_mais_antigo(client):
     resp = client.get('/boletins/buscar', query_string={'q': 'comunicado interno'})
 
     assert resp.status_code == 200
-    assert resp.data.index(b'Comunicado Interno') < resp.data.index(b'Resumo Operacional')
+    assert resp.data.index(b'Resumo Operacional') < resp.data.index(b'Comunicado Interno')
 
 
-def test_busca_boletim_usa_data_mais_recente_como_desempate_de_ranking(client):
+def test_busca_boletim_usa_data_mais_recente_como_criterio_principal(client):
     with app.app_context():
         user = _setup_user(client, ['boletim_buscar', 'boletim_visualizar'])
         _create_boletim(user, 'Comunicado Antigo', 'Texto irrelevante', date(2026, 1, 1))


### PR DESCRIPTION
### Motivation
- Garantir que resultados da busca de boletins sejam exibidos da data mais recente para a mais antiga como critério principal de ordenação.
- Preservar o ranking de relevância apenas como critério de desempate entre boletins com a mesma data.
- Atualizar os testes para refletir o novo comportamento esperado da ordenação.

### Description
- Ajusta em `blueprints/boletins.py` o `order_by` inicial para usar `Boletim.data_boletim.desc()` com `Boletim.id.desc()` como desempate em vez de `created_at`.
- Quando há termo de busca, altera a ordenação para `Boletim.data_boletim.desc(), relevance_score.desc(), Boletim.id.desc()` para garantir que a data seja o critério principal e a relevância sirva apenas como desempate entre mesma data.
- Atualiza o comentário explicativo sobre o uso do score de relevância como desempate e não como critério principal.
- Renomeia/ajusta assertions em `tests/test_boletins_busca.py` para validar que boletins mais recentes aparecem antes dos mais antigos mesmo se o mais antigo tivesse maior relevância textual.

### Testing
- Executado `pytest tests/test_boletins_busca.py` e todos os testes do arquivo passaram: `18 passed`.
- Não foram alterados outros testes automatizados nesta mudança e foram observados avisos de depreciação do SQLAlchemy sem impacto na execução dos testes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32e0ec9e60832e84842bd7187ceb43)