### PR TITLE
Cache PostgreSQL unaccent support detection

### DIFF
--- a/blueprints/boletins.py
+++ b/blueprints/boletins.py
@@ -11,12 +11,12 @@ try:
     from ..core.database import db
     from ..core.models import Boletim, User
     from ..core.services.ocr_queue import enqueue_boletim_for_ocr
-    from ..core.utils import build_like_pattern, normalize_search_text
+    from ..core.utils import build_like_pattern, normalize_search_text, supports_postgres_unaccent
 except ImportError:  # pragma: no cover
     from core.database import db
     from core.models import Boletim, User
     from core.services.ocr_queue import enqueue_boletim_for_ocr
-    from core.utils import build_like_pattern, normalize_search_text
+    from core.utils import build_like_pattern, normalize_search_text, supports_postgres_unaccent
 
 boletins_bp = Blueprint('boletins_bp', __name__)
 
@@ -151,6 +151,7 @@ def buscar_boletins():
 
     bind = db.session.get_bind()
     is_postgresql = bool(bind and bind.dialect.name == 'postgresql')
+    supports_unaccent = supports_postgres_unaccent() if is_postgresql else False
 
     def _normalize_for_search(value):
         return normalize_search_text(value)
@@ -176,6 +177,9 @@ def buscar_boletins():
             return func.normalize_search(expression)
 
         normalized = func.lower(_sql_normalize_whitespace(expression))
+        if supports_unaccent:
+            return func.unaccent(normalized)
+
         for accented, plain in (
             ('á', 'a'), ('à', 'a'), ('â', 'a'), ('ã', 'a'), ('ä', 'a'),
             ('é', 'e'), ('è', 'e'), ('ê', 'e'), ('ë', 'e'),

--- a/core/utils.py
+++ b/core/utils.py
@@ -55,12 +55,49 @@ except ImportError:  # pragma: no cover
     from core.database import db  # type: ignore
     from core.models import OrdemServico  # type: ignore
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 logger = logging.getLogger(__name__)
 _RESERVED_LOG_RECORD_FIELDS = set(logging.makeLogRecord({}).__dict__.keys())
 
 
+_POSTGRES_UNACCENT_SUPPORT: bool | None = None
+
+
+def reset_postgres_unaccent_support_cache() -> None:
+    """Limpa o cache de suporte à extensão unaccent. Uso principal: testes."""
+    global _POSTGRES_UNACCENT_SUPPORT
+    _POSTGRES_UNACCENT_SUPPORT = None
+
+
+def supports_postgres_unaccent() -> bool:
+    """Retorna se o banco PostgreSQL atual possui a extensão unaccent.
+
+    A detecção é cacheada em memória por processo para evitar consultar
+    pg_extension em cada requisição. Se a extensão unaccent for instalada ou
+    removida em produção, reinicie os processos web para atualizar este cache.
+    Ambientes sem PostgreSQL retornam False sem consultar o banco.
+    """
+    global _POSTGRES_UNACCENT_SUPPORT
+
+    if _POSTGRES_UNACCENT_SUPPORT is not None:
+        return _POSTGRES_UNACCENT_SUPPORT
+
+    bind = db.session.get_bind()
+    if not bind or bind.dialect.name != 'postgresql':
+        _POSTGRES_UNACCENT_SUPPORT = False
+        return False
+
+    try:
+        _POSTGRES_UNACCENT_SUPPORT = bool(
+            db.session.execute(
+                text("SELECT 1 FROM pg_extension WHERE extname='unaccent'")
+            ).scalar()
+        )
+    except Exception:
+        _POSTGRES_UNACCENT_SUPPORT = False
+
+    return _POSTGRES_UNACCENT_SUPPORT
 
 
 def strip_accents(value: str) -> str:

--- a/tests/test_boletins_busca.py
+++ b/tests/test_boletins_busca.py
@@ -265,3 +265,56 @@ def test_boletim_postgresql_fts_expression_corresponde_ao_indice():
         "to_tsvector('portuguese', "
         "coalesce(boletim.titulo, '') || ' ' || coalesce(boletim.ocr_text, ''))"
     )
+
+
+def test_supports_postgres_unaccent_retorna_false_sem_postgresql(app_ctx, monkeypatch):
+    from types import SimpleNamespace
+
+    from core import utils
+
+    utils.reset_postgres_unaccent_support_cache()
+    monkeypatch.setattr(
+        utils.db.session,
+        'get_bind',
+        lambda: SimpleNamespace(dialect=SimpleNamespace(name='sqlite')),
+    )
+
+    def fail_execute(*args, **kwargs):
+        raise AssertionError('pg_extension não deve ser consultada fora de PostgreSQL')
+
+    monkeypatch.setattr(utils.db.session, 'execute', fail_execute)
+
+    assert utils.supports_postgres_unaccent() is False
+
+
+def test_supports_postgres_unaccent_cacheia_consulta_pg_extension(app_ctx, monkeypatch):
+    from types import SimpleNamespace
+
+    from core import utils
+
+    utils.reset_postgres_unaccent_support_cache()
+    calls = {'execute': 0}
+    monkeypatch.setattr(
+        utils.db.session,
+        'get_bind',
+        lambda: SimpleNamespace(dialect=SimpleNamespace(name='postgresql')),
+    )
+
+    class Result:
+        def scalar(self):
+            return 1
+
+    def fake_execute(statement):
+        calls['execute'] += 1
+        assert "pg_extension" in str(statement)
+        return Result()
+
+    monkeypatch.setattr(utils.db.session, 'execute', fake_execute)
+
+    assert utils.supports_postgres_unaccent() is True
+    assert utils.supports_postgres_unaccent() is True
+    assert calls['execute'] == 1
+
+    # Se a extensão unaccent for instalada/removida, reinicie o processo web
+    # para que este cache em memória por processo seja recalculado.
+    utils.reset_postgres_unaccent_support_cache()


### PR DESCRIPTION
### Motivation
- Avoid querying `pg_extension` on every request when searching boletins by caching whether the PostgreSQL `unaccent` extension is available.

### Description
- Added a process-local helper `supports_postgres_unaccent()` and `reset_postgres_unaccent_support_cache()` in `core/utils.py` that caches the `unaccent` presence and returns `False` immediately for non-PostgreSQL binds.
- Updated `buscar_boletins` in `blueprints/boletins.py` to call `supports_postgres_unaccent()` once per request and use `func.unaccent(...)` only when the cached result is `True`, otherwise falling back to the existing manual accent replacement.
- Updated imports to expose the new helper and added an inline note that installing/removing the `unaccent` extension requires restarting web processes to refresh the in-memory cache.
- Added unit tests in `tests/test_boletins_busca.py` that assert non-PostgreSQL short-circuits (no `pg_extension` query) and that the detection is cached after a single query.

### Testing
- Ran `pytest -q tests/test_boletins_busca.py` and the suite passed with `20 passed` (warnings observed but unrelated to the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32eb288ffc832eaf973ecb44177fd5)