### PR TITLE
Otimiza busca de boletins: prioriza FTS e adiciona campo de busca normalizado

### DIFF
--- a/blueprints/boletins.py
+++ b/blueprints/boletins.py
@@ -4,19 +4,19 @@ import re
 import uuid
 
 from flask import Blueprint, current_app as app, flash, redirect, render_template, request, session, url_for
-from sqlalchemy import and_, case, false, func, literal_column, or_, text
+from sqlalchemy import case, false, func, literal_column, or_
 from werkzeug.utils import secure_filename
 
 try:
     from ..core.database import db
     from ..core.models import Boletim, User
     from ..core.services.ocr_queue import enqueue_boletim_for_ocr
-    from ..core.utils import build_like_pattern, strip_accents
+    from ..core.utils import build_like_pattern, normalize_search_text
 except ImportError:  # pragma: no cover
     from core.database import db
     from core.models import Boletim, User
     from core.services.ocr_queue import enqueue_boletim_for_ocr
-    from core.utils import build_like_pattern, strip_accents
+    from core.utils import build_like_pattern, normalize_search_text
 
 boletins_bp = Blueprint('boletins_bp', __name__)
 
@@ -151,19 +151,9 @@ def buscar_boletins():
 
     bind = db.session.get_bind()
     is_postgresql = bool(bind and bind.dialect.name == 'postgresql')
-    supports_unaccent = False
-    if is_postgresql:
-        try:
-            supports_unaccent = bool(
-                db.session.execute(
-                    text("SELECT 1 FROM pg_extension WHERE extname='unaccent'")
-                ).scalar()
-            )
-        except Exception:
-            supports_unaccent = False
 
     def _normalize_for_search(value):
-        return strip_accents(re.sub(r'\s+', ' ', value or '').lower())
+        return normalize_search_text(value)
 
     if not is_postgresql:
         try:
@@ -199,52 +189,60 @@ def buscar_boletins():
 
     query = Boletim.query
     order_by = [Boletim.data_boletim.desc(), Boletim.id.desc()]
+    pagination = None
     if termo:
         has_wildcard = '%' in termo
         termo_busca = termo if has_wildcard else re.sub(r'\s+', ' ', termo)
-        like_normalized = build_like_pattern(strip_accents(termo_busca).lower())
-        exact_normalized = strip_accents(re.sub(r'\s+', ' ', termo).lower())
+        like_normalized = build_like_pattern(normalize_search_text(termo_busca))
+        exact_normalized = normalize_search_text(termo)
         exact_like_normalized = build_like_pattern(exact_normalized)
 
-        titulo_normalizado = _sql_normalize_whitespace(Boletim.titulo)
-        ocr_normalizado = _sql_normalize_whitespace(Boletim.ocr_text)
+        normalized_search_text = func.coalesce(Boletim.search_text_normalized, '')
         titulo_sem_acento = _sql_strip_accents(Boletim.titulo)
-        ocr_sem_acento = _sql_strip_accents(Boletim.ocr_text)
-        conditions = []
+        # Bancos usados em testes locais não têm a coluna materializada populada por OCR/migration.
+        # Neles, mantemos a normalização em consulta apenas como compatibilidade fora de PostgreSQL.
+        if not is_postgresql:
+            normalized_search_text = _sql_strip_accents(
+                func.coalesce(Boletim.titulo, '') + ' ' + func.coalesce(Boletim.ocr_text, '')
+            )
+
+        def _apply_like_fallback(base_query):
+            return base_query.filter(or_(
+                titulo_sem_acento.ilike(like_normalized),
+                normalized_search_text.ilike(like_normalized),
+            ))
+
         phrase_tsquery = None
         if is_postgresql and not has_wildcard:
             phrase_tsquery = func.phraseto_tsquery(BOLETIM_FTS_CONFIG, termo_busca)
-            conditions.append(_boletim_tsvector_expression().op('@@')(phrase_tsquery))
-        conditions.extend([
-            titulo_sem_acento.ilike(like_normalized),
-            ocr_sem_acento.ilike(like_normalized),
-        ])
-        if is_postgresql and supports_unaccent:
-            conditions.extend([
-                func.unaccent(titulo_normalizado).ilike(like_normalized),
-                func.unaccent(ocr_normalizado).ilike(like_normalized),
-            ])
-        query = query.filter(or_(*conditions))
+            fts_match = _boletim_tsvector_expression().op('@@')(phrase_tsquery)
+            query = query.filter(fts_match)
+        else:
+            query = _apply_like_fallback(query)
 
-        # Ranking simples: título exato/normalizado, OCR exato/normalizado,
-        # match aproximado com %, usado apenas como desempate entre boletins da mesma data.
         titulo_exact_match = false() if has_wildcard else titulo_sem_acento.ilike(exact_like_normalized)
-        ocr_exact_match = false() if has_wildcard else ocr_sem_acento.ilike(exact_like_normalized)
+        normalized_exact_match = false() if has_wildcard else normalized_search_text.ilike(exact_like_normalized)
         titulo_approx_match = titulo_sem_acento.ilike(like_normalized)
-        ocr_approx_match = ocr_sem_acento.ilike(like_normalized)
+        normalized_approx_match = normalized_search_text.ilike(like_normalized)
         relevance_score = case(
             (titulo_exact_match, 300),
-            (ocr_exact_match, 200),
+            (normalized_exact_match, 200),
             (titulo_approx_match, 100),
-            (ocr_approx_match, 50),
+            (normalized_approx_match, 50),
             else_=0,
         )
         if is_postgresql and phrase_tsquery is not None:
             relevance_score = relevance_score + func.ts_rank_cd(_boletim_tsvector_expression(), phrase_tsquery)
 
         order_by = [Boletim.data_boletim.desc(), relevance_score.desc(), Boletim.id.desc()]
+        pagination = query.order_by(*order_by).paginate(page=page, per_page=per_page, error_out=False)
 
-    pagination = query.order_by(*order_by).paginate(page=page, per_page=per_page, error_out=False)
+        if is_postgresql and not has_wildcard and pagination.total == 0:
+            query = _apply_like_fallback(Boletim.query)
+            pagination = query.order_by(*order_by).paginate(page=page, per_page=per_page, error_out=False)
+
+    if pagination is None:
+        pagination = query.order_by(*order_by).paginate(page=page, per_page=per_page, error_out=False)
     return render_template(
         'boletins/busca.html',
         boletins=pagination.items,

--- a/core/models.py
+++ b/core/models.py
@@ -552,6 +552,7 @@ class Boletim(db.Model):
 
     ocr_status = db.Column(db.String(32), nullable=False, default='nao_aplicavel', server_default='nao_aplicavel')
     ocr_text = db.Column(db.Text, nullable=True)
+    search_text_normalized = db.Column(db.Text, nullable=True)
     ocr_processed_at = db.Column(db.DateTime(timezone=True), nullable=True)
     ocr_error_message = db.Column(db.Text, nullable=True)
     ocr_page_count = db.Column(db.Integer, nullable=True)

--- a/core/services/ocr_queue.py
+++ b/core/services/ocr_queue.py
@@ -11,11 +11,11 @@ from pypdf import PdfReader
 try:
     from ..database import db
     from ..models import Attachment, Boletim, OCRReprocessAudit
-    from ..utils import extract_text, log_article_event, log_article_exception
+    from ..utils import extract_text, log_article_event, log_article_exception, normalize_search_text
 except ImportError:  # pragma: no cover
     from core.database import db
     from core.models import Attachment, Boletim, OCRReprocessAudit
-    from core.utils import extract_text, log_article_event, log_article_exception
+    from core.utils import extract_text, log_article_event, log_article_exception, normalize_search_text
 
 OCR_STATUS_PENDENTE = "pendente"
 OCR_STATUS_PROCESSANDO = "processando"
@@ -348,6 +348,7 @@ def process_pending_ocr_boletins(
             extraction = _normalize_extract_result(_extract_text_with_metadata(file_path))
             content = extraction["text"]
             boletim.ocr_text = content
+            boletim.search_text_normalized = normalize_search_text(f"{boletim.titulo or ''} {content or ''}")
             finished_at = datetime.now(timezone.utc)
             boletim.ocr_finished_at = finished_at
             boletim.ocr_processed_at = finished_at

--- a/core/utils.py
+++ b/core/utils.py
@@ -68,6 +68,11 @@ def strip_accents(value: str) -> str:
     return ''.join(ch for ch in normalized if unicodedata.category(ch) != 'Mn')
 
 
+def normalize_search_text(value: str) -> str:
+    """Normalize text once for accent-insensitive fallback searches."""
+    return strip_accents(re.sub(r'\s+', ' ', value or '').lower()).strip()
+
+
 def build_like_pattern(term: str) -> str:
     cleaned = (term or '').strip()
     if not cleaned:

--- a/migrations/versions/bd72a3f4c9e8_add_boletim_normalized_search_text.py
+++ b/migrations/versions/bd72a3f4c9e8_add_boletim_normalized_search_text.py
@@ -1,0 +1,49 @@
+"""add boletim normalized search text
+
+Revision ID: bd72a3f4c9e8
+Revises: 4e6f8a1b2c3d
+Create Date: 2026-06-17 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'bd72a3f4c9e8'
+down_revision = '4e6f8a1b2c3d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('boletim') as batch_op:
+        batch_op.add_column(sa.Column('search_text_normalized', sa.Text(), nullable=True))
+
+    bind = op.get_bind()
+    if bind.dialect.name == 'postgresql':
+        op.execute("CREATE EXTENSION IF NOT EXISTS unaccent")
+        op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+        op.execute(
+            """
+            UPDATE boletim
+            SET search_text_normalized = lower(
+                unaccent(regexp_replace(coalesce(titulo, '') || ' ' || coalesce(ocr_text, ''), '\\s+', ' ', 'g'))
+            )
+            WHERE search_text_normalized IS NULL
+            """
+        )
+        op.execute(
+            """
+            CREATE INDEX IF NOT EXISTS ix_boletim_search_text_normalized_trgm
+            ON boletim USING GIN (search_text_normalized gin_trgm_ops)
+            """
+        )
+
+
+def downgrade():
+    bind = op.get_bind()
+    if bind.dialect.name == 'postgresql':
+        op.execute("DROP INDEX IF EXISTS ix_boletim_search_text_normalized_trgm")
+
+    with op.batch_alter_table('boletim') as batch_op:
+        batch_op.drop_column('search_text_normalized')


### PR DESCRIPTION
### Motivation

- Reduzir normalização em tempo de consulta sobre `Boletim.ocr_text` e priorizar buscas indexadas para melhorar desempenho em PostgreSQL.
- Manter compatibilidade com bancos sem suporte PostgreSQL/Fts e oferecer fallback aproximado apenas quando necessário.

### Description

- Prioriza busca full‑text em PostgreSQL usando `to_tsvector(... ) @@ phraseto_tsquery(...)` para pesquisas sem `%` e aplica fallback aproximado apenas quando há wildcard ou quando FTS não retorna resultados.
- Remove múltiplas normalizações diretas sobre `Boletim.ocr_text` no caminho PostgreSQL e passa a usar uma coluna materializada `search_text_normalized` para buscas aproximadas/ILIKE.
- Adiciona `normalize_search_text` em `core/utils.py` e popula `Boletim.search_text_normalized` no processamento OCR (`core/services/ocr_queue.py`).
- Adiciona coluna `search_text_normalized` ao modelo `Boletim` e inclui migração que faz backfill e cria índice GIN trigram (`pg_trgm`) para buscas aproximadas em PostgreSQL.

### Testing

- Executado `python -m pytest tests/test_boletins_busca.py` e todos os testes relacionados passaram (18 passed).
- Verificado que os módulos compilam com `python -m py_compile blueprints/boletins.py core/services/ocr_queue.py core/utils.py core/models.py` sem erro.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32e981d1c4832e88e3670e48123824)