### PR TITLE
Paginar listagem de boletins

### DIFF
--- a/blueprints/boletins.py
+++ b/blueprints/boletins.py
@@ -80,13 +80,21 @@ def listar_boletins():
     if denied:
         return denied
 
-    boletins = Boletim.query.order_by(Boletim.data_boletim.desc(), Boletim.id.desc()).all()
+    page = request.args.get('page', 1, type=int)
+    per_page = min(max(request.args.get('per_page', 20, type=int), 1), 100)
+    pagination = Boletim.query.order_by(
+        Boletim.data_boletim.desc(),
+        Boletim.id.desc(),
+    ).paginate(page=page, per_page=per_page, error_out=False)
+
     return render_template(
         'boletins/listagem.html',
-        boletins=boletins,
+        boletins=pagination.items,
         can_manage=user.has_permissao('boletim_gerenciar'),
         can_search=user.has_permissao('boletim_buscar'),
         badge_for=_ocr_status_badge,
+        pagination=pagination,
+        per_page=per_page,
     )
 
 

--- a/templates/boletins/listagem.html
+++ b/templates/boletins/listagem.html
@@ -9,6 +9,14 @@
       {% if can_manage %}<a class="btn btn-primary" href="{{ url_for('boletins_novo') }}">Novo boletim</a>{% endif %}
     </div>
   </div>
+  <form method="get" class="d-flex align-items-center gap-2 mb-3">
+    <label for="per_page" class="form-label mb-0 text-nowrap">Por página:</label>
+    <select id="per_page" name="per_page" class="form-select" style="width: 96px;" onchange="this.form.submit()">
+      {% for option in [10, 20, 50, 100] %}
+      <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
+      {% endfor %}
+    </select>
+  </form>
   <table class="table table-striped">
     <thead><tr><th>ID</th><th>Título</th><th>Data</th><th>Status OCR</th><th>Ações</th></tr></thead>
     <tbody>
@@ -27,5 +35,32 @@
       {% endfor %}
     </tbody>
   </table>
+
+  {% if pagination and pagination.pages > 1 %}
+  <nav class="mt-3" aria-label="Paginação">
+    <ul class="pagination flex-wrap gap-1">
+      <li class="page-item {% if not pagination.has_prev %}disabled{% endif %}">
+        <a class="page-link" href="{{ url_for('boletins_listar', per_page=per_page, page=1) }}">Primeira</a>
+      </li>
+      <li class="page-item {% if not pagination.has_prev %}disabled{% endif %}">
+        <a class="page-link" href="{{ url_for('boletins_listar', per_page=per_page, page=pagination.prev_num) }}">Anterior</a>
+      </li>
+      <li class="page-item disabled"><span class="page-link">Página {{ pagination.page }} de {{ pagination.pages }}</span></li>
+      <li class="page-item {% if not pagination.has_next %}disabled{% endif %}">
+        <a class="page-link" href="{{ url_for('boletins_listar', per_page=per_page, page=pagination.next_num) }}">Próxima</a>
+      </li>
+      <li class="page-item {% if not pagination.has_next %}disabled{% endif %}">
+        <a class="page-link" href="{{ url_for('boletins_listar', per_page=per_page, page=pagination.pages) }}">Última</a>
+      </li>
+      <li class="page-item">
+        <form method="get" class="d-flex ms-2">
+          <input type="hidden" name="per_page" value="{{ per_page }}">
+          <input class="form-control form-control-sm" type="number" name="page" min="1" max="{{ pagination.pages }}" value="{{ pagination.page }}" style="width: 90px;" aria-label="Página específica">
+          <button class="btn btn-sm btn-outline-secondary ms-1" type="submit">Ir</button>
+        </form>
+      </li>
+    </ul>
+  </nav>
+  {% endif %}
 </div>
 {% endblock %}

--- a/tests/test_boletins_busca.py
+++ b/tests/test_boletins_busca.py
@@ -184,6 +184,28 @@ def test_listagem_oculta_atalho_buscar_sem_permissao(client):
     assert b'>Buscar<' not in resp.data
 
 
+
+def test_listagem_boletins_paginada(client):
+    with app.app_context():
+        user = _setup_user(client, ['boletim_visualizar'])
+        for index in range(3):
+            _create_boletim(user, f'Boletim Paginado {index + 1}', 'Texto irrelevante', date(2026, 3, index + 1))
+
+    resp = client.get('/boletins', query_string={'per_page': 2, 'page': 1})
+
+    assert resp.status_code == 200
+    assert b'Boletim Paginado 3' in resp.data
+    assert b'Boletim Paginado 2' in resp.data
+    assert b'Boletim Paginado 1' not in resp.data
+    assert b'P\xc3\xa1gina 1 de 2' in resp.data
+    assert b'Por p\xc3\xa1gina:' in resp.data
+
+    resp_page_2 = client.get('/boletins', query_string={'per_page': 2, 'page': 2})
+
+    assert resp_page_2.status_code == 200
+    assert b'Boletim Paginado 1' in resp_page_2.data
+    assert b'Boletim Paginado 3' not in resp_page_2.data
+
 def test_busca_boletim_frase_exata_sem_percentual(client):
     with app.app_context():
         user = _setup_user(client, ['boletim_buscar', 'boletim_visualizar'])


### PR DESCRIPTION
### Motivation
- Melhorar a usabilidade da listagem de boletins ao suportar paginação e controle de itens por página semelhante à busca.
- Evitar carregamento completo em memória e oferecer navegação consistente preservando a ordenação por data e id.

### Description
- Em `blueprints/boletins.py` a função `listar_boletins` agora lê `page` e `per_page` de `request.args`, aplica limite em `per_page` entre 1 e 100 e usa `paginate(..., error_out=False)` mantendo `Boletim.data_boletim.desc(), Boletim.id.desc()` como ordenação. 
- A view passa `pagination`, `boletins=pagination.items` e `per_page` para o template de listagem (`templates/boletins/listagem.html`).
- Em `templates/boletins/listagem.html` foi adicionado o seletor `per_page` e os controles de paginação (Primeira / Anterior / Página X de Y / Próxima / Última / ir para página) espelhando `templates/boletins/busca.html`.
- Adicionado teste de regressão `test_listagem_boletins_paginada` em `tests/test_boletins_busca.py` que valida ordenação, paginação e exibição dos controles.

### Testing
- Executado `pytest tests/test_boletins_busca.py -q` e todos os testes daquele arquivo passaram (`21 passed`) com warnings de compatibilidade do SQLAlchemy, sem falhas.
- Os testes de integração adicionados confirmaram que a páginação retorna os itens esperados nas páginas 1 e 2 e que os controles e o seletor `Por página:` aparecem no HTML.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32ed780058832ea762547667e572fb)